### PR TITLE
Add low-precision to TFNO

### DIFF
--- a/config/darcy_config.yaml
+++ b/config/darcy_config.yaml
@@ -42,6 +42,7 @@ default: &DEFAULT
     dropout: 0.0
     tensor_lasso_penalty: 0.0
     joint_factorization: False
+    fno_block_precision: 'full'
 
   # Optimizer
   opt:

--- a/config/darcy_config.yaml
+++ b/config/darcy_config.yaml
@@ -43,6 +43,7 @@ default: &DEFAULT
     tensor_lasso_penalty: 0.0
     joint_factorization: False
     fno_block_precision: 'full'
+    stabilizer: None
 
   # Optimizer
   opt:

--- a/config/darcy_config.yaml
+++ b/config/darcy_config.yaml
@@ -42,8 +42,8 @@ default: &DEFAULT
     dropout: 0.0
     tensor_lasso_penalty: 0.0
     joint_factorization: False
-    fno_block_precision: 'full'
-    stabilizer: None
+    fno_block_precision: 'full' # or 'half', 'mixed'
+    stabilizer: None # or 'tanh'
 
   # Optimizer
   opt:

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -41,6 +41,7 @@ default: &DEFAULT
     tensor_lasso_penalty: 0.0
     joint_factorization: False
     fno_block_precision: 'full'
+    stabilizer: None
 
   # Optimizer
   opt:

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -40,6 +40,7 @@ default: &DEFAULT
     dropout: 0.0
     tensor_lasso_penalty: 0.0
     joint_factorization: False
+    fno_block_precision: 'full'
 
   # Optimizer
   opt:

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -40,8 +40,8 @@ default: &DEFAULT
     dropout: 0.0
     tensor_lasso_penalty: 0.0
     joint_factorization: False
-    fno_block_precision: 'full'
-    stabilizer: None
+    fno_block_precision: 'full' # or 'half', 'mixed'
+    stabilizer: None # or 'tanh'
 
   # Optimizer
   opt:

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -30,6 +30,7 @@ default: &DEFAULT
     dropout: 0.0
     tensor_lasso_penalty: 0.0
     joint_factorization: False
+    fno_block_precision: 'full'
   
   data:
     batch_size: 4

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -30,7 +30,8 @@ default: &DEFAULT
     dropout: 0.0
     tensor_lasso_penalty: 0.0
     joint_factorization: False
-    fno_block_precision: 'full'
+    fno_block_precision: 'full' #or 'half', 'mixed'
+    stabilizer: None #or 'tanh'
   
   data:
     batch_size: 4

--- a/neuralop/models/einsum_utils.py
+++ b/neuralop/models/einsum_utils.py
@@ -1,0 +1,73 @@
+import torch
+
+
+def einsum_complexhalf_two_input(eq, a, b):
+    """
+    Return the einsum(eq, a, b)
+    We call this instead of standard einsum when either a or b is ComplexHalf,
+    to run the operation in half precision.
+    """
+    assert len(eq.split(',')) == 2, "Einsum equation must have two inputs"
+
+    # cast both tensors to real and half precision
+    a = torch.view_as_real(a)
+    b = torch.view_as_real(b)
+    a = a.half()
+    b = b.half()
+
+    # create a new einsum equation 
+    input_output = eq.split('->')
+    new_output = 'xy' + input_output[1]
+    input_terms = input_output[0].split(',')
+    new_inputs = [input_terms[0] + 'x', input_terms[1] + 'y']
+    new_eqn = new_inputs[0] + ',' + new_inputs[1] + '->' + new_output
+
+    tmp = torch.einsum(new_eqn, a, b)
+    res = torch.stack([tmp[0, 0, ...] - tmp[1, 1, ...], tmp[1, 0, ...] + tmp[0, 1, ...]], dim=-1)
+    return torch.view_as_complex(res)
+
+def einsum_complexhalf(eq, *args):
+    """Compute einsum for complexhalf tensors"""
+
+    if len(args) == 2:
+        return einsum_complexhalf_two_input(eq, *args)
+
+    # todo: this can be made general. Call opt_einsum to get the partial_eqns
+    assert eq == 'abcd,e,be,fe,ce,de->afcd', "Currently only implemented for this eqn"
+
+    partial_eqns = ['fe,e->fe',
+                    'de,be->deb',
+                    'fe,ce->fec',
+                    'fec,deb->fcdb',
+                    'fcdb,abcd->afcd']
+
+    tensors = {}
+    labels = eq.split('->')[0].split(',')
+    tensors = dict(zip(labels,args))
+
+    for key, tensor in tensors.items():
+        tensor = torch.view_as_real(tensor)
+        tensor = tensor.half()
+        tensors[key] = tensor
+
+    # now all tensors are in the "view as real" form
+    for partial_eq in partial_eqns:
+
+        # get the tensors
+        in_labels, out_label = partial_eq.split('->')
+        in_labels = in_labels.split(',')
+        in_tensors = [tensors[label] for label in in_labels]
+
+        # create a new einsum equation 
+        input_output = partial_eq.split('->')
+        new_output = 'xy' + input_output[1]
+        input_terms = input_output[0].split(',')
+        new_inputs = [input_terms[0] + 'x', input_terms[1] + 'y']
+        new_eqn = new_inputs[0] + ',' + new_inputs[1] + '->' + new_output
+
+        # perform the einsum, and convert to "view as real" form
+        tmp = torch.einsum(new_eqn, *in_tensors)
+        result = torch.stack([tmp[0, 0, ...] - tmp[1, 1, ...], tmp[1, 0, ...] + tmp[0, 1, ...]], dim=-1)
+        tensors[out_label] = result
+
+    return torch.view_as_complex(tensors['afcd'])

--- a/neuralop/models/einsum_utils.py
+++ b/neuralop/models/einsum_utils.py
@@ -1,64 +1,66 @@
 import torch
+import opt_einsum
 
 
 def einsum_complexhalf_two_input(eq, a, b):
     """
-    Return the einsum(eq, a, b)
-    We call this instead of standard einsum when either a or b is ComplexHalf,
-    to run the operation in half precision.
+    Compute (two-input) einsum for complexhalf tensors.
+    Because torch.einsum currently does not support complex32 (complexhalf) types.
+    The inputs and outputs are the same as in torch.einsum
     """
-    assert len(eq.split(',')) == 2, "Einsum equation must have two inputs"
+    assert len(eq.split(',')) == 2, "Equation must have two inputs."
 
-    # cast both tensors to real and half precision
+    # cast both tensors to "view as real" form, and half precision
     a = torch.view_as_real(a)
     b = torch.view_as_real(b)
     a = a.half()
     b = b.half()
 
-    # create a new einsum equation 
+    # create a new einsum equation that takes into account "view as real" form
     input_output = eq.split('->')
     new_output = 'xy' + input_output[1]
     input_terms = input_output[0].split(',')
     new_inputs = [input_terms[0] + 'x', input_terms[1] + 'y']
     new_eqn = new_inputs[0] + ',' + new_inputs[1] + '->' + new_output
 
+    # convert back to complex form
     tmp = torch.einsum(new_eqn, a, b)
     res = torch.stack([tmp[0, 0, ...] - tmp[1, 1, ...], tmp[1, 0, ...] + tmp[0, 1, ...]], dim=-1)
     return torch.view_as_complex(res)
 
 def einsum_complexhalf(eq, *args):
-    """Compute einsum for complexhalf tensors"""
-
+    """
+    Compute einsum for complexhalf tensors.
+    Because torch.einsum currently does not support complex32 (complexhalf) types.
+    The inputs and outputs are the same as in torch.einsum
+    """
     if len(args) == 2:
+        # if there are two inputs, it is faster to call this method
         return einsum_complexhalf_two_input(eq, *args)
 
-    # todo: this can be made general. Call opt_einsum to get the partial_eqns
-    assert eq == 'abcd,e,be,fe,ce,de->afcd', "Currently only implemented for this eqn"
+    # find the optimal path
+    _, path_info = opt_einsum.contract_path(eq, *args)
+    partial_eqns = [contraction_info[2] for contraction_info in path_info.contraction_list]
 
-    partial_eqns = ['fe,e->fe',
-                    'de,be->deb',
-                    'fe,ce->fec',
-                    'fec,deb->fcdb',
-                    'fcdb,abcd->afcd']
-
+    # create a dict of the input tensors by their label in the einsum equation
     tensors = {}
-    labels = eq.split('->')[0].split(',')
-    tensors = dict(zip(labels,args))
+    input_labels = eq.split('->')[0].split(',')
+    output_label = eq.split('->')[1]
+    tensors = dict(zip(input_labels,args))
 
+    # convert all tensors to half precision and "view as real" form
     for key, tensor in tensors.items():
         tensor = torch.view_as_real(tensor)
         tensor = tensor.half()
         tensors[key] = tensor
 
-    # now all tensors are in the "view as real" form
     for partial_eq in partial_eqns:
-
-        # get the tensors
+        # get the input tensors to partial_eq
         in_labels, out_label = partial_eq.split('->')
         in_labels = in_labels.split(',')
         in_tensors = [tensors[label] for label in in_labels]
 
-        # create a new einsum equation 
+        # create new einsum equation that takes into account "view as real" form
         input_output = partial_eq.split('->')
         new_output = 'xy' + input_output[1]
         input_terms = input_output[0].split(',')
@@ -70,4 +72,4 @@ def einsum_complexhalf(eq, *args):
         result = torch.stack([tmp[0, 0, ...] - tmp[1, 1, ...], tmp[1, 0, ...] + tmp[0, 1, ...]], dim=-1)
         tensors[out_label] = result
 
-    return torch.view_as_complex(tensors['afcd'])
+    return torch.view_as_complex(tensors[output_label])

--- a/neuralop/models/einsum_utils.py
+++ b/neuralop/models/einsum_utils.py
@@ -1,5 +1,9 @@
 import torch
 import opt_einsum
+import tensorly as tl
+from tensorly.plugins import use_opt_einsum
+tl.set_backend('pytorch')
+use_opt_einsum('optimal')
 
 
 def einsum_complexhalf_two_input(eq, a, b):
@@ -24,7 +28,7 @@ def einsum_complexhalf_two_input(eq, a, b):
     new_eqn = new_inputs[0] + ',' + new_inputs[1] + '->' + new_output
 
     # convert back to complex form
-    tmp = torch.einsum(new_eqn, a, b)
+    tmp = tl.einsum(new_eqn, a, b)
     res = torch.stack([tmp[0, 0, ...] - tmp[1, 1, ...], tmp[1, 0, ...] + tmp[0, 1, ...]], dim=-1)
     return torch.view_as_complex(res)
 
@@ -68,7 +72,7 @@ def einsum_complexhalf(eq, *args):
         new_eqn = new_inputs[0] + ',' + new_inputs[1] + '->' + new_output
 
         # perform the einsum, and convert to "view as real" form
-        tmp = torch.einsum(new_eqn, *in_tensors)
+        tmp = tl.einsum(new_eqn, *in_tensors)
         result = torch.stack([tmp[0, 0, ...] - tmp[1, 1, ...], tmp[1, 0, ...] + tmp[0, 1, ...]], dim=-1)
         tensors[out_label] = result
 

--- a/neuralop/models/fno_block.py
+++ b/neuralop/models/fno_block.py
@@ -15,6 +15,7 @@ class FNOBlocks(nn.Module):
                  fno_block_precision='full',
                  use_mlp=False, mlp_dropout=0, mlp_expansion=0.5,
                  non_linearity=F.gelu,
+                 stabilizer=None,
                  norm=None, ada_in_features=None,
                  preactivation=False,
                  fno_skip='linear',
@@ -49,6 +50,7 @@ class FNOBlocks(nn.Module):
         self.n_layers = n_layers
         self.joint_factorization = joint_factorization
         self.non_linearity = non_linearity
+        self.stabilizer = stabilizer
         self.rank = rank
         self.factorization = factorization
         self.fixed_rank_modes = fixed_rank_modes
@@ -143,6 +145,9 @@ class FNOBlocks(nn.Module):
             if self.convs.output_scaling_factor is not None:
                 x_skip_mlp = resample(x_skip_mlp, self.output_scaling_factor[index]\
                                       , list(range(-len(self.output_scaling_factor[index]), 0)), output_shape = output_shape )
+
+        if self.stabilizer == 'tanh':
+            x = torch.tanh(x)
 
         x_fno = self.convs(x, index, output_shape = output_shape)
 

--- a/neuralop/models/fno_block.py
+++ b/neuralop/models/fno_block.py
@@ -12,6 +12,7 @@ class FNOBlocks(nn.Module):
                  output_scaling_factor=None,
                  n_layers=1,
                  incremental_n_modes=None,
+                 fno_block_precision='full',
                  use_mlp=False, mlp_dropout=0, mlp_expansion=0.5,
                  non_linearity=F.gelu,
                  norm=None, ada_in_features=None,
@@ -42,6 +43,7 @@ class FNOBlocks(nn.Module):
         self.output_scaling_factor = output_scaling_factor
 
         self._incremental_n_modes = incremental_n_modes
+        self.fno_block_preicison = fno_block_precision
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.n_layers = n_layers
@@ -66,6 +68,7 @@ class FNOBlocks(nn.Module):
                 self.in_channels, self.out_channels, self.n_modes, 
                 output_scaling_factor=output_scaling_factor,
                 incremental_n_modes=incremental_n_modes,
+                fno_block_precision=fno_block_precision,
                 rank=rank,
                 fft_norm=fft_norm,
                 fixed_rank_modes=fixed_rank_modes, 

--- a/neuralop/models/spectral_convolution.py
+++ b/neuralop/models/spectral_convolution.py
@@ -339,8 +339,6 @@ class FactorizedSpectralConv(nn.Module):
 
         if self.fno_block_precision == 'half':
             x = x.half()
-        else:
-            x = x.float()
 
         x = torch.fft.rfftn(x, norm=self.fft_norm, dim=fft_dims)
 

--- a/neuralop/models/spectral_convolution.py
+++ b/neuralop/models/spectral_convolution.py
@@ -85,7 +85,10 @@ def _contract_tucker(x, tucker_weight, separable=False):
     
     eq = x_syms + ',' + core_syms + ',' + ','.join(factor_syms) + '->' + ''.join(out_syms)
 
-    return tl.einsum(eq, x, tucker_weight.core, *tucker_weight.factors)
+    if x.dtype == torch.complex32:
+        return einsum_complexhalf(eq, x, tucker_weight.core, *tucker_weight.factors)
+    else:
+        return tl.einsum(eq, x, tucker_weight.core, *tucker_weight.factors)
 
 
 def _contract_tt(x, tt_weight, separable=False):
@@ -105,7 +108,10 @@ def _contract_tt(x, tt_weight, separable=False):
         tt_syms.append([rank_syms[i], s, rank_syms[i+1]])
     eq = ''.join(x_syms) + ',' + ','.join(''.join(f) for f in tt_syms) + '->' + ''.join(out_syms)
 
-    return tl.einsum(eq, x, *tt_weight.factors)
+    if x.dtype == torch.complex32:
+        return einsum_complexhalf(eq, x, *tt_weight.factors)
+    else:
+        return tl.einsum(eq, x, *tt_weight.factors)
 
 
 def get_contract_fun(weight, implementation='reconstructed', separable=False):

--- a/neuralop/models/tests/test_tfno.py
+++ b/neuralop/models/tests/test_tfno.py
@@ -12,7 +12,9 @@ tenalg.set_backend('einsum')
 @pytest.mark.parametrize('factorization', ['ComplexDense', 'ComplexTucker', 'ComplexCP', 'ComplexTT'])
 @pytest.mark.parametrize('implementation', ['factorized', 'reconstructed'])
 @pytest.mark.parametrize('n_dim', [1, 2, 3])
-def test_tfno(factorization, implementation, n_dim):
+@pytest.mark.parametrize('fno_block_precision', ['full', 'half', 'mixed'])
+@pytest.mark.parametrize('stabilizer', [None, 'tanh'])
+def test_tfno(factorization, implementation, n_dim, fno_block_precision, stabilizer):
     if torch.has_cuda:
         device = 'cuda'
         s = 128
@@ -25,6 +27,7 @@ def test_tfno(factorization, implementation, n_dim):
         mlp = Bunch(dict(expansion=0.5, dropout=0))
     else:
         device = 'cpu'
+        fno_block_precision = 'full'
         s = 16
         modes = 5
         width = 15
@@ -45,7 +48,9 @@ def test_tfno(factorization, implementation, n_dim):
                  fixed_rank_modes=False,
                  joint_factorization=False,
                  n_layers=n_layers,
+                 fno_block_precision=fno_block_precision,
                  use_mlp=use_mlp, mlp=mlp,
+                 stabilizer=stabilizer,
                  fc_channels=fc_channels).to(device)
     in_data = torch.randn(batch_size, 3, *size).to(device)
 

--- a/neuralop/models/tfno.py
+++ b/neuralop/models/tfno.py
@@ -66,6 +66,10 @@ class FNO(nn.Module):
         * If None, all the n_modes are used.
 
         This can be updated dynamically during training.
+    fno_block_precision : str {'full', 'half', 'mixed'}
+        if 'full', the FNO Block runs in full precision
+        if 'half', the FFT, contraction, and inverse FFT run in half precision
+        if 'mixed', the contraction and inverse FFT run in half precision
     use_mlp : bool, optional
         Whether to use an MLP layer after each FNO block, by default False
     mlp : dict, optional
@@ -112,6 +116,7 @@ class FNO(nn.Module):
                  n_layers=4,
                  output_scaling_factor=None,
                  incremental_n_modes=None,
+                 fno_block_precision='full',
                  use_mlp=False, mlp_dropout=0, mlp_expansion=0.5,
                  non_linearity=F.gelu,
                  norm=None, preactivation=False,
@@ -150,6 +155,7 @@ class FNO(nn.Module):
         self.implementation = implementation
         self.separable = separable
         self.preactivation = preactivation
+        self.fno_block_precision = fno_block_precision
 
         # See the class' property for underlying mechanism
         # When updated, change should be reflected in fno blocks
@@ -177,6 +183,7 @@ class FNO(nn.Module):
             fno_skip=fno_skip,
             mlp_skip=mlp_skip,
             incremental_n_modes=incremental_n_modes,
+            fno_block_precision=fno_block_precision,
             rank=rank,
             fft_norm=fft_norm,
             fixed_rank_modes=fixed_rank_modes, 
@@ -245,6 +252,10 @@ class FNO1d(FNO):
         * If None, all the n_modes are used.
 
         This can be updated dynamically during training.
+    fno_block_precision : str {'full', 'half', 'mixed'}
+        if 'full', the FNO Block runs in full precision
+        if 'half', the FFT, contraction, and inverse FFT run in half precision
+        if 'mixed', the contraction and inverse FFT run in half precision
     use_mlp : bool, optional
         Whether to use an MLP layer after each FNO block, by default False
     mlp : dict, optional
@@ -292,6 +303,7 @@ class FNO1d(FNO):
         lifting_channels=256,
         projection_channels=256,
         incremental_n_modes=None,
+        fno_block_precision='full',
         n_layers=4,
         output_scaling_factor=None,
         non_linearity=F.gelu,
@@ -322,6 +334,7 @@ class FNO1d(FNO):
             non_linearity=non_linearity,
             use_mlp=use_mlp, mlp_dropout=mlp_dropout, mlp_expansion=mlp_expansion,
             incremental_n_modes=incremental_n_modes,
+            fno_block_precision=fno_block_precision,
             norm=norm,
             skip=skip,
             separable=separable,
@@ -367,6 +380,10 @@ class FNO2d(FNO):
         * If None, all the n_modes are used.
 
         This can be updated dynamically during training.
+    fno_block_precision : str {'full', 'half', 'mixed'}
+        if 'full', the FNO Block runs in full precision
+        if 'half', the FFT, contraction, and inverse FFT run in half precision
+        if 'mixed', the contraction and inverse FFT run in half precision
     use_mlp : bool, optional
         Whether to use an MLP layer after each FNO block, by default False
     mlp : dict, optional
@@ -417,6 +434,7 @@ class FNO2d(FNO):
         n_layers=4,
         output_scaling_factor=None,
         incremental_n_modes=None,
+        fno_block_precision='full',
         non_linearity=F.gelu,
         use_mlp=False, mlp_dropout=0, mlp_expansion=0.5,
         norm=None,
@@ -445,6 +463,7 @@ class FNO2d(FNO):
             non_linearity=non_linearity,
             use_mlp=use_mlp, mlp_dropout=mlp_dropout, mlp_expansion=mlp_expansion,
             incremental_n_modes=incremental_n_modes,
+            fno_block_precision=fno_block_precision,
             norm=norm,
             skip=skip,
             separable=separable,
@@ -494,6 +513,10 @@ class FNO3d(FNO):
         * If None, all the n_modes are used.
 
         This can be updated dynamically during training.
+    fno_block_precision : str {'full', 'half', 'mixed'}
+        if 'full', the FNO Block runs in full precision
+        if 'half', the FFT, contraction, and inverse FFT run in half precision
+        if 'mixed', the contraction and inverse FFT run in half precision
     use_mlp : bool, optional
         Whether to use an MLP layer after each FNO block, by default False
     mlp : dict, optional
@@ -544,6 +567,7 @@ class FNO3d(FNO):
         n_layers=4,
         output_scaling_factor=None,
         incremental_n_modes=None,
+        fno_block_precision='full',
         non_linearity=F.gelu,
         use_mlp=False, mlp_dropout=0, mlp_expansion=0.5,
         norm=None,
@@ -571,6 +595,7 @@ class FNO3d(FNO):
             output_scaling_factor=None,
             non_linearity=non_linearity,
             incremental_n_modes=incremental_n_modes,
+            fno_block_precision=fno_block_precision,
             use_mlp=use_mlp, mlp_dropout=mlp_dropout, mlp_expansion=mlp_expansion,
             norm=norm,
             skip=skip,

--- a/neuralop/models/tfno.py
+++ b/neuralop/models/tfno.py
@@ -70,6 +70,8 @@ class FNO(nn.Module):
         if 'full', the FNO Block runs in full precision
         if 'half', the FFT, contraction, and inverse FFT run in half precision
         if 'mixed', the contraction and inverse FFT run in half precision
+    stabilizer : str {'tanh'} or None, optional
+        By default None, otherwise tanh is used before FFT in the FNO block 
     use_mlp : bool, optional
         Whether to use an MLP layer after each FNO block, by default False
     mlp : dict, optional
@@ -119,6 +121,7 @@ class FNO(nn.Module):
                  fno_block_precision='full',
                  use_mlp=False, mlp_dropout=0, mlp_expansion=0.5,
                  non_linearity=F.gelu,
+                 stabilizer=None, 
                  norm=None, preactivation=False,
                  fno_skip='linear',
                  mlp_skip='soft-gating',
@@ -178,7 +181,8 @@ class FNO(nn.Module):
             n_modes=self.n_modes,
             output_scaling_factor=output_scaling_factor,
             use_mlp=use_mlp, mlp_dropout=mlp_dropout, mlp_expansion=mlp_expansion,
-            non_linearity=non_linearity,
+            non_linearity=non_linearity, 
+            stabilizer=stabilizer,
             norm=norm, preactivation=preactivation,
             fno_skip=fno_skip,
             mlp_skip=mlp_skip,
@@ -256,6 +260,8 @@ class FNO1d(FNO):
         if 'full', the FNO Block runs in full precision
         if 'half', the FFT, contraction, and inverse FFT run in half precision
         if 'mixed', the contraction and inverse FFT run in half precision
+    stabilizer : str {'tanh'} or None, optional
+        By default None, otherwise tanh is used before FFT in the FNO block 
     use_mlp : bool, optional
         Whether to use an MLP layer after each FNO block, by default False
     mlp : dict, optional
@@ -307,6 +313,7 @@ class FNO1d(FNO):
         n_layers=4,
         output_scaling_factor=None,
         non_linearity=F.gelu,
+        stabilizer=None,
         use_mlp=False, mlp_dropout=0, mlp_expansion=0.5,
         norm=None,
         skip='soft-gating',
@@ -331,7 +338,8 @@ class FNO1d(FNO):
             projection_channels=projection_channels,
             n_layers=n_layers,
             output_scaling_factor=None,
-            non_linearity=non_linearity,
+            non_linearity=non_linearity, 
+            stabilizer=stabilizer,
             use_mlp=use_mlp, mlp_dropout=mlp_dropout, mlp_expansion=mlp_expansion,
             incremental_n_modes=incremental_n_modes,
             fno_block_precision=fno_block_precision,
@@ -384,6 +392,8 @@ class FNO2d(FNO):
         if 'full', the FNO Block runs in full precision
         if 'half', the FFT, contraction, and inverse FFT run in half precision
         if 'mixed', the contraction and inverse FFT run in half precision
+    stabilizer : str {'tanh'} or None, optional
+        By default None, otherwise tanh is used before FFT in the FNO block 
     use_mlp : bool, optional
         Whether to use an MLP layer after each FNO block, by default False
     mlp : dict, optional
@@ -436,6 +446,7 @@ class FNO2d(FNO):
         incremental_n_modes=None,
         fno_block_precision='full',
         non_linearity=F.gelu,
+        stabilizer=None,
         use_mlp=False, mlp_dropout=0, mlp_expansion=0.5,
         norm=None,
         skip='soft-gating',
@@ -460,7 +471,8 @@ class FNO2d(FNO):
             projection_channels=projection_channels,
             n_layers=n_layers,
             output_scaling_factor=None,
-            non_linearity=non_linearity,
+            non_linearity=non_linearity, 
+            stabilizer=stabilizer,
             use_mlp=use_mlp, mlp_dropout=mlp_dropout, mlp_expansion=mlp_expansion,
             incremental_n_modes=incremental_n_modes,
             fno_block_precision=fno_block_precision,
@@ -517,6 +529,8 @@ class FNO3d(FNO):
         if 'full', the FNO Block runs in full precision
         if 'half', the FFT, contraction, and inverse FFT run in half precision
         if 'mixed', the contraction and inverse FFT run in half precision
+    stabilizer : str {'tanh'} or None, optional
+        By default None, otherwise tanh is used before FFT in the FNO block 
     use_mlp : bool, optional
         Whether to use an MLP layer after each FNO block, by default False
     mlp : dict, optional
@@ -569,6 +583,7 @@ class FNO3d(FNO):
         incremental_n_modes=None,
         fno_block_precision='full',
         non_linearity=F.gelu,
+        stabilizer=None,
         use_mlp=False, mlp_dropout=0, mlp_expansion=0.5,
         norm=None,
         skip='soft-gating',
@@ -594,6 +609,7 @@ class FNO3d(FNO):
             n_layers=n_layers,
             output_scaling_factor=None,
             non_linearity=non_linearity,
+            stabilizer=stabilizer,
             incremental_n_modes=incremental_n_modes,
             fno_block_precision=fno_block_precision,
             use_mlp=use_mlp, mlp_dropout=mlp_dropout, mlp_expansion=mlp_expansion,

--- a/neuralop/tests/test_config.yaml
+++ b/neuralop/tests/test_config.yaml
@@ -42,7 +42,7 @@ default: &DEFAULT
     learning_rate: 1e-3
     training_loss: 'h1'
     weight_decay: 1e-4
-    amp_autocast: False
+    amp_autocast: True
 
     scheduler_T_max: 500 # For cosine only, typically take n_epochs
     scheduler_patience: 5 # For ReduceLROnPlateau only

--- a/scripts/train_darcy.py
+++ b/scripts/train_darcy.py
@@ -129,7 +129,7 @@ if config.verbose and is_logger:
 
 trainer = Trainer(model, n_epochs=config.opt.n_epochs,
                   device=device,
-                  amp_autocast=False,
+                  amp_autocast=config.opt.amp_autocast,
                   mg_patching_levels=config.patching.levels,
                   mg_patching_padding=config.patching.padding,
                   mg_patching_stitching=config.patching.stitching,

--- a/scripts/train_darcy.py
+++ b/scripts/train_darcy.py
@@ -53,7 +53,7 @@ if config.verbose and is_logger:
     pipe.log()
     sys.stdout.flush()
 
-# Loading the Navier-Stokes dataset in 128x128 resolution
+# Loading the Darcy flow dataset
 train_loader, test_loaders, output_encoder = load_darcy_flow_small(
         n_train=config.data.n_train, batch_size=config.data.batch_size, 
         positional_encoding=config.data.positional_encoding,

--- a/scripts/train_darcy.py
+++ b/scripts/train_darcy.py
@@ -129,6 +129,7 @@ if config.verbose and is_logger:
 
 trainer = Trainer(model, n_epochs=config.opt.n_epochs,
                   device=device,
+                  amp_autocast=False,
                   mg_patching_levels=config.patching.levels,
                   mg_patching_padding=config.patching.padding,
                   mg_patching_stitching=config.patching.stitching,

--- a/scripts/train_navier_stokes.py
+++ b/scripts/train_navier_stokes.py
@@ -124,7 +124,7 @@ if config.verbose:
 
 trainer = Trainer(model, n_epochs=config.opt.n_epochs,
                   device=device,
-                  amp_autocast=False,
+                  amp_autocast=config.opt.amp_autocast,
                   mg_patching_levels=config.patching.levels,
                   mg_patching_padding=config.patching.padding,
                   mg_patching_stitching=config.patching.stitching,

--- a/scripts/train_navier_stokes.py
+++ b/scripts/train_navier_stokes.py
@@ -124,6 +124,7 @@ if config.verbose:
 
 trainer = Trainer(model, n_epochs=config.opt.n_epochs,
                   device=device,
+                  amp_autocast=False,
                   mg_patching_levels=config.patching.levels,
                   mg_patching_padding=config.patching.padding,
                   mg_patching_stitching=config.patching.stitching,


### PR DESCRIPTION
This pull request adds low precision options for TFNO. Here is a brief summary.

 1. `opt.amp_autocast` was previously in the yaml file but was a no-op. This PR gets `opt.amp_autocast` working
- False (default): run the model in full precision
- True: turn on torch.amp.autocast, torch's built-in half-precision method. This turns many operations to half precision, with a few notable exceptions: reduction operations, weight updates (due to instability) and complex-valued operations (due to lack of implementation).

2. Add new parameter to the yaml file, `fno_block_precision`
- 'full' (default): standard full precision
- 'half': the FFT, contraction, and inverse FFT run in half precision
- 'mixed': the FFT runs in full-precision, and the contraction and inverse FFT run in half precision

3. Add new parameter to the yaml file, `stabilizer`
- None (default)
- 'tanh': adds a tanh just before the FFT in the fno-block. Typically this needs to be set to stabilize the FFT, when `fno_block_precision='half'`.

Running
```bash
python train_navier_stokes.py --opt.amp_autocast=True --tfno2d.fno_block_precision='half' --tfno2d.stabilizer='tanh'
python train_navier_darcy.py --opt.amp_autocast=True --tfno2d.fno_block_precision='half' --tfno2d.stabilizer='tanh'
```

Improves runtime and memory by up to 30%, depending on the GPU used, the resolution of the data (greater speedups for 64x64 resolution or higher), and other hyperparameters such as factorization and rank.