### PR TITLE
Liftproj mod to mlp

### DIFF
--- a/neuralop/models/tfno.py
+++ b/neuralop/models/tfno.py
@@ -6,37 +6,7 @@ from .spectral_convolution import FactorizedSpectralConv
 from .spherical_convolution import FactorizedSphericalConv
 from .padding import DomainPadding
 from .fno_block import FNOBlocks, resample
-
-
-class Lifting(nn.Module):
-    def __init__(self, in_channels, out_channels, n_dim=2):
-        super().__init__()
-        self.in_channels = in_channels
-        self.out_channels = out_channels
-        Conv = getattr(nn, f'Conv{n_dim}d')
-        self.fc = Conv(in_channels, out_channels, 1)
-
-    def forward(self, x):
-        return self.fc(x)
-
-
-class Projection(nn.Module):
-    def __init__(self, in_channels, out_channels, hidden_channels=None, n_dim=2, non_linearity=F.gelu):
-        super().__init__()
-        self.in_channels = in_channels
-        self.out_channels = out_channels
-        self.hidden_channels = in_channels if hidden_channels is None else hidden_channels 
-        self.non_linearity = non_linearity
-        Conv = getattr(nn, f'Conv{n_dim}d')
-        self.fc1 = Conv(in_channels, hidden_channels, 1)
-        self.fc2 = Conv(hidden_channels, out_channels, 1)
-
-    def forward(self, x):
-        x = self.fc1(x)
-        x = self.non_linearity(x)
-        x = self.fc2(x)
-        return x
-
+from .mlp import MLP
 
 
 class FNO(nn.Module):
@@ -199,9 +169,9 @@ class FNO(nn.Module):
             SpectralConv=SpectralConv,
             n_layers=n_layers)
 
-        self.lifting = Lifting(in_channels=in_channels, out_channels=self.hidden_channels, n_dim=self.n_dim)
-        self.projection = Projection(in_channels=self.hidden_channels, out_channels=out_channels, hidden_channels=projection_channels,
-                                     non_linearity=non_linearity, n_dim=self.n_dim)
+        self.lifting = MLP(in_channels=in_channels, out_channels=self.hidden_channels, hidden_channels=self.lifting_channels, 
+                 n_layers=1, n_dim=self.n_dim)
+        self.projection = MLP(in_channels=self.hidden_channels, out_channels=out_channels, hidden_channels=self.projection_channels, n_layers=2, n_dim=self.n_dim, non_linearity=non_linearity) 
 
     def forward(self, x):
         """TFNO's forward pass

--- a/neuralop/models/tfno.py
+++ b/neuralop/models/tfno.py
@@ -169,8 +169,7 @@ class FNO(nn.Module):
             SpectralConv=SpectralConv,
             n_layers=n_layers)
 
-        self.lifting = MLP(in_channels=in_channels, out_channels=self.hidden_channels, hidden_channels=self.lifting_channels, 
-                 n_layers=1, n_dim=self.n_dim)
+        self.lifting = MLP(in_channels=in_channels, out_channels=self.hidden_channels, hidden_channels=self.hidden_channels, n_layers=1, n_dim=self.n_dim)
         self.projection = MLP(in_channels=self.hidden_channels, out_channels=out_channels, hidden_channels=self.projection_channels, n_layers=2, n_dim=self.n_dim, non_linearity=non_linearity) 
 
     def forward(self, x):

--- a/neuralop/models/uno.py
+++ b/neuralop/models/uno.py
@@ -1,4 +1,3 @@
-from .tfno import Lifting, Projection
 import torch.nn as nn
 import torch.nn.functional as F
 from functools import partialmethod
@@ -194,8 +193,7 @@ class UNO(nn.Module):
 
 
         
-
-        self.lifting = Projection(in_channels=in_channels, out_channels=self.hidden_channels, hidden_channels=self.lifting_channels, n_dim=self.n_dim)
+        self.lifting = MLP(in_channels=in_channels, out_channels=self.hidden_channels, hidden_channels=self.lifting_channels, n_layers=2, n_dim=self.n_dim) 
         self.fno_blocks = nn.ModuleList([])
         self.horizontal_skips = torch.nn.ModuleDict({})
         prev_out = self.hidden_channels
@@ -234,8 +232,7 @@ class UNO(nn.Module):
 
             prev_out = self.uno_out_channels[i]
 
-        self.projection = Projection(in_channels=prev_out, out_channels=out_channels, hidden_channels=projection_channels,
-                                        non_linearity=non_linearity, n_dim=self.n_dim)
+        self.projection = MLP(in_channels=prev_out, out_channels=out_channels, hidden_channels=self.projection_channels, n_layers=2, n_dim=self.n_dim, non_linearity=non_linearity) 
      
     def forward(self, x):
         x = self.lifting(x)


### PR DESCRIPTION
Replacing listing and projection modules with mlp.

In this version, with n_layers=1, mlp out_channels with be hidden_channels (hence, hidden_channel must be set when n_layers=1. Fix is needed.