### PR TITLE
adding flag option to only pad the last dim

### DIFF
--- a/neuralop/layers/padding.py
+++ b/neuralop/layers/padding.py
@@ -12,7 +12,9 @@ class DomainPadding(nn.Module):
         whether to pad on both sides, by default 'one-sided'
     padding_dim : bool or list
         set True to pad all dimension, or provide a list of dimensions you want to pad, by default 'True'
-
+        the indices of dimensions to pad start with spatial dimension (excluding batch and channel).
+        first spatial dimension is 0, second spatial dimension is 1, ...
+        
     Notes
     -----
     This class works for any input resolution, as long as it is in the form

--- a/neuralop/layers/padding.py
+++ b/neuralop/layers/padding.py
@@ -44,7 +44,7 @@ class DomainPadding(nn.Module):
         if isinstance(self.domain_padding, (float, int)):
             self.domain_padding = [float(self.domain_padding)]*len(resolution)
 
-        assert len(self.domain_padding) == len(resolution)
+        assert len(self.domain_padding) == len(resolution),  "domain_padding length must match the number of spatial/time dimensions (excluding batch, ch)"
 
         if self.output_scaling_factor is None:
             self.output_scaling_factor = [1]*len(resolution)
@@ -76,12 +76,12 @@ class DomainPadding(nn.Module):
                 unpad_list = list()
                 for p in output_pad[::-1]:
                     if p == 0:
-                        unpad_amount_pos = None
-                        unpad_amount_neg = None
+                        padding_end = None
+                        padding_start = None
                     else:
-                        unpad_amount_pos = p
-                        unpad_amount_neg = -p
-                    unpad_list.append(slice(unpad_amount_pos, unpad_amount_neg, None))
+                        padding_end = p
+                        padding_start = -p
+                    unpad_list.append(slice(padding_end, padding_start, None))
                 unpad_indices = (Ellipsis, ) + tuple(unpad_list)
 
                 padding = [i for p in padding for i in (p, p)]
@@ -91,10 +91,10 @@ class DomainPadding(nn.Module):
                 unpad_list = list()
                 for p in output_pad[::-1]:
                     if p == 0:
-                        unpad_amount_neg = None
+                        padding_start = None
                     else:
-                        unpad_amount_neg = -p
-                    unpad_list.append(slice(None, unpad_amount_neg, None))
+                        padding_start = -p
+                    unpad_list.append(slice(None, padding_start, None))
                 unpad_indices = (Ellipsis, ) + tuple(unpad_list)
                 padding = [i for p in padding for i in (0, p)]
             else:

--- a/neuralop/layers/tests/test_padding.py
+++ b/neuralop/layers/tests/test_padding.py
@@ -3,20 +3,21 @@ from ..padding import DomainPadding
 import pytest
 
 @pytest.mark.parametrize('mode', ['one-sided', 'symmetric'])
-@pytest.mark.parametrize('padding_dim', [0.2, [0.1, 0.2]])
-def test_DomainPadding_2d(mode, padding_dim):
-    if isinstance(padding_dim, float):
+@pytest.mark.parametrize('padding', [0.2, [0.1, 0.2]])
+def test_DomainPadding_2d(mode, padding):
+    if isinstance(padding, float):
         out_size =  {'one-sided': [12, 12], 'symmetric': [14, 14]}
     else:
         out_size =  {'one-sided': [11, 12], 'symmetric': [12, 14]} 
 
     data = torch.randn((2, 3, 10, 10))
-    padder = DomainPadding(padding_dim, mode)
+    padder = DomainPadding(padding, mode)
     padded = padder.pad(data)
 
     target_shape = list(padded.shape)
-    for ctr in range(1,3):
-        target_shape[-ctr] = out_size[mode][-ctr]
+    # create the target shape from hardcoded out_size
+    for pad_dim in range(1,3):
+        target_shape[-pad_dim] = out_size[mode][-pad_dim]
     assert list(padded.shape) == target_shape
 
     unpadded = padder.unpad(padded)
@@ -24,20 +25,21 @@ def test_DomainPadding_2d(mode, padding_dim):
 
 
 @pytest.mark.parametrize('mode', ['one-sided', 'symmetric'])
-@pytest.mark.parametrize('padding_dim', [0.2, [0.1, 0, 0.2]])
-def test_DomainPadding_3d(mode, padding_dim):
-    if isinstance(padding_dim, float):
+@pytest.mark.parametrize('padding', [0.2, [0.1, 0, 0.2]])
+def test_DomainPadding_3d(mode, padding):
+    if isinstance(padding, float):
         out_size =  {'one-sided': [12, 12, 12], 'symmetric': [14, 14, 14]}
     else:
         out_size =  {'one-sided': [11, 10, 12], 'symmetric': [12, 10, 14]} 
 
     data = torch.randn((2, 3, 10, 10, 10))
-    padder = DomainPadding(padding_dim, mode)
+    padder = DomainPadding(padding, mode)
     padded = padder.pad(data)
 
     target_shape = list(padded.shape)
-    for ctr in range(1,4):
-        target_shape[-ctr] = out_size[mode][-ctr]
+    # create the target shape from hardcoded out_size
+    for pad_dim in range(1,4):
+        target_shape[-pad_dim] = out_size[mode][-pad_dim]
     assert list(padded.shape) == target_shape
 
     unpadded = padder.unpad(padded)

--- a/neuralop/layers/tests/test_padding.py
+++ b/neuralop/layers/tests/test_padding.py
@@ -3,16 +3,44 @@ from ..padding import DomainPadding
 import pytest
 
 @pytest.mark.parametrize('mode', ['one-sided', 'symmetric'])
-def test_DomainPadding(mode):
-    out_size = {'one-sided': 12, 'symmetric': 14}
+@pytest.mark.parametrize('padding_dim', [0.2, [0.1, 0.2]])
+def test_DomainPadding_2d(mode, padding_dim):
+    if isinstance(padding_dim, float):
+        out_size =  {'one-sided': [12, 12], 'symmetric': [14, 14]}
+    else:
+        out_size =  {'one-sided': [11, 12], 'symmetric': [12, 14]} 
+
     data = torch.randn((2, 3, 10, 10))
-    padder = DomainPadding(0.2, mode)
+    padder = DomainPadding(padding_dim, mode)
     padded = padder.pad(data)
 
     target_shape = list(padded.shape)
-    target_shape[-1] = target_shape[-2] = out_size[mode]
+    for ctr in range(1,3):
+        target_shape[-ctr] = out_size[mode][-ctr]
     assert list(padded.shape) == target_shape
 
     unpadded = padder.unpad(padded)
     assert unpadded.shape == data.shape
+
+
+@pytest.mark.parametrize('mode', ['one-sided', 'symmetric'])
+@pytest.mark.parametrize('padding_dim', [0.2, [0.1, 0, 0.2]])
+def test_DomainPadding_3d(mode, padding_dim):
+    if isinstance(padding_dim, float):
+        out_size =  {'one-sided': [12, 12, 12], 'symmetric': [14, 14, 14]}
+    else:
+        out_size =  {'one-sided': [11, 10, 12], 'symmetric': [12, 10, 14]} 
+
+    data = torch.randn((2, 3, 10, 10, 10))
+    padder = DomainPadding(padding_dim, mode)
+    padded = padder.pad(data)
+
+    target_shape = list(padded.shape)
+    for ctr in range(1,4):
+        target_shape[-ctr] = out_size[mode][-ctr]
+    assert list(padded.shape) == target_shape
+
+    unpadded = padder.unpad(padded)
+    assert unpadded.shape == data.shape
+
 

--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -44,10 +44,10 @@ class FNO(nn.Module):
         By default None, otherwise tanh is used before FFT in the FNO block 
     use_mlp : bool, optional
         Whether to use an MLP layer after each FNO block, by default False
-    mlp_dropout : float 
-        droupout parameter of MLP layer (default is 0)
-    mlp_expansion : float
-        expansion parameter of MLP layer (default is 0.5)
+    mlp_dropout : float , optional
+        droupout parameter of MLP layer, by default 0
+    mlp_expansion : float, optional
+        expansion parameter of MLP layer, by default 0.5
     non_linearity : nn.Module, optional
         Non-Linearity module to use, by default F.gelu
     norm : F.module, optional

--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -1,4 +1,5 @@
 import torch.nn as nn
+import numpy as np
 import torch.nn.functional as F
 from functools import partialmethod
 
@@ -107,7 +108,6 @@ class FNO(nn.Module):
                  decomposition_kwargs=dict(),
                  domain_padding=None,
                  domain_padding_mode='one-sided',
-                 domain_padding_dim=True,
                  fft_norm='forward',
                  SpectralConv=SpectralConv,
                  **kwargs):
@@ -138,10 +138,11 @@ class FNO(nn.Module):
         # When updated, change should be reflected in fno blocks
         self._incremental_n_modes = incremental_n_modes
 
-        if domain_padding is not None and domain_padding > 0:
-            self.domain_padding = DomainPadding(domain_padding=domain_padding, padding_mode=domain_padding_mode, output_scaling_factor=output_scaling_factor,padding_dim=domain_padding_dim)
+        if domain_padding is not None and ((isinstance(domain_padding, list) and sum(domain_padding) > 0) or (isinstance(domain_padding, (float, int)) and domain_padding > 0)):
+                self.domain_padding = DomainPadding(domain_padding=domain_padding, padding_mode=domain_padding_mode, output_scaling_factor=output_scaling_factor)
         else:
             self.domain_padding = None
+        print(self.domain_padding, "lll")
         self.domain_padding_mode = domain_padding_mode
 
         if output_scaling_factor is not None and not joint_factorization:

--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -105,7 +105,7 @@ class FNO(nn.Module):
                  decomposition_kwargs=dict(),
                  domain_padding=None,
                  domain_padding_mode='one-sided',
-                 domain_padding_only_last_dim=False,
+                 domain_padding_dim=True,
                  fft_norm='forward',
                  SpectralConv=SpectralConv,
                  **kwargs):
@@ -137,7 +137,7 @@ class FNO(nn.Module):
         self._incremental_n_modes = incremental_n_modes
 
         if domain_padding is not None and domain_padding > 0:
-            self.domain_padding = DomainPadding(domain_padding=domain_padding, padding_mode=domain_padding_mode, output_scaling_factor=output_scaling_factor,pad_only_last_dim=domain_padding_only_last_dim)
+            self.domain_padding = DomainPadding(domain_padding=domain_padding, padding_mode=domain_padding_mode, output_scaling_factor=output_scaling_factor,padding_dim=domain_padding_dim)
         else:
             self.domain_padding = None
         self.domain_padding_mode = domain_padding_mode

--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -142,7 +142,7 @@ class FNO(nn.Module):
                 self.domain_padding = DomainPadding(domain_padding=domain_padding, padding_mode=domain_padding_mode, output_scaling_factor=output_scaling_factor)
         else:
             self.domain_padding = None
-        print(self.domain_padding, "lll")
+
         self.domain_padding_mode = domain_padding_mode
 
         if output_scaling_factor is not None and not joint_factorization:

--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -54,8 +54,10 @@ class FNO(nn.Module):
         Normalization layer to use, by default None
     preactivation : bool, default is False
         if True, use resnet-style preactivation
-    skip : {'linear', 'identity', 'soft-gating'}, optional
-        Type of skip connection to use, by default 'soft-gating'
+    fno_skip : {'linear', 'identity', 'soft-gating'}, optional
+        Type of skip connection to use in fno, by default 'linear'
+    mlp_skip : {'linear', 'identity', 'soft-gating'}, optional
+        Type of skip connection to use in mlp, by default 'soft-gating'
     separable : bool, default is False
         if True, use a depthwise separable spectral convolution
     factorization : str or None, {'tucker', 'cp', 'tt'}

--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -104,6 +104,7 @@ class FNO(nn.Module):
                  decomposition_kwargs=dict(),
                  domain_padding=None,
                  domain_padding_mode='one-sided',
+                 domain_padding_only_last_dim=False,
                  fft_norm='forward',
                  SpectralConv=SpectralConv,
                  **kwargs):
@@ -135,7 +136,7 @@ class FNO(nn.Module):
         self._incremental_n_modes = incremental_n_modes
 
         if domain_padding is not None and domain_padding > 0:
-            self.domain_padding = DomainPadding(domain_padding=domain_padding, padding_mode=domain_padding_mode, output_scaling_factor=output_scaling_factor)
+            self.domain_padding = DomainPadding(domain_padding=domain_padding, padding_mode=domain_padding_mode, output_scaling_factor=output_scaling_factor,pad_only_last_dim=domain_padding_only_last_dim)
         else:
             self.domain_padding = None
         self.domain_padding_mode = domain_padding_mode


### PR DESCRIPTION
Added a pad_only_last_dim in DomainPadding class (default False). Updated FNO class to have the flag domain_padding_only_last_dim (default False). If set True, then padding is only applied to the last dim of the input.