### PR TITLE
Use lifting channels in FNO.lifting if it is passed

### DIFF
--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -175,7 +175,12 @@ class FNO(nn.Module):
             n_layers=n_layers,
             **kwargs)
 
-        self.lifting = MLP(in_channels=in_channels, out_channels=self.hidden_channels, hidden_channels=self.hidden_channels, n_layers=1, n_dim=self.n_dim)
+        # if lifting_channels is passed, make lifting an MLP with a hidden layer of size lifting_channels
+        if self.lifting_channels:
+            self.lifting = MLP(in_channels=in_channels, out_channels=self.hidden_channels, hidden_channels=self.lifting_channels, n_layers=2, n_dim=self.n_dim)
+        # otherwise, make it a linear layer
+        else:
+            self.lifting = MLP(in_channels=in_channels, out_channels=self.hidden_channels, hidden_channels=self.hidden_channels, n_layers=1, n_dim=self.n_dim)
         self.projection = MLP(in_channels=self.hidden_channels, out_channels=out_channels, hidden_channels=self.projection_channels, n_layers=2, n_dim=self.n_dim, non_linearity=non_linearity) 
 
     def forward(self, x):

--- a/neuralop/models/tests/test_fno.py
+++ b/neuralop/models/tests/test_fno.py
@@ -14,6 +14,7 @@ tenalg.set_backend('einsum')
 @pytest.mark.parametrize('n_dim', [1, 2, 3])
 @pytest.mark.parametrize('fno_block_precision', ['full', 'half', 'mixed'])
 @pytest.mark.parametrize('stabilizer', [None, 'tanh'])
+@pytest.mark.parameterized('lifting_channels', [None, 256])
 def test_tfno(factorization, implementation, n_dim, fno_block_precision, stabilizer):
     if torch.has_cuda:
         device = 'cuda'


### PR DESCRIPTION
Simple fix. Corresponding to Issue #162. Updated the FNO class so that when `lifting_channels` is passed to the FNO, `self.lifting` is an MLP with a hidden layer of size `lifting_channels` instead of a linear layer. 