### PR TITLE
Reformat `datasets/` directory with `black`

### DIFF
--- a/neuralop/datasets/burgers.py
+++ b/neuralop/datasets/burgers.py
@@ -1,22 +1,24 @@
 from pathlib import Path
 import torch
 
-def load_burgers(data_path, n_train, n_test, batch_train=32, batch_test=100, 
-                 time=1, grid=[0,1]):
 
-    data_path = Path(data_path).joinpath('burgers.pt').as_posix()
+def load_burgers(
+    data_path, n_train, n_test, batch_train=32, batch_test=100, time=1, grid=[0, 1]
+):
+
+    data_path = Path(data_path).joinpath("burgers.pt").as_posix()
     data = torch.load(data_path)
 
-    x_train = data[0:n_train,:,0]
-    x_test = data[n_train:(n_train + n_test),:,0]
+    x_train = data[0:n_train, :, 0]
+    x_test = data[n_train : (n_train + n_test), :, 0]
 
-    y_train = data[0:n_train,:,time]
-    y_test = data[n_train:(n_train + n_test),:,time]
+    y_train = data[0:n_train, :, time]
+    y_test = data[n_train : (n_train + n_test), :, time]
 
     s = x_train.size(-1)
-    
+
     if grid is not None:
-        grid = torch.linspace(grid[0], grid[1], s + 1)[0:-1].view(1,-1)
+        grid = torch.linspace(grid[0], grid[1], s + 1)[0:-1].view(1, -1)
 
         grid_train = grid.repeat(n_train, 1)
         grid_test = grid.repeat(n_test, 1)
@@ -24,7 +26,15 @@ def load_burgers(data_path, n_train, n_test, batch_train=32, batch_test=100,
         x_train = torch.cat((x_train.unsqueeze(1), grid_train.unsqueeze(1)), 1)
         x_test = torch.cat((x_test.unsqueeze(1), grid_test.unsqueeze(1)), 1)
 
-    train_loader = torch.utils.data.DataLoader(torch.utils.data.TensorDataset(x_train, y_train), batch_size=batch_train, shuffle=False)
-    test_loader = torch.utils.data.DataLoader(torch.utils.data.TensorDataset(x_test, y_test), batch_size=batch_test, shuffle=False)
+    train_loader = torch.utils.data.DataLoader(
+        torch.utils.data.TensorDataset(x_train, y_train),
+        batch_size=batch_train,
+        shuffle=False,
+    )
+    test_loader = torch.utils.data.DataLoader(
+        torch.utils.data.TensorDataset(x_test, y_test),
+        batch_size=batch_test,
+        shuffle=False,
+    )
 
     return train_loader, test_loader

--- a/neuralop/datasets/darcy.py
+++ b/neuralop/datasets/darcy.py
@@ -1,23 +1,27 @@
-import torch
 from pathlib import Path
+import torch
 
 from ..utils import UnitGaussianNormalizer
 from .tensor_dataset import TensorDataset
 from .transforms import PositionalEmbedding
 
 
-def load_darcy_flow_small(n_train, n_tests,
-                batch_size, test_batch_sizes,
-                test_resolutions=[16, 32],
-                grid_boundaries=[[0,1],[0,1]],
-                positional_encoding=True,
-                encode_input=False,
-                encode_output=True,
-                encoding='channel-wise', 
-                channel_dim=1):
+def load_darcy_flow_small(
+    n_train,
+    n_tests,
+    batch_size,
+    test_batch_sizes,
+    test_resolutions=[16, 32],
+    grid_boundaries=[[0, 1], [0, 1]],
+    positional_encoding=True,
+    encode_input=False,
+    encode_output=True,
+    encoding="channel-wise",
+    channel_dim=1,
+):
     """Loads a small Darcy-Flow dataset
-    
-    Training contains 1000 samples in resolution 16x16. 
+
+    Training contains 1000 samples in resolution 16x16.
     Testing contains 100 samples at resolution 16x16 and
     50 samples at resolution 32x32.
 
@@ -34,7 +38,8 @@ def load_darcy_flow_small(n_train, n_tests,
     encode_output : bool, default is True
     encoding : 'channel-wise'
     channel_dim : int, default is 1
-        where to put the channel dimension, defaults size is batch, channel, height, width
+        where to put the channel dimension, defaults size is 1
+        i.e: batch, channel, height, width
 
     Returns
     -------
@@ -45,35 +50,51 @@ def load_darcy_flow_small(n_train, n_tests,
     """
     for res in test_resolutions:
         if res not in [16, 32]:
-            raise ValueError(f'Only 32 and 64 are supported for test resolution, but got {test_resolutions=}')
-    path = Path(__file__).resolve().parent.joinpath('data')
-    return load_darcy_pt(str(path), 
-                         n_train=n_train, n_tests=n_tests, 
-                         batch_size=batch_size, test_batch_sizes=test_batch_sizes,
-                         test_resolutions=test_resolutions, train_resolution=16,
-                         grid_boundaries=grid_boundaries,
-                         positional_encoding=positional_encoding,
-                         encode_input=encode_input,
-                         encode_output=encode_output,
-                         encoding=encoding,
-                         channel_dim=channel_dim)
+            raise ValueError(
+                f"Only 32 and 64 are supported for test resolution, "
+                f"but got test_resolutions={test_resolutions}"
+            )
+    path = Path(__file__).resolve().parent.joinpath("data")
+    return load_darcy_pt(
+        str(path),
+        n_train=n_train,
+        n_tests=n_tests,
+        batch_size=batch_size,
+        test_batch_sizes=test_batch_sizes,
+        test_resolutions=test_resolutions,
+        train_resolution=16,
+        grid_boundaries=grid_boundaries,
+        positional_encoding=positional_encoding,
+        encode_input=encode_input,
+        encode_output=encode_output,
+        encoding=encoding,
+        channel_dim=channel_dim,
+    )
 
-def load_darcy_pt(data_path, 
-                n_train, n_tests,
-                batch_size, test_batch_sizes,
-                test_resolutions=[32],
-                train_resolution=32,
-                grid_boundaries=[[0,1],[0,1]],
-                positional_encoding=True,
-                encode_input=False,
-                encode_output=True,
-                encoding='channel-wise', 
-                channel_dim=1):
-    """Load the Navier-Stokes dataset
-    """
-    data = torch.load(Path(data_path).joinpath(f'darcy_train_{train_resolution}.pt').as_posix())
-    x_train = data['x'][0:n_train, :, :].unsqueeze(channel_dim).type(torch.float32).clone()
-    y_train = data['y'][0:n_train, :, :].unsqueeze(channel_dim).clone()
+
+def load_darcy_pt(
+    data_path,
+    n_train,
+    n_tests,
+    batch_size,
+    test_batch_sizes,
+    test_resolutions=[32],
+    train_resolution=32,
+    grid_boundaries=[[0, 1], [0, 1]],
+    positional_encoding=True,
+    encode_input=False,
+    encode_output=True,
+    encoding="channel-wise",
+    channel_dim=1,
+):
+    """Load the Navier-Stokes dataset"""
+    data = torch.load(
+        Path(data_path).joinpath(f"darcy_train_{train_resolution}.pt").as_posix()
+    )
+    x_train = (
+        data["x"][0:n_train, :, :].unsqueeze(channel_dim).type(torch.float32).clone()
+    )
+    y_train = data["y"][0:n_train, :, :].unsqueeze(channel_dim).clone()
     del data
 
     idx = test_resolutions.index(train_resolution)
@@ -81,15 +102,17 @@ def load_darcy_pt(data_path,
     n_test = n_tests.pop(idx)
     test_batch_size = test_batch_sizes.pop(idx)
 
-    data = torch.load(Path(data_path).joinpath(f'darcy_test_{train_resolution}.pt').as_posix())
-    x_test = data['x'][:n_test, :, :].unsqueeze(channel_dim).type(torch.float32).clone()
-    y_test = data['y'][:n_test, :, :].unsqueeze(channel_dim).clone()
+    data = torch.load(
+        Path(data_path).joinpath(f"darcy_test_{train_resolution}.pt").as_posix()
+    )
+    x_test = data["x"][:n_test, :, :].unsqueeze(channel_dim).type(torch.float32).clone()
+    y_test = data["y"][:n_test, :, :].unsqueeze(channel_dim).clone()
     del data
-    
+
     if encode_input:
-        if encoding == 'channel-wise':
+        if encoding == "channel-wise":
             reduce_dims = list(range(x_train.ndim))
-        elif encoding == 'pixel-wise':
+        elif encoding == "pixel-wise":
             reduce_dims = [0]
 
         input_encoder = UnitGaussianNormalizer(x_train, reduce_dim=reduce_dims)
@@ -99,9 +122,9 @@ def load_darcy_pt(data_path,
         input_encoder = None
 
     if encode_output:
-        if encoding == 'channel-wise':
+        if encoding == "channel-wise":
             reduce_dims = list(range(y_train.ndim))
-        elif encoding == 'pixel-wise':
+        elif encoding == "pixel-wise":
             reduce_dims = [0]
 
         output_encoder = UnitGaussianNormalizer(y_train, reduce_dim=reduce_dims)
@@ -109,29 +132,69 @@ def load_darcy_pt(data_path,
     else:
         output_encoder = None
 
-    train_db = TensorDataset(x_train, y_train, transform_x=PositionalEmbedding(grid_boundaries, 0) if positional_encoding else None)
-    train_loader = torch.utils.data.DataLoader(train_db,
-                                            batch_size=batch_size, shuffle=True,
-                                            num_workers=0, pin_memory=True, persistent_workers=False)
+    train_db = TensorDataset(
+        x_train,
+        y_train,
+        transform_x=PositionalEmbedding(grid_boundaries, 0)
+        if positional_encoding
+        else None,
+    )
+    train_loader = torch.utils.data.DataLoader(
+        train_db,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=0,
+        pin_memory=True,
+        persistent_workers=False,
+    )
 
-    test_db = TensorDataset(x_test, y_test,transform_x=PositionalEmbedding(grid_boundaries, 0) if positional_encoding else None)
-    test_loader = torch.utils.data.DataLoader(test_db,
-                                              batch_size=test_batch_size, shuffle=False,
-                                              num_workers=0, pin_memory=True, persistent_workers=False)
-    test_loaders =  {train_resolution: test_loader}
-    for (res, n_test, test_batch_size) in zip(test_resolutions, n_tests, test_batch_sizes):
-        print(f'Loading test db at resolution {res} with {n_test} samples and batch-size={test_batch_size}')
-        data = torch.load(Path(data_path).joinpath(f'darcy_test_{res}.pt').as_posix())
-        x_test = data['x'][:n_test, :, :].unsqueeze(channel_dim).type(torch.float32).clone()
-        y_test = data['y'][:n_test, :, :].unsqueeze(channel_dim).clone()
-        del data 
+    test_db = TensorDataset(
+        x_test,
+        y_test,
+        transform_x=PositionalEmbedding(grid_boundaries, 0)
+        if positional_encoding
+        else None,
+    )
+    test_loader = torch.utils.data.DataLoader(
+        test_db,
+        batch_size=test_batch_size,
+        shuffle=False,
+        num_workers=0,
+        pin_memory=True,
+        persistent_workers=False,
+    )
+    test_loaders = {train_resolution: test_loader}
+    for (res, n_test, test_batch_size) in zip(
+        test_resolutions, n_tests, test_batch_sizes
+    ):
+        print(
+            f"Loading test db at resolution {res} with {n_test} samples "
+            f"and batch-size={test_batch_size}"
+        )
+        data = torch.load(Path(data_path).joinpath(f"darcy_test_{res}.pt").as_posix())
+        x_test = (
+            data["x"][:n_test, :, :].unsqueeze(channel_dim).type(torch.float32).clone()
+        )
+        y_test = data["y"][:n_test, :, :].unsqueeze(channel_dim).clone()
+        del data
         if input_encoder is not None:
             x_test = input_encoder.encode(x_test)
 
-        test_db = TensorDataset(x_test, y_test, transform_x=PositionalEmbedding(grid_boundaries, 0) if positional_encoding else None)
-        test_loader = torch.utils.data.DataLoader(test_db,
-                                                  batch_size=test_batch_size, shuffle=False,
-                                                  num_workers=0, pin_memory=True, persistent_workers=False)
+        test_db = TensorDataset(
+            x_test,
+            y_test,
+            transform_x=PositionalEmbedding(grid_boundaries, 0)
+            if positional_encoding
+            else None,
+        )
+        test_loader = torch.utils.data.DataLoader(
+            test_db,
+            batch_size=test_batch_size,
+            shuffle=False,
+            num_workers=0,
+            pin_memory=True,
+            persistent_workers=False,
+        )
         test_loaders[res] = test_loader
 
     return train_loader, test_loaders, output_encoder

--- a/neuralop/datasets/hdf5_dataset.py
+++ b/neuralop/datasets/hdf5_dataset.py
@@ -1,17 +1,27 @@
-import torch
 import h5py
+import torch
 from torch.utils.data import Dataset
 
 
 class H5pyDataset(Dataset):
     """PDE h5py dataset"""
-    def __init__(self, data_path, resolution=128, transform_x=None, transform_y=None,
-                 n_samples=None):
-        resolution_to_step = {128:8, 256:4, 512:2, 1024:1}
+
+    def __init__(
+        self,
+        data_path,
+        resolution=128,
+        transform_x=None,
+        transform_y=None,
+        n_samples=None,
+    ):
+        resolution_to_step = {128: 8, 256: 4, 512: 2, 1024: 1}
         try:
             subsample_step = resolution_to_step[resolution]
         except KeyError:
-            raise ValueError(f'Got {resolution=}, expected one of {resolution_to_step.keys()}')
+            raise ValueError(
+                f"Got resolution={resolution}, "
+                f"expected one of {resolution_to_step.keys()}"
+            )
 
         self.subsample_step = subsample_step
         self.data_path = data_path
@@ -22,13 +32,13 @@ class H5pyDataset(Dataset):
         if n_samples is not None:
             self.n_samples = n_samples
         else:
-            with h5py.File(str(self.data_path), 'r') as f:
-                self.n_samples = f['x'].shape[0]
+            with h5py.File(str(self.data_path), "r") as f:
+                self.n_samples = f["x"].shape[0]
 
     @property
     def data(self):
         if self._data is None:
-            self._data = h5py.File(str(self.data_path), 'r')
+            self._data = h5py.File(str(self.data_path), "r")
         return self._data
 
     def _attribute(self, variable, name):
@@ -36,19 +46,24 @@ class H5pyDataset(Dataset):
 
     def __len__(self):
         return self.n_samples
-    
+
     def __getitem__(self, idx):
         if torch.is_tensor(idx):
             idx = idx.tolist()
         if isinstance(idx, int):
-            assert idx < self.n_samples, f'Trying to access sample {idx} of dataset with {self.n_samples} samples'
+            assert (
+                idx < self.n_samples
+            ), f"Trying to access sample {idx} of dataset with {self.n_samples} samples"
         else:
             for i in idx:
-                assert i < self.n_samples, f'Trying to access sample {i} of dataset with {self.n_samples} samples'
-    
-        x = self.data['x'][idx, ::self.subsample_step, ::self.subsample_step]
-        y = self.data['y'][idx, ::self.subsample_step, ::self.subsample_step]
-        
+                assert (
+                    i < self.n_samples
+                ), f"Trying to access sample {i} " \
+                   f"of dataset with {self.n_samples} samples"
+
+        x = self.data["x"][idx, :: self.subsample_step, :: self.subsample_step]
+        y = self.data["y"][idx, :: self.subsample_step, :: self.subsample_step]
+
         x = torch.tensor(x, dtype=torch.float32)
         y = torch.tensor(y, dtype=torch.float32)
 
@@ -58,5 +73,4 @@ class H5pyDataset(Dataset):
         if self.transform_y:
             y = self.transform_y(y)
 
-        return {'x': x, 'y': y}
-    
+        return {"x": x, "y": y}

--- a/neuralop/datasets/zarr_dataset.py
+++ b/neuralop/datasets/zarr_dataset.py
@@ -5,13 +5,23 @@ from torch.utils.data import Dataset
 
 class ZarrDataset(Dataset):
     """PDE h5py dataset"""
-    def __init__(self, filename, resolution=128, transform_x=None, transform_y=None,
-                 n_samples=None):
-        resolution_to_step = {128:8, 256:4, 512:2, 1024:1}
+
+    def __init__(
+        self,
+        filename,
+        resolution=128,
+        transform_x=None,
+        transform_y=None,
+        n_samples=None,
+    ):
+        resolution_to_step = {128: 8, 256: 4, 512: 2, 1024: 1}
         try:
             subsample_step = resolution_to_step[resolution]
         except KeyError:
-            raise ValueError(f'Got {resolution=}, expected one of {resolution_to_step.keys()}')
+            raise ValueError(
+                f"Got resolution={resolution}, "
+                f"expected one of {resolution_to_step.keys()}"
+            )
 
         self.subsample_step = subsample_step
         self.filename = str(filename)
@@ -23,12 +33,14 @@ class ZarrDataset(Dataset):
         if n_samples is not None:
             self.n_samples = n_samples
         else:
-            data = zarr.open(self.filename, mode='r')
+            data = zarr.open(self.filename, mode="r")
             self.n_samples = data.shape[0]
             del data
 
     def attrs(self, array_name, name):
-        data = zarr.open(self.filename, mode='r', synchronizer=zarr.ThreadSynchronizer())
+        data = zarr.open(
+            self.filename, mode="r", synchronizer=zarr.ThreadSynchronizer()
+        )
         value = data[array_name].attrs[name]
         del data
         return value
@@ -36,26 +48,32 @@ class ZarrDataset(Dataset):
     @property
     def data(self):
         if self._data is None:
-            self._data = zarr.open(self.filename, mode='r', synchronizer=zarr.ThreadSynchronizer())
+            self._data = zarr.open(
+                self.filename, mode="r", synchronizer=zarr.ThreadSynchronizer()
+            )
         return self._data
 
     def __len__(self):
         return self.n_samples
-    
+
     def __getitem__(self, idx):
         if torch.is_tensor(idx):
             idx = idx.tolist()
 
         if isinstance(idx, int):
-            assert idx < self.n_samples, f'Trying to access sample {idx} of dataset with {self.n_samples} samples'
+            assert (
+                idx < self.n_samples
+            ), f"Trying to access sample {idx} of dataset with {self.n_samples} samples"
         else:
             for i in idx:
-                assert i < self.n_samples, f'Trying to access sample {i} of dataset with {self.n_samples} samples'
-    
-        x = self.data['x'][idx, ::self.subsample_step, ::self.subsample_step]
-        y = self.data['y'][idx, ::self.subsample_step, ::self.subsample_step]
-        
-        
+                assert (
+                    i < self.n_samples
+                ), f"Trying to access sample {i} " \
+                   f"of dataset with {self.n_samples} samples"
+
+        x = self.data["x"][idx, :: self.subsample_step, :: self.subsample_step]
+        y = self.data["y"][idx, :: self.subsample_step, :: self.subsample_step]
+
         x = torch.tensor(x, dtype=torch.float32)
         y = torch.tensor(y, dtype=torch.float32).unsqueeze(0)
 
@@ -65,19 +83,31 @@ class ZarrDataset(Dataset):
         if self.transform_y:
             y = self.transform_y(y)
 
-        return {'x': x, 'y': y}
-    
+        return {"x": x, "y": y}
+
     def __getitems__(self, idx):
         if torch.is_tensor(idx):
             idx = idx.tolist()
 
-        x = torch.tensor([self.data['x'][i, ::self.subsample_step, ::self.subsample_step] for i in idx], dtype=torch.float32)
-        y = torch.tensor([self.data['y'][i, ::self.subsample_step, ::self.subsample_step] for i in idx], dtype=torch.float32)
-        
+        x = torch.tensor(
+            [
+                self.data["x"][i, :: self.subsample_step, :: self.subsample_step]
+                for i in idx
+            ],
+            dtype=torch.float32,
+        )
+        y = torch.tensor(
+            [
+                self.data["y"][i, :: self.subsample_step, :: self.subsample_step]
+                for i in idx
+            ],
+            dtype=torch.float32,
+        )
+
         if self.transform_x:
             x = self.transform_x(x)
 
         if self.transform_y:
             y = self.transform_y(y)
 
-        return {'x': x, 'y': y}
+        return {"x": x, "y": y}


### PR DESCRIPTION
Reformat select files (in particular, those changes in https://github.com/neuraloperator/neuraloperator/pull/186, https://github.com/m4e7/neuraloperator/pull/6) in directory `neuralop/datasets` with `black`.

Reviewer(s): @JeanKossaifi @zongyi-li 