### PR TITLE
 Fix Python 3.6 f-string compatibility and condense documentation for FNO classes

### DIFF
--- a/neuralop/layers/integral_transform.py
+++ b/neuralop/layers/integral_transform.py
@@ -66,7 +66,9 @@ class IntegralTransform(nn.Module):
            self.transform_type != 'nonlinear_kernelonly' and \
            self.transform_type != 'nonlinear':
             
-            raise ValueError(f'Got {transform_type=} but expected one of [linear_kernelonly, linear, nonlinear_kernelonly, nonlinear]')
+            raise ValueError(
+                f'Got transform_type={transform_type} but expected one of '
+                '[linear_kernelonly, linear, nonlinear_kernelonly, nonlinear]')
 
         if mlp is None:
             self.mlp = MLPLinear(layers=mlp_layers,

--- a/neuralop/layers/integral_transform.py
+++ b/neuralop/layers/integral_transform.py
@@ -1,9 +1,10 @@
 import torch
 from torch import nn
 import torch.nn.functional as F
-
 from torch_scatter import segment_csr
+
 from .mlp import MLPLinear
+
 
 class IntegralTransform(nn.Module):
     """Integral Kernel Transform (GNO)
@@ -15,10 +16,10 @@ class IntegralTransform(nn.Module):
 
     x : Points for which the output is defined
     y : Points for which the input is defined
-    A(x) : A subset of all points y (depending on 
+    A(x) : A subset of all points y (depending on
            each x) over which to integrate
     k : A kernel parametrized as a MLP
-    f : Input function to integrate against given 
+    f : Input function to integrate against given
         on the points y
 
     If f is not given, a transform of type (a)
@@ -32,12 +33,12 @@ class IntegralTransform(nn.Module):
         MLP parametrizing the kernel k. Input dimension
         should be dim x + dim y or dim x + dim y + dim f
     mlp_layers : list, default None
-        List of layers sizes speficing a MLP which 
-        parametrizes the kernel k. The MLP will be 
-        instansiated by the MLPLinear class  
+        List of layers sizes speficing a MLP which
+        parametrizes the kernel k. The MLP will be
+        instansiated by the MLPLinear class
     mlp_non_linearity : callable, default torch.nn.functional.gelu
-        Non-linear function used to be used by the 
-        MLPLinear class. Only used if mlp_layers is 
+        Non-linear function used to be used by the
+        MLPLinear class. Only used if mlp_layers is
         given and mlp is None
     transform_type : str, default 'linear'
         Which integral transform to compute. The mapping is:
@@ -45,37 +46,41 @@ class IntegralTransform(nn.Module):
         'linear' -> (b)
         'nonlinear_kernelonly' -> (c)
         'nonlinear' -> (d)
-        If the input f is not given then (a) is computed 
+        If the input f is not given then (a) is computed
         by default independently of this parameter.
     """
-    def __init__(self, 
-                 mlp=None,
-                 mlp_layers=None,
-                 mlp_non_linearity=F.gelu, 
-                 transform_type='linear'
-                 ):
-        
+
+    def __init__(
+        self,
+        mlp=None,
+        mlp_layers=None,
+        mlp_non_linearity=F.gelu,
+        transform_type="linear",
+    ):
+
         super().__init__()
 
         assert mlp is not None or mlp_layers is not None
 
         self.transform_type = transform_type
 
-        if self.transform_type != 'linear_kernelonly' and \
-           self.transform_type != 'linear' and \
-           self.transform_type != 'nonlinear_kernelonly' and \
-           self.transform_type != 'nonlinear':
-            
+        if (
+            self.transform_type != "linear_kernelonly"
+            and self.transform_type != "linear"
+            and self.transform_type != "nonlinear_kernelonly"
+            and self.transform_type != "nonlinear"
+        ):
+
             raise ValueError(
-                f'Got transform_type={transform_type} but expected one of '
-                '[linear_kernelonly, linear, nonlinear_kernelonly, nonlinear]')
+                f"Got transform_type={transform_type} but expected one of "
+                "[linear_kernelonly, linear, nonlinear_kernelonly, nonlinear]"
+            )
 
         if mlp is None:
-            self.mlp = MLPLinear(layers=mlp_layers,
-                                 non_linearity=mlp_non_linearity)
+            self.mlp = MLPLinear(layers=mlp_layers, non_linearity=mlp_non_linearity)
         else:
             self.mlp = mlp
-        
+
     """"
     
 
@@ -85,27 +90,29 @@ class IntegralTransform(nn.Module):
     NOTE: For transforms of type 0 or 2, out channels must be
     the same as the channels of f
     """
-    def forward(self, 
-                y, 
-                neighbors,
-                x=None, 
-                f_y=None, 
-                weights=None
-            ):
+
+    def forward(
+        self,
+        y,
+        neighbors,
+        x=None,
+        f_y=None,
+        weights=None,
+    ):
         """Compute a kernel integral transform
 
         Parameters
         ----------
         y : torch.Tensor of shape [n, d1]
-            n points of dimension d1 specifying 
+            n points of dimension d1 specifying
             the space to integrate over.
         neighbors : dict
-            The sets A(x) given in CRS format. The 
+            The sets A(x) given in CRS format. The
             dict must contain the keys "neighbors_index"
             and "neighbors_row_splits." For descriptions
             of the two, see NeighborSearch.
         x : torch.Tensor of shape [m, d2], default None
-            m points of dimension d2 over which the 
+            m points of dimension d2 over which the
             output function is defined. If None,
             x = y.
         f_y : torch.Tensor of shape [n, d3], default None
@@ -114,47 +121,52 @@ class IntegralTransform(nn.Module):
             hence its output shape must be d3 for the transforms
             (b) or (d). If None, (a) is computed.
         weights : torch.Tensor of shape [n,], default None
-            Weights for each point y proprtional to the 
+            Weights for each point y proprtional to the
             volume around f(y) being integrated. For example,
             suppose d1=1 and let y_1 < y_2 < ... < y_{n+1}
             be some points. Then, for a Riemann sum,
             the weights are y_{j+1} - y_j. If None,
             1/|A(x)| is used.
-        
+
         Output
         ----------
         out_features : torch.Tensor of shape [m, d4]
             Output function given on the points x.
             d4 is the output size of the kernel k.
         """
-        
+
         if x is None:
             x = y
 
-        rep_features = y[neighbors['neighbors_index']]
+        rep_features = y[neighbors["neighbors_index"]]
         if f_y is not None:
-            in_features = f_y[neighbors['neighbors_index']]
+            in_features = f_y[neighbors["neighbors_index"]]
 
-        num_reps = neighbors['neighbors_row_splits'][1:] - neighbors['neighbors_row_splits'][:-1]
+        num_reps = (
+            neighbors["neighbors_row_splits"][1:]
+            - neighbors["neighbors_row_splits"][:-1]
+        )
         self_features = torch.repeat_interleave(x, num_reps, dim=0)
 
         agg_features = torch.cat([rep_features, self_features], dim=1)
-        if f_y is not None and (self.transform_type == 'nonlinear_kernelonly' or \
-                                self.transform_type == 'nonlinear'):
+        if f_y is not None and (
+            self.transform_type == "nonlinear_kernelonly"
+            or self.transform_type == "nonlinear"
+        ):
             agg_features = torch.cat([agg_features, in_features], dim=1)
 
         rep_features = self.mlp(agg_features)
 
-        if f_y is not None and self.transform_type != 'nonlinear_kernelonly':
-            rep_features = rep_features*in_features 
+        if f_y is not None and self.transform_type != "nonlinear_kernelonly":
+            rep_features = rep_features * in_features
 
         if weights is not None:
-            rep_features = weights[neighbors['neighbors_index']]*rep_features
-            reduction = 'sum'
+            rep_features = weights[neighbors["neighbors_index"]] * rep_features
+            reduction = "sum"
         else:
-            reduction = 'mean'
+            reduction = "mean"
 
-        out_features = segment_csr(rep_features, 
-                                   neighbors['neighbors_row_splits'], 
-                                   reduce=reduction)
+        out_features = segment_csr(
+            rep_features, neighbors["neighbors_row_splits"], reduce=reduction
+        )
         return out_features

--- a/neuralop/models/model_dispatcher.py
+++ b/neuralop/models/model_dispatcher.py
@@ -59,7 +59,7 @@ def get_model(config):
     try:
         return dispatch_model(MODEL_ZOO[arch], config_arch)
     except KeyError:
-        raise ValueError(f'Got config.{arch=}, expected one of {MODEL_ZOO.keys}.')
+        raise ValueError(f'Got config.arch={arch}, expected one of {MODEL_ZOO.keys}.')
 
 
 def dispatch_model(ModelClass, config):
@@ -82,7 +82,7 @@ def dispatch_model(ModelClass, config):
     # Verify that given parameters are actually arguments of the model
     for key in config:
         if key not in sig.parameters:
-            print(f"Given argument {key=} that is not in {model_name}'s signature.")
+            print(f"Given argument key={key} that is not in {model_name}'s signature.")
             # warnings.warn(f"Given argument {key=} that is not in {model_name}'s signature.")
     
     # Check for model arguments not specified in the configuration

--- a/neuralop/models/model_dispatcher.py
+++ b/neuralop/models/model_dispatcher.py
@@ -1,25 +1,25 @@
+import inspect
+
 from .fno import TFNO, TFNO1d, TFNO2d, TFNO3d
 from .fno import FNO, FNO1d, FNO2d, FNO3d
 from .uno import UNO
-import inspect
 
 
 MODEL_ZOO = {
-    'tfno'   : TFNO,
-    'tfno1d' : TFNO1d,
-    'tfno2d' : TFNO2d,
-    'tfno3d' : TFNO3d,
-    'fno'    : FNO,
-    'fno1d'  : FNO1d,
-    'fno2d'  : FNO2d,
-    'fno3d'  : FNO3d,
-    'uno'    : UNO,
+    "tfno": TFNO,
+    "tfno1d": TFNO1d,
+    "tfno2d": TFNO2d,
+    "tfno3d": TFNO3d,
+    "fno": FNO,
+    "fno1d": FNO1d,
+    "fno2d": FNO2d,
+    "fno3d": FNO3d,
+    "uno": UNO,
 }
 
 
 def available_models():
-    """List the available neural operators
-    """
+    """List the available neural operators"""
     return list(MODEL_ZOO.keys())
 
 
@@ -33,7 +33,7 @@ def get_model(config):
     Parameters
     ----------
     config : Bunch or dict-like
-        configuration, must have 
+        configuration, must have
         arch = config['arch'] (string)
         and the corresponding config[arch] (a subdict with the kwargs of the model)
 
@@ -42,30 +42,30 @@ def get_model(config):
     model : nn.Module
         the instanciated module
     """
-    arch = config['arch'].lower()
+    arch = config["arch"].lower()
     config_arch = config.get(arch)
 
     # Set the number of input channels depending on channels in data + mg patching
-    data_channels = config_arch.pop('data_channels')
+    data_channels = config_arch.pop("data_channels")
     try:
-        patching_levels = config['patching']['levels']
+        patching_levels = config["patching"]["levels"]
     except KeyError:
         patching_levels = 0
     if patching_levels:
-        data_channels *= (patching_levels + 1)
-    config_arch['in_channels'] = data_channels
+        data_channels *= patching_levels + 1
+    config_arch["in_channels"] = data_channels
 
     # Dispatch model creation
     try:
         return dispatch_model(MODEL_ZOO[arch], config_arch)
     except KeyError:
-        raise ValueError(f'Got config.arch={arch}, expected one of {MODEL_ZOO.keys}.')
+        raise ValueError(f"Got config.arch={arch}, expected one of {MODEL_ZOO.keys}.")
 
 
 def dispatch_model(ModelClass, config):
     """This function just creates an instance of the model ModelClass(**config)
     but performs additional checks to warn users about missing/wrong arguments.
-    
+
     Parameters
     ----------
     ModelClass : nn.Module
@@ -78,17 +78,24 @@ def dispatch_model(ModelClass, config):
     """
     sig = inspect.signature(ModelClass)
     model_name = ModelClass.__name__
-    
+
     # Verify that given parameters are actually arguments of the model
     for key in config:
         if key not in sig.parameters:
-            print(f"Given argument key={key} that is not in {model_name}'s signature.")
-            # warnings.warn(f"Given argument {key=} that is not in {model_name}'s signature.")
-    
+            print(f"Given argument key={key} "
+                  f"that is not in {model_name}'s signature.")
+            # warnings.warn(f"Given argument {key=} "
+            #               f"that is not in {model_name}'s signature.")
+
     # Check for model arguments not specified in the configuration
     for key, value in sig.parameters.items():
         if (value.default is not inspect._empty) and (key not in config):
-            print(f"Keyword argument {key} not specified for model {model_name}, using default={value.default}.")
-            # warnings.warn(f"Keyword argument {key} not specified for model {model_name}, using default={value.default}.")
+            print(
+                f"Keyword argument {key} not specified for model {model_name}, "
+                f"using default={value.default}."
+            )
+            # warnings.warn(
+            #     f"Keyword argument {key} not specified for model {model_name}, "
+            #     f"using default={value.default}.")
 
     return ModelClass(**config)

--- a/neuralop/training/patching.py
+++ b/neuralop/training/patching.py
@@ -30,7 +30,12 @@ class MultigridPatching2D(nn.Module):
         self.stitching = stitching
         
         if levels > 0:
-            print(f'MGPatching({self.n_patches=}, {self.padding_fraction=}, {self.levels=}, {use_distributed=}, {stitching=})')
+            print('MGPatching('
+                  f'n_patches={self.n_patches}, '
+                  f'padding_fraction={self.padding_fraction}, '
+                  f'levels={self.levels}, '
+                  f'use_distributed={use_distributed}, '
+                  f'stitching={stitching})')
         
         #If distributed patches are stiched, re-scale gradients to revert DDP averaging 
         if self.use_distributed and self.stitching:

--- a/neuralop/training/patching.py
+++ b/neuralop/training/patching.py
@@ -1,79 +1,93 @@
+import math
+
 import torch
-import math 
 from torch import nn
-from neuralop.mpu.mappings import gather_from_model_parallel_region, scatter_to_model_parallel_region
+
 import neuralop.mpu.comm as comm
+from neuralop.mpu.mappings import (
+    gather_from_model_parallel_region,
+    scatter_to_model_parallel_region,
+)
 
 
 class MultigridPatching2D(nn.Module):
-    def __init__(self, model, levels=0, padding_fraction=0, use_distributed=False, stitching=True):
-        """Wraps a model inside a multi-grid patching
-        """
+    def __init__(
+        self,
+        model,
+        levels=0,
+        padding_fraction=0,
+        use_distributed=False,
+        stitching=True,
+    ):
+        """Wraps a model inside a multi-grid patching"""
         super().__init__()
 
         self.skip_padding = (padding_fraction is None) or (padding_fraction <= 0)
 
-        self.levels=levels
+        self.levels = levels
 
-        if isinstance(padding_fraction, float) or isinstance(padding_fraction, int):
+        if isinstance(padding_fraction, (float, int)):
             padding_fraction = [padding_fraction, padding_fraction]
         self.padding_fraction = padding_fraction
-        
-        n_patches=2**levels
+
+        n_patches = 2**levels
         if isinstance(n_patches, int):
             n_patches = [n_patches, n_patches]
         self.n_patches = n_patches
-        
+
         self.model = model
 
         self.use_distributed = use_distributed
         self.stitching = stitching
-        
+
         if levels > 0:
-            print('MGPatching('
-                  f'n_patches={self.n_patches}, '
-                  f'padding_fraction={self.padding_fraction}, '
-                  f'levels={self.levels}, '
-                  f'use_distributed={use_distributed}, '
-                  f'stitching={stitching})')
-        
-        #If distributed patches are stiched, re-scale gradients to revert DDP averaging 
+            print(
+                "MGPatching("
+                f"n_patches={self.n_patches}, "
+                f"padding_fraction={self.padding_fraction}, "
+                f"levels={self.levels}, "
+                f"use_distributed={use_distributed}, "
+                f"stitching={stitching})"
+            )
+
+        # If distributed patches are stiched, re-scale gradients to revert DDP averaging
         if self.use_distributed and self.stitching:
             for param in model.parameters():
-                param.register_hook(lambda grad: grad * float(comm.get_model_parallel_size())) 
+                param.register_hook(
+                    lambda grad: grad * float(comm.get_model_parallel_size())
+                )
 
     def patch(self, x, y):
-        #If not stitching, scatter truth, otherwise keep on every GPU
+        # If not stitching, scatter truth, otherwise keep on every GPU
         if self.use_distributed and not self.stitching:
             y = make_patches(y, n=self.n_patches, p=0)
             y = scatter_to_model_parallel_region(y, 0)
 
-        #Create padded patches in batch dimension (identity if levels=0)
+        # Create padded patches in batch dimension (identity if levels=0)
         x = self._make_mg_patches(x)
 
-        #Split data across processes
+        # Split data across processes
         if self.use_distributed:
             x = scatter_to_model_parallel_region(x, 0)
-        
+
         return x, y
 
     def unpatch(self, x, y, evaluation=False):
-        """Always stitch during evaluation
-        """
+        """Always stitch during evaluation"""
         if self.skip_padding:
             return x, y
 
-        #Remove padding in the output 
+        # Remove padding in the output
         if self.padding_height > 0 or self.padding_width > 0:
             x = self._unpad(x)
 
-        #Gather patches if they are to be stiched back together
+        # Gather patches if they are to be stitched back together
         if self.use_distributed and self.stitching:
             x = gather_from_model_parallel_region(x, dim=0)
         else:
             x = x
 
-        #Stich patches or patch the truth if output left unstitched
+        # Stich patches or patch the truth if output left unstitched
         if self.stitching or evaluation:
             x = self._stitch(x)
 
@@ -83,28 +97,28 @@ class MultigridPatching2D(nn.Module):
         if self.skip_padding:
             return x
 
-        #Only 1D and 2D supported
-        assert x.ndim == 4, f'Only 2D patche supported but got input with {x.ndim} dims.'
-        
+        # Only 1D and 2D supported
+        assert x.ndim == 4, f"Only 2D patch supported but got input with {x.ndim} dims."
+
         if self.n_patches[0] <= 1 and self.n_patches[1] <= 1:
             return x
 
-        #Size with padding removed    
+        # Size with padding removed
         size = x.size()
 
         # if self.mode == "batch-wise":
-        B = size[0]//(self.n_patches[0]*self.n_patches[1])
-        W = size[3]*self.n_patches[1]
+        B = size[0] // (self.n_patches[0] * self.n_patches[1])
+        W = size[3] * self.n_patches[1]
 
         C = size[1]
-        H = size[2]*self.n_patches[0]
+        H = size[2] * self.n_patches[0]
 
-        #Reshape
-        x = x.permute(0,3,2,1)
+        # Reshape
+        x = x.permute(0, 3, 2, 1)
         x = x.reshape(B, self.n_patches[0], self.n_patches[1], size[3], size[2], C)
-        x = x.permute(0,5,1,4,2,3)
+        x = x.permute(0, 5, 1, 4, 2, 3)
         x = x.reshape(B, C, H, W)
-        
+
         return x
 
     def _make_mg_patches(self, x):
@@ -112,96 +126,140 @@ class MultigridPatching2D(nn.Module):
         if levels <= 0:
             return x
 
-        batch_size, channels, height, width = x.shape
-        padding = [int(round(v)) for v in [height * self.padding_fraction[0], width * self.padding_fraction[1]]]
+        _, _, height, width = x.shape
+        padding = [
+            int(round(v))
+            for v in [
+                height * self.padding_fraction[0],
+                width * self.padding_fraction[1],
+            ]
+        ]
         self.padding_height = padding[0]
         self.padding_width = padding[1]
 
         patched = make_patches(x, n=2**self.levels, p=padding)
 
-        s1_patched = patched.size(-2) - 2*padding[0]
-        s2_patched = patched.size(-1) - 2*padding[1]
+        s1_patched = patched.size(-2) - 2 * padding[0]
+        s2_patched = patched.size(-1) - 2 * padding[1]
 
-        for level in range(1,levels+1):
+        for level in range(1, levels + 1):
             sub_sample = 2**level
-            s1_stride = s1_patched//sub_sample
-            s2_stride = s2_patched//sub_sample
+            s1_stride = s1_patched // sub_sample
+            s2_stride = s2_patched // sub_sample
 
-            x_sub = x[:,:,::sub_sample, ::sub_sample]
+            x_sub = x[:, :, ::sub_sample, ::sub_sample]
 
-            s2_pad = math.ceil((s2_patched + (2**levels - 1)*s2_stride - x_sub.size(-1))/2.0) + padding[1]
-            s1_pad = math.ceil((s1_patched + (2**levels - 1)*s1_stride - x_sub.size(-2))/2.0) + padding[0]
+            s2_pad = (
+                math.ceil(
+                    (s2_patched + (2**levels - 1) * s2_stride - x_sub.size(-1)) / 2.0
+                )
+                + padding[1]
+            )
+            s1_pad = (
+                math.ceil(
+                    (s1_patched + (2**levels - 1) * s1_stride - x_sub.size(-2)) / 2.0
+                )
+                + padding[0]
+            )
 
             if s2_pad > x_sub.size(-1):
                 diff = s2_pad - x_sub.size(-1)
-                x_sub = torch.nn.functional.pad(x_sub, pad=[x_sub.size(-1), x_sub.size(-1), 0, 0], mode='circular')
-                x_sub = torch.nn.functional.pad(x_sub, pad=[diff, diff, 0, 0], mode='circular')
+                x_sub = torch.nn.functional.pad(
+                    x_sub, pad=[x_sub.size(-1), x_sub.size(-1), 0, 0], mode="circular"
+                )
+                x_sub = torch.nn.functional.pad(
+                    x_sub, pad=[diff, diff, 0, 0], mode="circular"
+                )
             else:
-                x_sub = torch.nn.functional.pad(x_sub, pad=[s2_pad, s2_pad, 0, 0], mode='circular')
-            
+                x_sub = torch.nn.functional.pad(
+                    x_sub, pad=[s2_pad, s2_pad, 0, 0], mode="circular"
+                )
+
             if s1_pad > x_sub.size(-2):
                 diff = s1_pad - x_sub.size(-2)
-                x_sub = torch.nn.functional.pad(x_sub, pad=[0, 0, x_sub.size(-2), x_sub.size(-2)], mode='circular')
-                x_sub = torch.nn.functional.pad(x_sub, pad=[0, 0, diff, diff], mode='circular')
+                x_sub = torch.nn.functional.pad(
+                    x_sub, pad=[0, 0, x_sub.size(-2), x_sub.size(-2)], mode="circular"
+                )
+                x_sub = torch.nn.functional.pad(
+                    x_sub, pad=[0, 0, diff, diff], mode="circular"
+                )
             else:
-                x_sub = torch.nn.functional.pad(x_sub, pad=[0, 0, s1_pad, s1_pad], mode='circular')
+                x_sub = torch.nn.functional.pad(
+                    x_sub, pad=[0, 0, s1_pad, s1_pad], mode="circular"
+                )
 
-            x_sub = x_sub.unfold(-1, s2_patched + 2*padding[1], s2_stride)
-            x_sub = x_sub.unfold(-3, s1_patched + 2*padding[0], s1_stride)
+            x_sub = x_sub.unfold(-1, s2_patched + 2 * padding[1], s2_stride)
+            x_sub = x_sub.unfold(-3, s1_patched + 2 * padding[0], s1_stride)
 
-            x_sub = x_sub.permute(0,2,3,4,5,1)
-            x_sub = x_sub.reshape(patched.size(0), s2_patched + 2*padding[1], s1_patched + 2*padding[0], -1)
-            x_sub = x_sub.permute(0,3,2,1)
+            x_sub = x_sub.permute(0, 2, 3, 4, 5, 1)
+            x_sub = x_sub.reshape(
+                patched.size(0),
+                s2_patched + 2 * padding[1],
+                s1_patched + 2 * padding[0],
+                -1,
+            )
+            x_sub = x_sub.permute(0, 3, 2, 1)
 
             patched = torch.cat((patched, x_sub), 1)
-        
+
         return patched
 
     def _unpad(self, x):
-        return x[...,self.padding_height:-self.padding_height,self.padding_width:-self.padding_width].contiguous()
+        return x[
+            ...,
+            self.padding_height : -self.padding_height,
+            self.padding_width : -self.padding_width,
+        ].contiguous()
 
 
-#x : (batch, C, s) or (batch, C, h, w)
-#y : (n*batch, C, s/n + 2p) or (n1*n2*batch, C, h/n1 + 2*p1, w/n2 + 2*p2)
+# x : (batch, C, s) or (batch, C, h, w)
+# y : (n*batch, C, s/n + 2p) or (n1*n2*batch, C, h/n1 + 2*p1, w/n2 + 2*p2)
 def make_patches(x, n, p=0):
 
     size = x.size()
 
-    #Only 1D and 2D supported
+    # Only 1D and 2D supported
     assert len(size) == 3 or len(size) == 4
-        
+
     if len(size) == 3:
         d = 1
     else:
         d = 2
-    
+
     if isinstance(p, int):
         p = [p, p]
-    
-    #Pad
+
+    # Pad
     if p[0] > 0 or p[1] > 0:
         if d == 1:
-            x = torch.nn.functional.pad(x, pad=p, mode='circular')
+            x = torch.nn.functional.pad(x, pad=p, mode="circular")
         else:
-            x = torch.nn.functional.pad(x, pad=[p[1], p[1], p[0], p[0]], mode='circular')
-    
+            x = torch.nn.functional.pad(
+                x, pad=[p[1], p[1], p[0], p[0]], mode="circular"
+            )
+
     if isinstance(n, int):
         n = [n, n]
-    
+
     if n[0] <= 1 and n[1] <= 1:
         return x
 
-    #Patches must be equally sized
+    # Patches must be equally sized
     for j in range(d):
-        assert size[-(j+1)] % n[-(j+1)] == 0
+        assert size[-(j + 1)] % n[-(j + 1)] == 0
 
-    #Patch
+    # Patch
     for j in range(d):
-        patch_size = size[-(j+1)]//n[-(j+1)]
-        x = x.unfold(-(2*j+1), patch_size + 2*p[-(j+1)], patch_size)
+        patch_size = size[-(j + 1)] // n[-(j + 1)]
+        x = x.unfold(-(2 * j + 1), patch_size + 2 * p[-(j + 1)], patch_size)
 
-    x = x.permute(0,2,3,4,5,1)
-    x = x.reshape(size[0]*n[0]*n[1], size[-1]//n[-1] + 2*p[-1], size[-2]//n[-2] + 2*p[-2], size[1])
-    x = x.permute(0,3,2,1)
-        
+    x = x.permute(0, 2, 3, 4, 5, 1)
+    x = x.reshape(
+        size[0] * n[0] * n[1],
+        size[-1] // n[-1] + 2 * p[-1],
+        size[-2] // n[-2] + 2 * p[-2],
+        size[1],
+    )
+    x = x.permute(0, 3, 2, 1)
+
     return x

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -107,12 +107,13 @@ class Trainer:
                 x, y = sample['x'], sample['y']
                 
                 if epoch == 0 and idx == 0 and self.verbose and is_logger:
-                    print(f'Training on raw inputs of size {x.shape=}, {y.shape=}')
+                    print(f'Training on raw inputs of size '
+                          f'x.shape={x.shape}, y.shape={y.shape}')
 
                 x, y = self.patcher.patch(x, y)
 
                 if epoch == 0 and idx == 0 and self.verbose and is_logger:
-                    print(f'.. patched inputs of size {x.shape=}, {y.shape=}')
+                    print(f'.. patched inputs of size x.shape={x.shape}, y.shape={y.shape}')
 
                 x = x.to(self.device)
                 y = y.to(self.device)
@@ -127,15 +128,16 @@ class Trainer:
                 else:
                     out = model(x)
                 if epoch == 0 and idx == 0 and self.verbose and is_logger:
-                    print(f'Raw outputs of size {out.shape=}')
+                    print(f'Raw outputs of size out.shape={out.shape}')
 
                 out, y = self.patcher.unpatch(out, y)
-                #Output encoding only works if output is stiched
+                # Output encoding only works if output is stitched
                 if output_encoder is not None and self.mg_patching_stitching:
                     out = output_encoder.decode(out)
                     y = output_encoder.decode(y)
                 if epoch == 0 and idx == 0 and self.verbose and is_logger:
-                    print(f'.. Processed (unpatched) outputs of size {out.shape=}')
+                    print('.. Processed (unpatched) outputs of size'
+                          f' out.shape={out.shape}')
 
                 if self.amp_autocast:
                     with amp.autocast(enabled=True):

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -1,19 +1,31 @@
-import torch
-from torch.cuda import amp
+import sys
+
 from timeit import default_timer
 import wandb
-import sys 
+import torch
+from torch.cuda import amp
 
 import neuralop.mpu.comm as comm
-
 from .patching import MultigridPatching2D
 from .losses import LpLoss
 
 
 class Trainer:
-    def __init__(self, model, n_epochs, wandb_log=True, device=None, amp_autocast=False,
-                 mg_patching_levels=0, mg_patching_padding=0, mg_patching_stitching=True,
-                 log_test_interval=1, log_output=False, use_distributed=False, verbose=True):
+    def __init__(
+        self,
+        model,
+        n_epochs,
+        wandb_log=True,
+        device=None,
+        amp_autocast=False,
+        mg_patching_levels=0,
+        mg_patching_padding=0,
+        mg_patching_stitching=True,
+        log_test_interval=1,
+        log_output=False,
+        use_distributed=False,
+        verbose=True,
+    ):
         """
         A general Trainer class to train neural-operators on given datasets
 
@@ -28,10 +40,12 @@ class Trainer:
             if 0, no multi-grid domain decomposition is used
             if > 0, indicates the number of levels to use
         mg_patching_padding : float, default is 0
-            value between 0 and 1, indicates the fraction of size to use as padding on each side
-            e.g. for an image of size 64, padding=0.25 will use 16 pixels of padding on each side
+            value between 0 and 1, indicates the fraction of size to use as
+            padding on each side. E.g. for an image of size 64, padding=0.25
+            will use 16 pixels of padding on each side
         mg_patching_stitching : bool, default is True
-            if False, the patches are not stitched back together and the loss is instead computed per patch
+            if False, the patches are not stitched back together and the loss is
+            instead computed per patch
         log_test_interval : int, default is 1
             how frequently to print updates
         log_output : bool, default is False
@@ -54,22 +68,36 @@ class Trainer:
         if mg_patching_levels > 0:
             self.mg_n_patches = 2**mg_patching_levels
             if verbose:
-                print(f'Training on {self.mg_n_patches**2} multi-grid patches.')
+                print(f"Training on {self.mg_n_patches**2} multi-grid patches.")
                 sys.stdout.flush()
         else:
             self.mg_n_patches = 1
             mg_patching_padding = 0
             if verbose:
-                print(f'Training on regular inputs (no multi-grid patching).')
+                print(f"Training on regular inputs (no multi-grid patching).")
                 sys.stdout.flush()
 
         self.mg_patching_padding = mg_patching_padding
-        self.patcher = MultigridPatching2D(model, levels=mg_patching_levels, padding_fraction=mg_patching_padding,
-                                           use_distributed=use_distributed, stitching=mg_patching_stitching)
+        self.patcher = MultigridPatching2D(
+            model,
+            levels=mg_patching_levels,
+            padding_fraction=mg_patching_padding,
+            use_distributed=use_distributed,
+            stitching=mg_patching_stitching,
+        )
 
-    def train(self, train_loader, test_loaders, output_encoder,
-              model, optimizer, scheduler, regularizer, 
-              training_loss=None, eval_losses=None):
+    def train(
+        self,
+        train_loader,
+        test_loaders,
+        output_encoder,
+        model,
+        optimizer,
+        scheduler,
+        regularizer,
+        training_loss=None,
+        eval_losses=None,
+    ):
         """Trains the given model on the given datasets"""
         n_train = len(train_loader.dataset)
 
@@ -77,25 +105,27 @@ class Trainer:
             test_loaders = dict(test=test_loaders)
 
         if self.verbose:
-            print(f'Training on {n_train} samples')
-            print(f'Testing on {[len(loader.dataset) for loader in test_loaders.values()]} samples'
-                  f'         on resolutions {[name for name in test_loaders]}.')
+            print(f"Training on {n_train} samples")
+            print(
+                f"Testing on {[len(loader.dataset) for loader in test_loaders.values()]} samples"
+                f"         on resolutions {[name for name in test_loaders]}."
+            )
             sys.stdout.flush()
 
         if training_loss is None:
             training_loss = LpLoss(d=2)
 
-        if eval_losses is None: # By default just evaluate on the training loss
+        if eval_losses is None:  # By default, just evaluate on the training loss
             eval_losses = dict(l2=training_loss)
 
         if output_encoder is not None:
             output_encoder.to(self.device)
-        
+
         if self.use_distributed:
-            is_logger = (comm.get_world_rank() == 0)
+            is_logger = comm.get_world_rank() == 0
         else:
-            is_logger = True 
-        
+            is_logger = True
+
         for epoch in range(self.n_epochs):
             avg_loss = 0
             avg_lasso_loss = 0
@@ -104,16 +134,21 @@ class Trainer:
             train_err = 0.0
 
             for idx, sample in enumerate(train_loader):
-                x, y = sample['x'], sample['y']
-                
+                x, y = sample["x"], sample["y"]
+
                 if epoch == 0 and idx == 0 and self.verbose and is_logger:
-                    print(f'Training on raw inputs of size '
-                          f'x.shape={x.shape}, y.shape={y.shape}')
+                    print(
+                        "Training on raw inputs of size "
+                        f"x.shape={x.shape}, y.shape={y.shape}"
+                    )
 
                 x, y = self.patcher.patch(x, y)
 
                 if epoch == 0 and idx == 0 and self.verbose and is_logger:
-                    print(f'.. patched inputs of size x.shape={x.shape}, y.shape={y.shape}')
+                    print(
+                        ".. patched inputs of size "
+                        f"x.shape={x.shape}, y.shape={y.shape}"
+                    )
 
                 x = x.to(self.device)
                 y = y.to(self.device)
@@ -128,7 +163,7 @@ class Trainer:
                 else:
                     out = model(x)
                 if epoch == 0 and idx == 0 and self.verbose and is_logger:
-                    print(f'Raw outputs of size out.shape={out.shape}')
+                    print(f"Raw outputs of size out.shape={out.shape}")
 
                 out, y = self.patcher.unpatch(out, y)
                 # Output encoding only works if output is stitched
@@ -136,8 +171,10 @@ class Trainer:
                     out = output_encoder.decode(out)
                     y = output_encoder.decode(y)
                 if epoch == 0 and idx == 0 and self.verbose and is_logger:
-                    print('.. Processed (unpatched) outputs of size'
-                          f' out.shape={out.shape}')
+                    print(
+                        ".. Processed (unpatched) outputs of size"
+                        f" out.shape={out.shape}"
+                    )
 
                 if self.amp_autocast:
                     with amp.autocast(enabled=True):
@@ -149,10 +186,10 @@ class Trainer:
                     loss += regularizer.loss
 
                 loss.backward()
-                
+
                 optimizer.step()
                 train_err += loss.item()
-        
+
                 with torch.no_grad():
                     avg_loss += loss.item()
                     if regularizer:
@@ -166,14 +203,19 @@ class Trainer:
             epoch_train_time = default_timer() - t1
             del x, y
 
-            train_err/= n_train
+            train_err /= n_train
             avg_loss /= self.n_epochs
-            
-            if epoch % self.log_test_interval == 0: 
-                
-                msg = f'[{epoch}] time={epoch_train_time:.2f}, avg_loss={avg_loss:.4f}, train_err={train_err:.4f}'
 
-                values_to_log = dict(train_err=train_err, time=epoch_train_time, avg_loss=avg_loss)
+            if epoch % self.log_test_interval == 0:
+
+                msg = f"[{epoch}] " \
+                      f"time={epoch_train_time:.2f}, " \
+                      f"avg_loss={avg_loss:.4f}, " \
+                      f"train_err={train_err:.4f}"
+
+                values_to_log = dict(
+                    train_err=train_err, time=epoch_train_time, avg_loss=avg_loss
+                )
 
                 for loader_name, loader in test_loaders.items():
                     if epoch == self.n_epochs - 1 and self.log_output:
@@ -181,15 +223,21 @@ class Trainer:
                     else:
                         to_log_output = False
 
-                    errors = self.evaluate(model, eval_losses, loader, output_encoder, log_prefix=loader_name)
+                    errors = self.evaluate(
+                        model,
+                        eval_losses,
+                        loader,
+                        output_encoder,
+                        log_prefix=loader_name,
+                    )
 
                     for loss_name, loss_value in errors.items():
-                        msg += f', {loss_name}={loss_value:.4f}'
+                        msg += f", {loss_name}={loss_value:.4f}"
                         values_to_log[loss_name] = loss_value
 
                 if regularizer:
                     avg_lasso_loss /= self.n_epochs
-                    msg += f', avg_lasso={avg_lasso_loss:.5f}'
+                    msg += f", avg_lasso={avg_lasso_loss:.5f}"
 
                 if self.verbose and is_logger:
                     print(msg)
@@ -198,18 +246,19 @@ class Trainer:
                 # Wandb loging
                 if self.wandb_log and is_logger:
                     for pg in optimizer.param_groups:
-                        lr = pg['lr']
-                        values_to_log['lr'] = lr
+                        lr = pg["lr"]
+                        values_to_log["lr"] = lr
                     wandb.log(values_to_log, step=epoch, commit=True)
 
-    def evaluate(self, model, loss_dict, data_loader, output_encoder=None,
-                 log_prefix=''):
+    def evaluate(
+        self, model, loss_dict, data_loader, output_encoder=None, log_prefix=""
+    ):
         """Evaluates the model on a dictionary of losses
-        
+
         Parameters
         ----------
         model : model to evaluate
-        loss_dict : dict of functions 
+        loss_dict : dict of functions
           each function takes as input a tuple (prediction, ground_truth)
           and returns the corresponding loss
         data_loader : data_loader to evaluate on
@@ -225,25 +274,25 @@ class Trainer:
         model.eval()
 
         if self.use_distributed:
-            is_logger = (comm.get_world_rank() == 0)
+            is_logger = comm.get_world_rank() == 0
         else:
-            is_logger = True 
+            is_logger = True
 
-        errors = {f'{log_prefix}_{loss_name}':0 for loss_name in loss_dict.keys()}
+        errors = {f"{log_prefix}_{loss_name}": 0 for loss_name in loss_dict.keys()}
 
         n_samples = 0
         with torch.no_grad():
             for it, sample in enumerate(data_loader):
-                x, y = sample['x'], sample['y']
+                x, y = sample["x"], sample["y"]
 
                 n_samples += x.size(0)
-                
+
                 x, y = self.patcher.patch(x, y)
                 y = y.to(self.device)
                 x = x.to(self.device)
-                
+
                 out = model(x)
-        
+
                 out, y = self.patcher.unpatch(out, y, evaluation=True)
 
                 if output_encoder is not None:
@@ -254,10 +303,17 @@ class Trainer:
                         img = out
                     else:
                         img = out.squeeze()[0]
-                    wandb.log({f'image_{log_prefix}': wandb.Image(img.unsqueeze(-1).cpu().numpy())}, commit=False)
-                
+                    wandb.log(
+                        {
+                            f"image_{log_prefix}": wandb.Image(
+                                img.unsqueeze(-1).cpu().numpy()
+                            )
+                        },
+                        commit=False,
+                    )
+
                 for loss_name, loss in loss_dict.items():
-                    errors[f'{log_prefix}_{loss_name}'] += loss(out, y).item()
+                    errors[f"{log_prefix}_{loss_name}"] += loss(out, y).item()
 
         del x, y, out
 
@@ -265,5 +321,3 @@ class Trainer:
             errors[key] /= n_samples
 
         return errors
-
-

--- a/scripts/train_darcy.py
+++ b/scripts/train_darcy.py
@@ -1,46 +1,60 @@
-import torch
-import wandb
 import sys
-from configmypy import ConfigPipeline, YamlConfig, ArgparseConfig
-from neuralop import get_model
-from neuralop import Trainer
-from neuralop.training import setup
-from neuralop.datasets import load_darcy_flow_small
-from neuralop.utils import get_wandb_api_key, count_params
-from neuralop import LpLoss, H1Loss
 
+from configmypy import ConfigPipeline, YamlConfig, ArgparseConfig
+import torch
 from torch.nn.parallel import DistributedDataParallel as DDP
+import wandb
+
+from neuralop import H1Loss, LpLoss, Trainer, get_model
+from neuralop.datasets import load_darcy_flow_small
+from neuralop.training import setup
+from neuralop.utils import get_wandb_api_key, count_params
 
 
 # Read the configuration
-config_name = 'default'
-pipe = ConfigPipeline([YamlConfig('./darcy_config.yaml', config_name='default', config_folder='../config'),
-                       ArgparseConfig(infer_types=True, config_name=None, config_file=None),
-                       YamlConfig(config_folder='../config')
-                      ])
+config_name = "default"
+pipe = ConfigPipeline(
+    [
+        YamlConfig(
+            "./darcy_config.yaml", config_name="default", config_folder="../config"
+        ),
+        ArgparseConfig(infer_types=True, config_name=None, config_file=None),
+        YamlConfig(config_folder="../config"),
+    ]
+)
 config = pipe.read_conf()
 config_name = pipe.steps[-1].config_name
 
-#Set-up distributed communication, if using
+# Set-up distributed communication, if using
 device, is_logger = setup(config)
 
-#Set up WandB logging
+# Set up WandB logging
 if config.wandb.log and is_logger:
     wandb.login(key=get_wandb_api_key())
     if config.wandb.name:
         wandb_name = config.wandb.name
     else:
-        wandb_name = '_'.join(
-            f'{var}' for var in [config_name, config.tfno2d.n_layers, 
-                                 config.tfno2d.hidden_channels, 
-                                 config.tfno2d.n_modes_width,
-                                 config.tfno2d.n_modes_height,
-                                 config.tfno2d.factorization,
-                                 config.tfno2d.rank, 
-                                 config.patching.levels, 
-                                 config.patching.padding])
-    wandb.init(config=config, name=wandb_name, group=config.wandb.group,
-               project=config.wandb.project, entity=config.wandb.entity)
+        wandb_name = "_".join(
+            f"{var}"
+            for var in [
+                config_name,
+                config.tfno2d.n_layers,
+                config.tfno2d.hidden_channels,
+                config.tfno2d.n_modes_width,
+                config.tfno2d.n_modes_height,
+                config.tfno2d.factorization,
+                config.tfno2d.rank,
+                config.patching.levels,
+                config.patching.padding,
+            ]
+        )
+    wandb.init(
+        config=config,
+        name=wandb_name,
+        group=config.wandb.group,
+        project=config.wandb.project,
+        entity=config.wandb.entity,
+    )
     if config.wandb.sweep:
         for key in wandb.config.keys():
             config.params[key] = wandb.config[key]
@@ -48,106 +62,127 @@ if config.wandb.log and is_logger:
 # Make sure we only print information when needed
 config.verbose = config.verbose and is_logger
 
-#Print config to screen
+# Print config to screen
 if config.verbose and is_logger:
     pipe.log()
     sys.stdout.flush()
 
 # Loading the Darcy flow dataset
 train_loader, test_loaders, output_encoder = load_darcy_flow_small(
-        n_train=config.data.n_train, batch_size=config.data.batch_size, 
-        positional_encoding=config.data.positional_encoding,
-        test_resolutions=config.data.test_resolutions, n_tests=config.data.n_tests, test_batch_sizes=config.data.test_batch_sizes,
-        encode_input=config.data.encode_input, encode_output=config.data.encode_output,
-        )
+    n_train=config.data.n_train,
+    batch_size=config.data.batch_size,
+    positional_encoding=config.data.positional_encoding,
+    test_resolutions=config.data.test_resolutions,
+    n_tests=config.data.n_tests,
+    test_batch_sizes=config.data.test_batch_sizes,
+    encode_input=config.data.encode_input,
+    encode_output=config.data.encode_output,
+)
 
 model = get_model(config)
 model = model.to(device)
 
-#Use distributed data parallel 
+# Use distributed data parallel
 if config.distributed.use_distributed:
-    model = DDP(model,
-                device_ids=[device.index],
-                output_device=device.index,
-                static_graph=True)
+    model = DDP(
+        model, device_ids=[device.index], output_device=device.index, static_graph=True
+    )
 
-#Log parameter count
+# Log parameter count
 if is_logger:
     n_params = count_params(model)
 
     if config.verbose:
-        print(f'\nn_params: {n_params}')
+        print(f"\nn_params: {n_params}")
         sys.stdout.flush()
 
     if config.wandb.log:
-        to_log = {'n_params': n_params}
+        to_log = {"n_params": n_params}
         if config.n_params_baseline is not None:
-            to_log['n_params_baseline'] = config.n_params_baseline,
-            to_log['compression_ratio'] = config.n_params_baseline/n_params,
-            to_log['space_savings'] = 1 - (n_params/config.n_params_baseline)
+            to_log["n_params_baseline"] = (config.n_params_baseline,)
+            to_log["compression_ratio"] = (config.n_params_baseline / n_params,)
+            to_log["space_savings"] = 1 - (n_params / config.n_params_baseline)
         wandb.log(to_log)
         wandb.watch(model)
 
 
-#Create the optimizer
-optimizer = torch.optim.Adam(model.parameters(), 
-                                lr=config.opt.learning_rate, 
-                                weight_decay=config.opt.weight_decay)
+# Create the optimizer
+optimizer = torch.optim.Adam(
+    model.parameters(),
+    lr=config.opt.learning_rate,
+    weight_decay=config.opt.weight_decay,
+)
 
-if config.opt.scheduler == 'ReduceLROnPlateau':
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, factor=config.opt.gamma, patience=config.opt.scheduler_patience, mode='min')
-elif config.opt.scheduler == 'CosineAnnealingLR':
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=config.opt.scheduler_T_max)
-elif config.opt.scheduler == 'StepLR':
-    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, 
-                                                step_size=config.opt.step_size,
-                                                gamma=config.opt.gamma)
+if config.opt.scheduler == "ReduceLROnPlateau":
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer,
+        factor=config.opt.gamma,
+        patience=config.opt.scheduler_patience,
+        mode="min",
+    )
+elif config.opt.scheduler == "CosineAnnealingLR":
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        optimizer, T_max=config.opt.scheduler_T_max
+    )
+elif config.opt.scheduler == "StepLR":
+    scheduler = torch.optim.lr_scheduler.StepLR(
+        optimizer, step_size=config.opt.step_size, gamma=config.opt.gamma
+    )
 else:
-    raise ValueError(f'Got scheduler={config.opt.scheduler}')
+    raise ValueError(f"Got scheduler={config.opt.scheduler}")
 
 
 # Creating the losses
 l2loss = LpLoss(d=2, p=2)
 h1loss = H1Loss(d=2)
-if config.opt.training_loss == 'l2':
+if config.opt.training_loss == "l2":
     train_loss = l2loss
-elif config.opt.training_loss == 'h1':
+elif config.opt.training_loss == "h1":
     train_loss = h1loss
 else:
-    raise ValueError(f'Got training_loss={config.opt.training_loss} but expected one of ["l2", "h1"]')
-eval_losses={'h1': h1loss, 'l2': l2loss}
+    raise ValueError(
+        f'Got training_loss={config.opt.training_loss} '
+        f'but expected one of ["l2", "h1"]'
+    )
+eval_losses = {"h1": h1loss, "l2": l2loss}
 
 if config.verbose and is_logger:
-    print('\n### MODEL ###\n', model)
-    print('\n### OPTIMIZER ###\n', optimizer)
-    print('\n### SCHEDULER ###\n', scheduler)
-    print('\n### LOSSES ###')
-    print(f'\n * Train: {train_loss}')
-    print(f'\n * Test: {eval_losses}')
-    print(f'\n### Beginning Training...\n')
+    print("\n### MODEL ###\n", model)
+    print("\n### OPTIMIZER ###\n", optimizer)
+    print("\n### SCHEDULER ###\n", scheduler)
+    print("\n### LOSSES ###")
+    print(f"\n * Train: {train_loss}")
+    print(f"\n * Test: {eval_losses}")
+    print(f"\n### Beginning Training...\n")
     sys.stdout.flush()
 
-trainer = Trainer(model, n_epochs=config.opt.n_epochs,
-                  device=device,
-                  amp_autocast=config.opt.amp_autocast,
-                  mg_patching_levels=config.patching.levels,
-                  mg_patching_padding=config.patching.padding,
-                  mg_patching_stitching=config.patching.stitching,
-                  wandb_log=config.wandb.log,
-                  log_test_interval=config.wandb.log_test_interval,
-                  log_output=config.wandb.log_output,
-                  use_distributed=config.distributed.use_distributed,
-                  verbose=config.verbose and is_logger)
+trainer = Trainer(
+    model,
+    n_epochs=config.opt.n_epochs,
+    device=device,
+    amp_autocast=config.opt.amp_autocast,
+    mg_patching_levels=config.patching.levels,
+    mg_patching_padding=config.patching.padding,
+    mg_patching_stitching=config.patching.stitching,
+    wandb_log=config.wandb.log,
+    log_test_interval=config.wandb.log_test_interval,
+    log_output=config.wandb.log_output,
+    use_distributed=config.distributed.use_distributed,
+    verbose=config.verbose and is_logger,
+)
 
 
-trainer.train(train_loader, test_loaders,
-              output_encoder,
-              model, 
-              optimizer,
-              scheduler, 
-              regularizer=False, 
-              training_loss=train_loss,
-              eval_losses=eval_losses)
+trainer.train(
+    train_loader,
+    test_loaders,
+    output_encoder,
+    model,
+    optimizer,
+    scheduler,
+    regularizer=False,
+    training_loss=train_loss,
+    eval_losses=eval_losses,
+)
 
 if config.wandb.log and is_logger:
     wandb.finish()

--- a/scripts/train_darcy.py
+++ b/scripts/train_darcy.py
@@ -103,7 +103,7 @@ elif config.opt.scheduler == 'StepLR':
                                                 step_size=config.opt.step_size,
                                                 gamma=config.opt.gamma)
 else:
-    raise ValueError(f'Got {config.opt.scheduler=}')
+    raise ValueError(f'Got scheduler={config.opt.scheduler}')
 
 
 # Creating the losses

--- a/scripts/train_navier_stokes.py
+++ b/scripts/train_navier_stokes.py
@@ -98,7 +98,7 @@ elif config.opt.scheduler == 'StepLR':
                                                 step_size=config.opt.step_size,
                                                 gamma=config.opt.gamma)
 else:
-    raise ValueError(f'Got {config.opt.scheduler=}')
+    raise ValueError(f'Got scheduler={config.opt.scheduler}')
 
 
 # Creating the losses

--- a/scripts/train_navier_stokes.py
+++ b/scripts/train_navier_stokes.py
@@ -1,41 +1,60 @@
-import torch
-import wandb
 import sys
-from configmypy import ConfigPipeline, YamlConfig, ArgparseConfig
-from neuralop import get_model
-from neuralop import Trainer
-from neuralop.training import setup
-from neuralop.datasets.navier_stokes import load_navier_stokes_pt
-from neuralop.utils import get_wandb_api_key, count_params
-from neuralop import LpLoss, H1Loss
 
+from configmypy import ConfigPipeline, YamlConfig, ArgparseConfig
+import torch
 from torch.nn.parallel import DistributedDataParallel as DDP
+import wandb
+
+from neuralop import H1Loss, LpLoss, Trainer, get_model
+from neuralop.datasets.navier_stokes import load_navier_stokes_pt
+from neuralop.training import setup
+from neuralop.utils import get_wandb_api_key, count_params
 
 
 # Read the configuration
-config_name = 'default'
-pipe = ConfigPipeline([YamlConfig('./default_config.yaml', config_name='default', config_folder='../config'),
-                       ArgparseConfig(infer_types=True, config_name=None, config_file=None),
-                       YamlConfig(config_folder='../config')
-                      ])
+config_name = "default"
+pipe = ConfigPipeline(
+    [
+        YamlConfig(
+            "./default_config.yaml", config_name="default", config_folder="../config"
+        ),
+        ArgparseConfig(infer_types=True, config_name=None, config_file=None),
+        YamlConfig(config_folder="../config"),
+    ]
+)
 config = pipe.read_conf()
 config_name = pipe.steps[-1].config_name
 
-#Set-up distributed communication, if using
+# Set-up distributed communication, if using
 device, is_logger = setup(config)
 
-#Set up WandB logging
+# Set up WandB logging
 if config.wandb.log and is_logger:
     wandb.login(key=get_wandb_api_key())
     if config.wandb.name:
         wandb_name = config.wandb.name
     else:
-        wandb_name = '_'.join(
-            f'{var}' for var in [config_name, config.fno2d.n_layers, config.fno2d.n_modes_width, config.fno2d.n_modes_height,
-                                 config.fno2d.hidden_channels, config.fno2d.factorization, config.fno2d.rank, 
-                                 config.patching.levels, config.patching.padding])
-    wandb.init(config=config, name=wandb_name, group=config.wandb.group,
-               project=config.wandb.project, entity=config.wandb.entity)
+        wandb_name = "_".join(
+            f"{var}"
+            for var in [
+                config_name,
+                config.fno2d.n_layers,
+                config.fno2d.n_modes_width,
+                config.fno2d.n_modes_height,
+                config.fno2d.hidden_channels,
+                config.fno2d.factorization,
+                config.fno2d.rank,
+                config.patching.levels,
+                config.patching.padding,
+            ]
+        )
+    wandb.init(
+        config=config,
+        name=wandb_name,
+        group=config.wandb.group,
+        project=config.wandb.project,
+        entity=config.wandb.entity,
+    )
     if config.wandb.sweep:
         for key in wandb.config.keys():
             config.params[key] = wandb.config[key]
@@ -43,106 +62,131 @@ if config.wandb.log and is_logger:
 # Make sure we only print information when needed
 config.verbose = config.verbose and is_logger
 
-#Print config to screen
+# Print config to screen
 if config.verbose:
     pipe.log()
     sys.stdout.flush()
 
 # Loading the Navier-Stokes dataset in 128x128 resolution
 train_loader, test_loaders, output_encoder = load_navier_stokes_pt(
-        config.data.folder, train_resolution=config.data.train_resolution, n_train=config.data.n_train, batch_size=config.data.batch_size, 
-        positional_encoding=config.data.positional_encoding,
-        test_resolutions=config.data.test_resolutions, n_tests=config.data.n_tests, test_batch_sizes=config.data.test_batch_sizes,
-        encode_input=config.data.encode_input, encode_output=config.data.encode_output,
-        num_workers=config.data.num_workers, pin_memory=config.data.pin_memory, persistent_workers=config.data.persistent_workers
-        )
+    config.data.folder,
+    train_resolution=config.data.train_resolution,
+    n_train=config.data.n_train,
+    batch_size=config.data.batch_size,
+    positional_encoding=config.data.positional_encoding,
+    test_resolutions=config.data.test_resolutions,
+    n_tests=config.data.n_tests,
+    test_batch_sizes=config.data.test_batch_sizes,
+    encode_input=config.data.encode_input,
+    encode_output=config.data.encode_output,
+    num_workers=config.data.num_workers,
+    pin_memory=config.data.pin_memory,
+    persistent_workers=config.data.persistent_workers,
+)
 
 model = get_model(config)
 model = model.to(device)
 
-#Use distributed data parallel 
+# Use distributed data parallel
 if config.distributed.use_distributed:
-    model = DDP(model,
-                device_ids=[device.index],
-                output_device=device.index,
-                static_graph=True)
+    model = DDP(
+        model, device_ids=[device.index], output_device=device.index, static_graph=True
+    )
 
-#Log parameter count
+# Log parameter count
 if is_logger:
     n_params = count_params(model)
 
     if config.verbose:
-        print(f'\nn_params: {n_params}')
+        print(f"\nn_params: {n_params}")
         sys.stdout.flush()
 
     if config.wandb.log:
-        to_log = {'n_params': n_params}
+        to_log = {"n_params": n_params}
         if config.n_params_baseline is not None:
-            to_log['n_params_baseline'] = config.n_params_baseline,
-            to_log['compression_ratio'] = config.n_params_baseline/n_params,
-            to_log['space_savings'] = 1 - (n_params/config.n_params_baseline)
+            to_log["n_params_baseline"] = (config.n_params_baseline,)
+            to_log["compression_ratio"] = (config.n_params_baseline / n_params,)
+            to_log["space_savings"] = 1 - (n_params / config.n_params_baseline)
         wandb.log(to_log)
         wandb.watch(model)
 
-#Create the optimizer
-optimizer = torch.optim.Adam(model.parameters(), 
-                                lr=config.opt.learning_rate, 
-                                weight_decay=config.opt.weight_decay)
+# Create the optimizer
+optimizer = torch.optim.Adam(
+    model.parameters(),
+    lr=config.opt.learning_rate,
+    weight_decay=config.opt.weight_decay,
+)
 
-if config.opt.scheduler == 'ReduceLROnPlateau':
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, factor=config.opt.gamma, patience=config.opt.scheduler_patience, mode='min')
-elif config.opt.scheduler == 'CosineAnnealingLR':
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=config.opt.scheduler_T_max)
-elif config.opt.scheduler == 'StepLR':
-    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, 
-                                                step_size=config.opt.step_size,
-                                                gamma=config.opt.gamma)
+if config.opt.scheduler == "ReduceLROnPlateau":
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer,
+        factor=config.opt.gamma,
+        patience=config.opt.scheduler_patience,
+        mode="min",
+    )
+elif config.opt.scheduler == "CosineAnnealingLR":
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        optimizer, T_max=config.opt.scheduler_T_max
+    )
+elif config.opt.scheduler == "StepLR":
+    scheduler = torch.optim.lr_scheduler.StepLR(
+        optimizer, step_size=config.opt.step_size, gamma=config.opt.gamma
+    )
 else:
-    raise ValueError(f'Got scheduler={config.opt.scheduler}')
+    raise ValueError(f"Got scheduler={config.opt.scheduler}")
 
 
 # Creating the losses
 l2loss = LpLoss(d=2, p=2)
 h1loss = H1Loss(d=2)
-if config.opt.training_loss == 'l2':
+if config.opt.training_loss == "l2":
     train_loss = l2loss
-elif config.opt.training_loss == 'h1':
+elif config.opt.training_loss == "h1":
     train_loss = h1loss
 else:
-    raise ValueError(f'Got training_loss={config.opt.training_loss} but expected one of ["l2", "h1"]')
-eval_losses={'h1': h1loss, 'l2': l2loss}
+    raise ValueError(
+        f'Got training_loss={config.opt.training_loss} '
+        f'but expected one of ["l2", "h1"]'
+    )
+eval_losses = {"h1": h1loss, "l2": l2loss}
 
 if config.verbose:
-    print('\n### MODEL ###\n', model)
-    print('\n### OPTIMIZER ###\n', optimizer)
-    print('\n### SCHEDULER ###\n', scheduler)
-    print('\n### LOSSES ###')
-    print(f'\n * Train: {train_loss}')
-    print(f'\n * Test: {eval_losses}')
-    print(f'\n### Beginning Training...\n')
+    print("\n### MODEL ###\n", model)
+    print("\n### OPTIMIZER ###\n", optimizer)
+    print("\n### SCHEDULER ###\n", scheduler)
+    print("\n### LOSSES ###")
+    print(f"\n * Train: {train_loss}")
+    print(f"\n * Test: {eval_losses}")
+    print(f"\n### Beginning Training...\n")
     sys.stdout.flush()
 
-trainer = Trainer(model, n_epochs=config.opt.n_epochs,
-                  device=device,
-                  amp_autocast=config.opt.amp_autocast,
-                  mg_patching_levels=config.patching.levels,
-                  mg_patching_padding=config.patching.padding,
-                  mg_patching_stitching=config.patching.stitching,
-                  wandb_log=config.wandb.log,
-                  log_test_interval=config.wandb.log_test_interval,
-                  log_output=config.wandb.log_output,
-                  use_distributed=config.distributed.use_distributed,
-                  verbose=config.verbose)
+trainer = Trainer(
+    model,
+    n_epochs=config.opt.n_epochs,
+    device=device,
+    amp_autocast=config.opt.amp_autocast,
+    mg_patching_levels=config.patching.levels,
+    mg_patching_padding=config.patching.padding,
+    mg_patching_stitching=config.patching.stitching,
+    wandb_log=config.wandb.log,
+    log_test_interval=config.wandb.log_test_interval,
+    log_output=config.wandb.log_output,
+    use_distributed=config.distributed.use_distributed,
+    verbose=config.verbose,
+)
 
 
-trainer.train(train_loader, test_loaders,
-              output_encoder,
-              model, 
-              optimizer,
-              scheduler, 
-              regularizer=False, 
-              training_loss=train_loss,
-              eval_losses=eval_losses)
+trainer.train(
+    train_loader,
+    test_loaders,
+    output_encoder,
+    model,
+    optimizer,
+    scheduler,
+    regularizer=False,
+    training_loss=train_loss,
+    eval_losses=eval_losses,
+)
 
 if config.wandb.log and is_logger:
     wandb.finish()


### PR DESCRIPTION
There are several instances of `f"{x=}"` in the repo, which causes issues when trying to import the library in to Python 3.6. Drop the `=` in these f-string to fix this problem.

Additionally, the repeated docstrings between base class `FNO` and subclasses `FNOnd` make maintaining documentation more work than it needs to be. The parameters are used identically in the base- and sub-class, and in some cases the subclass documentation is already out of date. Delete the repeated parameter comments in favor of referring users back up to the full documentation of `FNO` (tested in a local `make` of `sphinx-gallery`).

Lastly, run `black` on touched files.

Reviewer(s): @zongyi-li @JeanKossaifi