### PR TITLE
Split `preactivation` from `FNOBlock.forward()`

### DIFF
--- a/neuralop/layers/fno_block.py
+++ b/neuralop/layers/fno_block.py
@@ -7,7 +7,7 @@ from .normalization_layers import AdaIN
 from .resample import resample
 from .skip_connections import skip_connection
 from .spectral_convolution import SpectralConv
-from ..utils import validate_output_scaling_factor_2d
+from ..utils import validate_output_scaling_factor
 
 
 class FNOBlocks(nn.Module):
@@ -47,7 +47,7 @@ class FNOBlocks(nn.Module):
         self.n_modes = n_modes
         self.n_dim = len(n_modes)
 
-        self.output_scaling_factor = validate_output_scaling_factor_2d(
+        self.output_scaling_factor = validate_output_scaling_factor(
             output_scaling_factor, self.n_dim, n_layers
         )
 

--- a/neuralop/layers/fno_block.py
+++ b/neuralop/layers/fno_block.py
@@ -261,11 +261,15 @@ class FNOBlocks(nn.Module):
 
         return x
 
-    def resample(self, x, index, output_shape):
+    def resample(self, x, index, output_shape=None):
         """Resamples input if scaling factors are available for this block."""
-        if self.output_scaling_factor is None:
+        if self.output_scaling_factor is None and output_shape is None:
             return x
 
+        if output_shape is not None:
+            return resample(x, res_scale=1, axis=None, output_shape=output_shape)
+
+        # output_shape is None and self.output_scaling_factor is not None
         scaling_factor = self.output_scaling_factor[index]
         return resample(
             x,

--- a/neuralop/layers/fno_block.py
+++ b/neuralop/layers/fno_block.py
@@ -170,9 +170,6 @@ class FNOBlocks(nn.Module):
                 "[instance_norm, group_norm, layer_norm]"
             )
 
-        if self.preactivation:
-            self.forward = self.forward_with_preactivation
-
     def set_ada_in_embeddings(self, *embeddings):
         """Sets the embeddings of each Ada-IN norm layers
 
@@ -190,6 +187,12 @@ class FNOBlocks(nn.Module):
                 norm.set_embedding(embedding)
 
     def forward(self, x, index=0, output_shape=None):
+        if self.preactivation:
+            return self.forward_with_preactivation(x, index, output_shape)
+        else:
+            return self.forward_with_postactivation(x, index, output_shape)
+
+    def forward_with_postactivation(self, x, index=0, output_shape=None):
         x_skip_fno = self.fno_skips[index](x)
         x_skip_fno = self.resample(x_skip_fno, index, output_shape)
 

--- a/neuralop/layers/mlp.py
+++ b/neuralop/layers/mlp.py
@@ -91,7 +91,7 @@ class MLPLinear(torch.nn.Module):
     def forward(self, x):
         for i, fc in enumerate(self.fcs):
             x = fc(x)
-            if i < self.n_layers:
+            if i < self.n_layers - 1:
                 x = self.non_linearity(x)
             if self.dropout is not None:
                 x = self.dropout(x)

--- a/neuralop/layers/padding.py
+++ b/neuralop/layers/padding.py
@@ -1,7 +1,7 @@
 from torch import nn
 from torch.nn import functional as F
 
-from neuralop.utils import validate_output_scaling_factor_1d
+from neuralop.utils import validate_output_scaling_factor
 
 
 class DomainPadding(nn.Module):
@@ -56,8 +56,8 @@ class DomainPadding(nn.Module):
             "(excluding batch, ch)"
         )
 
-        # if unset by the user, scaling will be 1 be default:
-        output_scaling_factor = validate_output_scaling_factor_1d(
+        # if unset by the user, scaling_factor will be 1 be default:
+        output_scaling_factor = validate_output_scaling_factor(
             self.output_scaling_factor, resolution
         )
 

--- a/neuralop/layers/padding.py
+++ b/neuralop/layers/padding.py
@@ -1,7 +1,9 @@
+from typing import List
+
 from torch import nn
 from torch.nn import functional as F
 
-from neuralop.utils import validate_output_scaling_factor
+from neuralop.utils import validate_scaling_factor
 
 
 class DomainPadding(nn.Module):
@@ -23,12 +25,15 @@ class DomainPadding(nn.Module):
     """
 
     def __init__(
-        self, domain_padding, padding_mode="one-sided", output_scaling_factor=1
+        self,
+        domain_padding,
+        padding_mode="one-sided",
+        output_scaling_factor: float = 1.0,
     ):
         super().__init__()
         self.domain_padding = domain_padding
         self.padding_mode = padding_mode.lower()
-        self.output_scaling_factor = output_scaling_factor
+        self.output_scaling_factor: float = output_scaling_factor
 
         # dict(f'{resolution}'=padding) such that padded = F.pad(x, indices)
         self._padding = dict()
@@ -56,10 +61,11 @@ class DomainPadding(nn.Module):
             "(excluding batch, ch)"
         )
 
-        # if unset by the user, scaling_factor will be 1 be default:
-        output_scaling_factor = validate_output_scaling_factor(
-            self.output_scaling_factor, len(resolution)
-        )[0]
+        # if unset by the user, scaling_factor will be 1 be default,
+        # so `output_scaling_factor` should never be None.
+        output_scaling_factor: List[float] = validate_scaling_factor(
+            self.output_scaling_factor, len(resolution), n_layers=-1
+        )
 
         try:
             padding = self._padding[f"{resolution}"]

--- a/neuralop/layers/padding.py
+++ b/neuralop/layers/padding.py
@@ -58,8 +58,8 @@ class DomainPadding(nn.Module):
 
         # if unset by the user, scaling_factor will be 1 be default:
         output_scaling_factor = validate_output_scaling_factor(
-            self.output_scaling_factor, resolution
-        )
+            self.output_scaling_factor, len(resolution)
+        )[0]
 
         try:
             padding = self._padding[f"{resolution}"]

--- a/neuralop/layers/padding.py
+++ b/neuralop/layers/padding.py
@@ -66,7 +66,7 @@ class DomainPadding(nn.Module):
             # if unset by the user, scaling_factor will be 1 be default,
             # so `output_scaling_factor` should never be None.
             output_scaling_factor: List[float] = validate_scaling_factor(
-                self.output_scaling_factor, len(resolution), n_layers=-1
+                self.output_scaling_factor, len(resolution), n_layers=None
             )
 
         try:

--- a/neuralop/layers/padding.py
+++ b/neuralop/layers/padding.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 from torch import nn
 from torch.nn import functional as F
@@ -28,12 +28,12 @@ class DomainPadding(nn.Module):
         self,
         domain_padding,
         padding_mode="one-sided",
-        output_scaling_factor: float = 1.0,
+        output_scaling_factor: Union[int, List[int]] = 1,
     ):
         super().__init__()
         self.domain_padding = domain_padding
         self.padding_mode = padding_mode.lower()
-        self.output_scaling_factor: float = output_scaling_factor
+        self.output_scaling_factor: Union[int, List[int]] = output_scaling_factor
 
         # dict(f'{resolution}'=padding) such that padded = F.pad(x, indices)
         self._padding = dict()
@@ -61,11 +61,13 @@ class DomainPadding(nn.Module):
             "(excluding batch, ch)"
         )
 
-        # if unset by the user, scaling_factor will be 1 be default,
-        # so `output_scaling_factor` should never be None.
-        output_scaling_factor: List[float] = validate_scaling_factor(
-            self.output_scaling_factor, len(resolution), n_layers=-1
-        )
+        output_scaling_factor = self.output_scaling_factor
+        if not isinstance(self.output_scaling_factor, list):
+            # if unset by the user, scaling_factor will be 1 be default,
+            # so `output_scaling_factor` should never be None.
+            output_scaling_factor: List[float] = validate_scaling_factor(
+                self.output_scaling_factor, len(resolution), n_layers=-1
+            )
 
         try:
             padding = self._padding[f"{resolution}"]

--- a/neuralop/layers/resample.py
+++ b/neuralop/layers/resample.py
@@ -15,7 +15,8 @@ def resample(x, res_scale, axis, output_shape=None):
     res_scale: int or tuple
             Scaling factor along each of the dimensions in 'axis' parameter. If res_scale is scaler, then isotropic 
             scaling is performed
-    axis: axis or dimensions along which interpolation will be performed. 
+    axis: axis or dimensions along which interpolation will be performed.
+    output_shape : None or tuple[int]
     """
 
     if isinstance(res_scale, (float, int)):

--- a/neuralop/layers/spectral_convolution.py
+++ b/neuralop/layers/spectral_convolution.py
@@ -1,7 +1,7 @@
 import itertools
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
-from ..utils import validate_output_scaling_factor
+from ..utils import validate_scaling_factor
 
 try:
     from typing import Literal
@@ -184,6 +184,9 @@ def get_contract_fun(weight, implementation="reconstructed", separable=False):
         )
 
 
+Number = Union[int, float]
+
+
 class SpectralConv(nn.Module):
     """Generic N-Dimensional Fourier Neural Operator
 
@@ -245,7 +248,7 @@ class SpectralConv(nn.Module):
         bias=True,
         n_layers=1,
         separable=False,
-        output_scaling_factor=None,
+        output_scaling_factor: Optional[Union[Number, List[Number]]] = None,
         fno_block_precision="full",
         rank=0.5,
         factorization=None,
@@ -287,9 +290,9 @@ class SpectralConv(nn.Module):
         self.n_layers = n_layers
         self.implementation = implementation
 
-        self.output_scaling_factor = validate_output_scaling_factor(
-            output_scaling_factor, self.order, n_layers
-        )
+        self.output_scaling_factor: Union[
+            None, List[List[float]]
+        ] = validate_scaling_factor(output_scaling_factor, self.order, n_layers)
 
         if init_std == "auto":
             init_std = 1 / (in_channels * out_channels)

--- a/neuralop/layers/spectral_convolution.py
+++ b/neuralop/layers/spectral_convolution.py
@@ -1,7 +1,7 @@
 import itertools
 from typing import Optional, Tuple
 
-from ..utils import validate_output_scaling_factor_2d
+from ..utils import validate_output_scaling_factor
 
 try:
     from typing import Literal
@@ -287,7 +287,7 @@ class SpectralConv(nn.Module):
         self.n_layers = n_layers
         self.implementation = implementation
 
-        self.output_scaling_factor = validate_output_scaling_factor_2d(
+        self.output_scaling_factor = validate_output_scaling_factor(
             output_scaling_factor, self.order, n_layers
         )
 

--- a/neuralop/layers/spectral_convolution.py
+++ b/neuralop/layers/spectral_convolution.py
@@ -1,6 +1,8 @@
 import itertools
 from typing import Optional, Tuple
 
+from ..utils import validate_output_scaling_factor_2d
+
 try:
     from typing import Literal
 except ImportError:
@@ -285,21 +287,14 @@ class SpectralConv(nn.Module):
         self.n_layers = n_layers
         self.implementation = implementation
 
-        if output_scaling_factor is not None:
-            if isinstance(output_scaling_factor, (float, int)):
-                output_scaling_factor = [
-                    [float(output_scaling_factor)] * len(self.n_modes)
-                ] * n_layers
-            elif isinstance(output_scaling_factor[0], (float, int)):
-                output_scaling_factor = [
-                    [s] * len(self.n_modes) for s in output_scaling_factor
-                ]
-        self.output_scaling_factor = output_scaling_factor
+        self.output_scaling_factor = validate_output_scaling_factor_2d(
+            output_scaling_factor, self.order, n_layers
+        )
 
         if init_std == "auto":
             init_std = 1 / (in_channels * out_channels)
         else:
-            init_std = 0.02
+            init_std = init_std
 
         if isinstance(fixed_rank_modes, bool):
             if fixed_rank_modes:

--- a/neuralop/layers/spherical_convolution.py
+++ b/neuralop/layers/spherical_convolution.py
@@ -1,3 +1,5 @@
+from typing import List, Optional, Union
+
 import torch
 from torch import nn
 from torch_harmonics import RealSHT, InverseRealSHT
@@ -6,7 +8,7 @@ import tensorly as tl
 from tensorly.plugins import use_opt_einsum
 from tltorch.factorized_tensors.core import FactorizedTensor
 
-from neuralop.utils import validate_output_scaling_factor
+from neuralop.utils import validate_scaling_factor
 
 tl.set_backend("pytorch")
 use_opt_einsum("optimal")
@@ -197,6 +199,9 @@ def get_contract_fun(weight, implementation="reconstructed", separable=False):
         )
 
 
+Number = Union[int, float]
+
+
 class SphericalConv(nn.Module):
     def __init__(
         self,
@@ -207,7 +212,7 @@ class SphericalConv(nn.Module):
         bias=True,
         n_layers=1,
         separable=False,
-        output_scaling_factor=None,
+        output_scaling_factor: Optional[Union[Number, List[Number]]] = None,
         fno_block_precision="full",
         rank=0.5,
         factorization="cp",
@@ -249,14 +254,9 @@ class SphericalConv(nn.Module):
         self.n_layers = n_layers
         self.implementation = implementation
 
-        if output_scaling_factor is not None:
-            if isinstance(output_scaling_factor, (float, int)):
-                output_scaling_factor = [float(output_scaling_factor)] * len(
-                    self.n_modes
-                )
-        self.output_scaling_factor = validate_output_scaling_factor(
-            output_scaling_factor, self.order
-        )
+        self.output_scaling_factor: Union[
+            None, List[List[float]]
+        ] = validate_scaling_factor(output_scaling_factor, self.order, n_layers)
 
         if init_std == "auto":
             init_std = 1 / (in_channels * out_channels)
@@ -423,8 +423,9 @@ class SphericalConv(nn.Module):
         batchsize, channels, height, width = x.shape
 
         if self.output_scaling_factor is not None and output_shape is None:
-            height = round(height * self.output_scaling_factor[0])
-            width = round(width * self.output_scaling_factor[1])
+            scaling_factors = self.output_scaling_factor[indices]
+            height = round(height * scaling_factors[0])
+            width = round(width * scaling_factors[1])
         elif output_shape is not None:
             height, width = output_shape[0], output_shape[1]
 

--- a/neuralop/layers/spherical_convolution.py
+++ b/neuralop/layers/spherical_convolution.py
@@ -6,7 +6,7 @@ import tensorly as tl
 from tensorly.plugins import use_opt_einsum
 from tltorch.factorized_tensors.core import FactorizedTensor
 
-from neuralop.utils import validate_output_scaling_factor_1d
+from neuralop.utils import validate_output_scaling_factor
 
 tl.set_backend("pytorch")
 use_opt_einsum("optimal")
@@ -254,7 +254,7 @@ class SphericalConv(nn.Module):
                 output_scaling_factor = [float(output_scaling_factor)] * len(
                     self.n_modes
                 )
-        self.output_scaling_factor = validate_output_scaling_factor_1d(
+        self.output_scaling_factor = validate_output_scaling_factor(
             output_scaling_factor, self.order
         )
 

--- a/neuralop/models/tests/test_fno.py
+++ b/neuralop/models/tests/test_fno.py
@@ -1,23 +1,36 @@
-
-import torch
-from neuralop import TFNO3d, TFNO2d, TFNO1d, TFNO
-from neuralop.models import FNO
-import pytest
-from tensorly import tenalg
 from math import prod
+
+import pytest
+import torch
+from tensorly import tenalg
 from configmypy import Bunch
-tenalg.set_backend('einsum')
+
+from neuralop import TFNO
+from neuralop.models import FNO
+
+tenalg.set_backend("einsum")
 
 
-@pytest.mark.parametrize('factorization', ['ComplexDense', 'ComplexTucker', 'ComplexCP', 'ComplexTT'])
-@pytest.mark.parametrize('implementation', ['factorized', 'reconstructed'])
-@pytest.mark.parametrize('n_dim', [1, 2, 3])
-@pytest.mark.parametrize('fno_block_precision', ['full', 'half', 'mixed'])
-@pytest.mark.parametrize('stabilizer', [None, 'tanh'])
-@pytest.mark.parameterized('lifting_channels', [None, 256])
-def test_tfno(factorization, implementation, n_dim, fno_block_precision, stabilizer):
+@pytest.mark.parametrize(
+    "factorization", ["ComplexDense", "ComplexTucker", "ComplexCP", "ComplexTT"]
+)
+@pytest.mark.parametrize("implementation", ["factorized", "reconstructed"])
+@pytest.mark.parametrize("n_dim", [1, 2, 3])
+@pytest.mark.parametrize("fno_block_precision", ["full", "half", "mixed"])
+@pytest.mark.parametrize("stabilizer", [None, "tanh"])
+@pytest.mark.parametrize("lifting_channels", [None, 256])
+@pytest.mark.parametrize("preactivation", [False, True])
+def test_tfno(
+    factorization,
+    implementation,
+    n_dim,
+    fno_block_precision,
+    stabilizer,
+    lifting_channels,
+    preactivation,
+):
     if torch.has_cuda:
-        device = 'cuda'
+        device = "cuda"
         s = 128
         modes = 16
         width = 64
@@ -27,8 +40,8 @@ def test_tfno(factorization, implementation, n_dim, fno_block_precision, stabili
         n_layers = 4
         mlp = Bunch(dict(expansion=0.5, dropout=0))
     else:
-        device = 'cpu'
-        fno_block_precision = 'full'
+        device = "cpu"
+        fno_block_precision = "full"
         s = 16
         modes = 5
         width = 15
@@ -40,19 +53,25 @@ def test_tfno(factorization, implementation, n_dim, fno_block_precision, stabili
         mlp = Bunch(dict(expansion=0.5, dropout=0))
 
     rank = 0.2
-    size = (s, )*n_dim
-    n_modes = (modes,)*n_dim
-    model = TFNO(hidden_channels=width, n_modes=n_modes,
-                 factorization=factorization,
-                 implementation=implementation,
-                 rank=rank,
-                 fixed_rank_modes=False,
-                 joint_factorization=False,
-                 n_layers=n_layers,
-                 fno_block_precision=fno_block_precision,
-                 use_mlp=use_mlp, mlp=mlp,
-                 stabilizer=stabilizer,
-                 fc_channels=fc_channels).to(device)
+    size = (s,) * n_dim
+    n_modes = (modes,) * n_dim
+    model = TFNO(
+        hidden_channels=width,
+        n_modes=n_modes,
+        factorization=factorization,
+        implementation=implementation,
+        rank=rank,
+        fixed_rank_modes=False,
+        joint_factorization=False,
+        n_layers=n_layers,
+        fno_block_precision=fno_block_precision,
+        use_mlp=use_mlp,
+        mlp=mlp,
+        stabilizer=stabilizer,
+        fc_channels=fc_channels,
+        lifting_channels=lifting_channels,
+        preactivation=preactivation,
+    ).to(device)
     in_data = torch.randn(batch_size, 3, *size).to(device)
 
     # Test forward pass
@@ -69,12 +88,21 @@ def test_tfno(factorization, implementation, n_dim, fno_block_precision, stabili
     for param in model.parameters():
         if param.grad is None:
             n_unused_params += 1
-    assert n_unused_params == 0, f'{n_unused_params} parameters were unused!'
+    assert n_unused_params == 0, f"{n_unused_params} parameters were unused!"
 
-@pytest.mark.parametrize('output_scaling_factor', 
-                         [[2, 1, 1], [1, 2, 1], [1, 1, 2], [1, 2, 2], [1, 0.5, 1]])
+
+@pytest.mark.parametrize(
+    "output_scaling_factor",
+    [
+        [2, 1, 1],
+        [1, 2, 1],
+        [1, 1, 2],
+        [1, 2, 2],
+        [1, 0.5, 1],
+    ],
+)
 def test_fno_superresolution(output_scaling_factor):
-    device = 'cpu'
+    device = "cpu"
     s = 16
     modes = 5
     hidden_channels = 15
@@ -84,19 +112,22 @@ def test_fno_superresolution(output_scaling_factor):
     use_mlp = True
     n_dim = 2
     rank = 0.2
-    size = (s, )*n_dim
-    n_modes = (modes,)*n_dim
+    size = (s,) * n_dim
+    n_modes = (modes,) * n_dim
 
-    model = FNO(n_modes, hidden_channels,
-                in_channels=3, 
-                out_channels=1,
-                factorization='cp',
-                implementation='reconstructed',
-                rank=rank,
-                output_scaling_factor=output_scaling_factor,
-                n_layers=n_layers,
-                use_mlp=use_mlp,
-                fc_channels=fc_channels).to(device)
+    model = FNO(
+        n_modes,
+        hidden_channels,
+        in_channels=3,
+        out_channels=1,
+        factorization="cp",
+        implementation="reconstructed",
+        rank=rank,
+        output_scaling_factor=output_scaling_factor,
+        n_layers=n_layers,
+        use_mlp=use_mlp,
+        fc_channels=fc_channels,
+    ).to(device)
 
     in_data = torch.randn(batch_size, 3, *size).to(device)
     # Test forward pass
@@ -104,5 +135,5 @@ def test_fno_superresolution(output_scaling_factor):
 
     # Check output size
     factor = prod(output_scaling_factor)
-    
-    assert list(out.shape) == [batch_size, 1] + [int(round(factor*s)) for s in size]
+
+    assert list(out.shape) == [batch_size, 1] + [int(round(factor * s)) for s in size]

--- a/neuralop/models/tests/test_uno.py
+++ b/neuralop/models/tests/test_uno.py
@@ -3,50 +3,71 @@ from ..uno import UNO
 import torch
 import pytest
 
-@pytest.mark.parametrize('input_shape', 
-                         [(32,3,64,55),(32,3,100,105),(32,3,133,95)])
+
+@pytest.mark.parametrize(
+    "input_shape", [(32, 3, 64, 55), (32, 3, 100, 105), (32, 3, 133, 95)]
+)
 def test_UNO(input_shape):
-    horizontal_skips_map ={4:0,3:1}
-    model = UNO(3,3,5,uno_out_channels = [32,64,64,64,32], uno_n_modes= [[5,5],[5,5],[5,5],[5,5],[5,5]], uno_scalings=  [[1.0,1.0],[0.5,0.5],[1,1],[1,1],[2,2]],\
-                 horizontal_skips_map = horizontal_skips_map, n_layers = 5, domain_padding = 0.2, output_scaling_factor = 1)
+    horizontal_skips_map = {4: 0, 3: 1}
+    model = UNO(
+        3,  # in_channels
+        3,  # out_channels
+        5,  # hidden_channels
+        uno_out_channels=[32, 64, 64, 64, 32],
+        uno_n_modes=[[5, 5], [5, 5], [5, 5], [5, 5], [5, 5]],
+        uno_scalings=[[1.0, 1.0], [0.5, 0.5], [1, 1], [1, 1], [2, 2]],
+        horizontal_skips_map=horizontal_skips_map,
+        n_layers=5,
+        domain_padding=0.2,
+        output_scaling_factor=1,
+    )
 
     t1 = time.time()
     in_data = torch.randn(input_shape)
     out = model(in_data)
     t = time.time() - t1
-    print(f'Output of size {out.shape} in {t}.')
+    print(f"Output of size {out.shape} in {t}.")
     for i in range(len(out.shape)):
         assert in_data.shape[i] == out.shape[i]
     loss = out.sum()
     t1 = time.time()
     loss.backward()
     t = time.time() - t1
-    print(f'Gradient Calculated in {t}.')
+    print(f"Gradient Calculated in {t}.")
     n_unused_params = 0
 
-    for name,param in model.named_parameters():
+    for name, param in model.named_parameters():
         if param.grad is None:
             n_unused_params += 1
 
-
-    model = UNO(3,3,5,uno_out_channels = [32,64,64,64,32], uno_n_modes= [[5,5],[5,5],[5,5],[5,5],[5,5]], uno_scalings=  [[1.0,1.0],[0.5,0.5],[1,1],[1,1],[2,2]],\
-            horizontal_skips_map = None, n_layers = 5, domain_padding = 0.2, output_scaling_factor = 1)
+    model = UNO(
+        3,
+        3,
+        5,
+        uno_out_channels=[32, 64, 64, 64, 32],
+        uno_n_modes=[[5, 5], [5, 5], [5, 5], [5, 5], [5, 5]],
+        uno_scalings=[[1.0, 1.0], [0.5, 0.5], [1, 1], [1, 1], [2, 2]],
+        horizontal_skips_map=None,
+        n_layers=5,
+        domain_padding=0.2,
+        output_scaling_factor=1,
+    )
 
     t1 = time.time()
     in_data = torch.randn(input_shape)
     out = model(in_data)
     t = time.time() - t1
-    print(f'Output of size {out.shape} in {t}.')
+    print(f"Output of size {out.shape} in {t}.")
 
     loss = out.sum()
     t1 = time.time()
     loss.backward()
     t = time.time() - t1
-    print(f'Gradient Calculated in {t}.')
+    print(f"Gradient Calculated in {t}.")
     n_unused_params = 0
 
-    for name,param in model.named_parameters():
+    for name, param in model.named_parameters():
         if param.grad is None:
             n_unused_params += 1
 
-    assert n_unused_params == 0, f'{n_unused_params} parameters were unused!'
+    assert n_unused_params == 0, f"{n_unused_params} parameters were unused!"

--- a/neuralop/models/uno.py
+++ b/neuralop/models/uno.py
@@ -6,7 +6,8 @@ from ..layers.mlp import MLP
 from ..layers.spectral_convolution import SpectralConv
 from ..layers.skip_connections import skip_connection
 from ..layers.padding import DomainPadding
-from ..layers.fno_block import FNOBlocks,resample
+from ..layers.fno_block import FNOBlocks, resample
+
 
 class UNO(nn.Module):
     """U-Shaped Neural Operator
@@ -37,13 +38,13 @@ class UNO(nn.Module):
     horizontal_skips_map: Dict, optional
                     a map {...., b: a, ....} denoting horizontal skip connection from a-th layer to
                     b-th layer. If None default skip connection is applied.
-                    Example: For a 5 layer UNO architecture, the skip connections can be 
+                    Example: For a 5 layer UNO architecture, the skip connections can be
                     horizontal_skips_map ={4:0,3:1}
 
     incremental_n_modes : None or int tuple, default is None
-        * If not None, this allows to incrementally increase the number of modes in Fourier domain 
+        * If not None, this allows to incrementally increase the number of modes in Fourier domain
           during training. Has to verify n <= N for (n, m) in zip(incremental_n_modes, n_modes).
-        
+
         * If None, all the n_modes are used.
 
         This can be updated dynamically during training.
@@ -85,47 +86,59 @@ class UNO(nn.Module):
     fft_norm : str, optional
         by default 'forward'
     """
-    def __init__(self,
-                 in_channels, 
-                 out_channels,
-                 hidden_channels,
-                 lifting_channels=256,
-                 projection_channels=256,
-                 n_layers=4,
-                 uno_out_channels= None,
-                 uno_n_modes=None,
-                 uno_scalings=None,
-                 horizontal_skips_map=None,
-                 incremental_n_modes=None,
-                 use_mlp=False, mlp_dropout=0, mlp_expansion=0.5,
-                 non_linearity=F.gelu,
-                 norm=None, preactivation=False,
-                 fno_skip='linear',
-                 horizontal_skip='linear',
-                 mlp_skip='soft-gating',
-                 separable=False,
-                 factorization=None,
-                 rank=1.0,
-                 joint_factorization=False, 
-                 fixed_rank_modes=False,
-                 integral_operator=SpectralConv,
-                 operator_block=FNOBlocks,
-                 implementation='factorized',
-                 decomposition_kwargs=dict(),
-                 domain_padding=None,
-                 domain_padding_mode='one-sided',
-                 fft_norm='forward',
-                 normalizer=None,
-                 verbose=False,
-                 **kwargs):
+
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        hidden_channels,
+        lifting_channels=256,
+        projection_channels=256,
+        n_layers=4,
+        uno_out_channels=None,
+        uno_n_modes=None,
+        uno_scalings=None,
+        horizontal_skips_map=None,
+        incremental_n_modes=None,
+        use_mlp=False,
+        mlp_dropout=0,
+        mlp_expansion=0.5,
+        non_linearity=F.gelu,
+        norm=None,
+        preactivation=False,
+        fno_skip="linear",
+        horizontal_skip="linear",
+        mlp_skip="soft-gating",
+        separable=False,
+        factorization=None,
+        rank=1.0,
+        joint_factorization=False,
+        fixed_rank_modes=False,
+        integral_operator=SpectralConv,
+        operator_block=FNOBlocks,
+        implementation="factorized",
+        decomposition_kwargs=dict(),
+        domain_padding=None,
+        domain_padding_mode="one-sided",
+        fft_norm="forward",
+        normalizer=None,
+        verbose=False,
+        **kwargs
+    ):
         super().__init__()
         self.n_layers = n_layers
-        assert uno_out_channels is not None , "uno_out_channels can not be None"
-        assert uno_n_modes is not None , "uno_n_modes can not be None"
-        assert uno_scalings is not None , "uno_scalings can not be None"
-        assert len(uno_out_channels) == n_layers, "Output channels for all layers are not given"
-        assert len(uno_n_modes) == n_layers, "number of modes for all layers are not given"
-        assert len(uno_scalings) == n_layers, "Scaling factor for all layers are not given"
+        assert uno_out_channels is not None, "uno_out_channels can not be None"
+        assert uno_n_modes is not None, "uno_n_modes can not be None"
+        assert uno_scalings is not None, "uno_scalings can not be None"
+        assert (
+            len(uno_out_channels) == n_layers
+        ), "Output channels for all layers are not given"
+        assert (
+            len(uno_n_modes) == n_layers
+        ), "number of modes for all layers are not given"
+        assert (
+            len(uno_scalings) == n_layers
+        ), "Scaling factor for all layers are not given"
 
         self.n_dim = len(uno_n_modes[0])
         self.uno_out_channels = uno_out_channels
@@ -143,8 +156,8 @@ class UNO(nn.Module):
         self.factorization = factorization
         self.fixed_rank_modes = fixed_rank_modes
         self.decomposition_kwargs = decomposition_kwargs
-        self.fno_skip = fno_skip,
-        self.mlp_skip = mlp_skip,
+        self.fno_skip = (fno_skip,)
+        self.mlp_skip = (mlp_skip,)
         self.fft_norm = fft_norm
         self.implementation = implementation
         self.separable = separable
@@ -152,107 +165,141 @@ class UNO(nn.Module):
         self._incremental_n_modes = incremental_n_modes
         self.operator_block = operator_block
         self.integral_operator = integral_operator
-        
-        #constructing default skip maps
+
+        # constructing default skip maps
         if self.horizontal_skips_map is None:
             self.horizontal_skips_map = {}
-            for i in range(n_layers//2,0,):
-                self.horizontal_skips_map[n_layers - i -1] = i
-                
-        
+            for i in range(
+                n_layers // 2,
+                0,
+            ):
+                self.horizontal_skips_map[n_layers - i - 1] = i
+
         # self.uno_scalings may be a 1d list specifying uniform scaling factor at each layer
         # or a 2d list, where each row specifies scaling factors along each dimention.
-        # To get the final (end to end) scaling factors we need to multiply 
+        # To get the final (end to end) scaling factors we need to multiply
         # the scaling factors (a list) of all layer.
 
-        self.end_to_end_scaling_factor = [1]*len(self.uno_scalings[0])
+        self.end_to_end_scaling_factor = [1] * len(self.uno_scalings[0])
         # multiplying scaling factors
         for k in self.uno_scalings:
-            self.end_to_end_scaling_factor = [i*j for (i,j) in zip(self.end_to_end_scaling_factor, k)]
-        
+            self.end_to_end_scaling_factor = [
+                i * j for (i, j) in zip(self.end_to_end_scaling_factor, k)
+            ]
+
         # list with a single element is replaced by the scaler.
         if len(self.end_to_end_scaling_factor) == 1:
             self.end_to_end_scaling_factor = self.end_to_end_scaling_factor[0]
 
         if isinstance(self.end_to_end_scaling_factor, (float, int)):
-            self.end_to_end_scaling_factor = [self.end_to_end_scaling_factor]*self.n_dim
-            
+            self.end_to_end_scaling_factor = [
+                self.end_to_end_scaling_factor
+            ] * self.n_dim
+
         if verbose:
             print("calculated out factor", self.end_to_end_scaling_factor)
-            
+
         if domain_padding is not None and domain_padding > 0:
-            self.domain_padding = DomainPadding(domain_padding=domain_padding, padding_mode=domain_padding_mode\
-            , output_scaling_factor = self.end_to_end_scaling_factor)
+            self.domain_padding = DomainPadding(
+                domain_padding=domain_padding,
+                padding_mode=domain_padding_mode,
+                output_scaling_factor=self.end_to_end_scaling_factor,
+            )
         else:
             self.domain_padding = None
         self.domain_padding_mode = domain_padding_mode
 
-
-
-        
-        self.lifting = MLP(in_channels=in_channels, out_channels=self.hidden_channels, hidden_channels=self.lifting_channels, n_layers=2, n_dim=self.n_dim) 
+        self.lifting = MLP(
+            in_channels=in_channels,
+            out_channels=self.hidden_channels,
+            hidden_channels=self.lifting_channels,
+            n_layers=2,
+            n_dim=self.n_dim,
+        )
         self.fno_blocks = nn.ModuleList([])
         self.horizontal_skips = torch.nn.ModuleDict({})
         prev_out = self.hidden_channels
 
         for i in range(self.n_layers):
-
             if i in self.horizontal_skips_map.keys():
-                prev_out = prev_out + self.uno_out_channels[self.horizontal_skips_map[i]]
+                prev_out = (
+                    prev_out + self.uno_out_channels[self.horizontal_skips_map[i]]
+                )
 
-            self.fno_blocks.append(self.operator_block(
-                                            in_channels=prev_out,
-                                            out_channels= self.uno_out_channels[i], 
-                                            n_modes=self.uno_n_modes[i],
-                                            use_mlp=use_mlp, 
-                                            mlp_dropout=mlp_dropout, 
-                                            mlp_expansion=mlp_expansion,
-                                            output_scaling_factor=[self.uno_scalings[i]],
-                                            non_linearity=non_linearity,
-                                            norm=norm, preactivation=preactivation,
-                                            fno_skip=fno_skip,
-                                            mlp_skip=mlp_skip,
-                                            incremental_n_modes=incremental_n_modes,
-                                            rank=rank,
-                                            SpectralConv=self.integral_operator,
-                                            fft_norm=fft_norm,
-                                            fixed_rank_modes=fixed_rank_modes, 
-                                            implementation=implementation,
-                                            separable=separable,
-                                            factorization=factorization,
-                                            decomposition_kwargs=decomposition_kwargs,
-                                            joint_factorization=joint_factorization, normalizer=normalizer))
-            
+            self.fno_blocks.append(
+                self.operator_block(
+                    in_channels=prev_out,
+                    out_channels=self.uno_out_channels[i],
+                    n_modes=self.uno_n_modes[i],
+                    use_mlp=use_mlp,
+                    mlp_dropout=mlp_dropout,
+                    mlp_expansion=mlp_expansion,
+                    output_scaling_factor=[self.uno_scalings[i]],
+                    non_linearity=non_linearity,
+                    norm=norm,
+                    preactivation=preactivation,
+                    fno_skip=fno_skip,
+                    mlp_skip=mlp_skip,
+                    incremental_n_modes=incremental_n_modes,
+                    rank=rank,
+                    SpectralConv=self.integral_operator,
+                    fft_norm=fft_norm,
+                    fixed_rank_modes=fixed_rank_modes,
+                    implementation=implementation,
+                    separable=separable,
+                    factorization=factorization,
+                    decomposition_kwargs=decomposition_kwargs,
+                    joint_factorization=joint_factorization,
+                    normalizer=normalizer,
+                )
+            )
+
             if i in self.horizontal_skips_map.values():
-                self.horizontal_skips[str(i)]=skip_connection(self.uno_out_channels[i], \
-                                                              self.uno_out_channels[i], skip_type=horizontal_skip, n_dim=self.n_dim)
+                self.horizontal_skips[str(i)] = skip_connection(
+                    self.uno_out_channels[i],
+                    self.uno_out_channels[i],
+                    skip_type=horizontal_skip,
+                    n_dim=self.n_dim,
+                )
 
             prev_out = self.uno_out_channels[i]
 
-        self.projection = MLP(in_channels=prev_out, out_channels=out_channels, hidden_channels=self.projection_channels, n_layers=2, n_dim=self.n_dim, non_linearity=non_linearity) 
-     
+        self.projection = MLP(
+            in_channels=prev_out,
+            out_channels=out_channels,
+            hidden_channels=self.projection_channels,
+            n_layers=2,
+            n_dim=self.n_dim,
+            non_linearity=non_linearity,
+        )
+
     def forward(self, x):
         x = self.lifting(x)
 
         if self.domain_padding is not None:
             x = self.domain_padding.pad(x)
-        output_shape = [int(round(i*j)) for (i,j) in zip(x.shape[-self.n_dim:], self.end_to_end_scaling_factor)]
-        
+        output_shape = [
+            int(round(i * j))
+            for (i, j) in zip(x.shape[-self.n_dim :], self.end_to_end_scaling_factor)
+        ]
+
         skip_outputs = {}
         cur_output = None
         for layer_idx in range(self.n_layers):
-
-            if layer_idx in  self.horizontal_skips_map.keys():
+            if layer_idx in self.horizontal_skips_map.keys():
                 skip_val = skip_outputs[self.horizontal_skips_map[layer_idx]]
-                output_scaling_factors = [m/n for (m,n) in zip(x.shape,skip_val.shape)]
-                output_scaling_factors = output_scaling_factors[-1*self.n_dim:]
-                t = resample(skip_val,output_scaling_factors, list(range(-self.n_dim, 0)))
-                x = torch.cat([x,t], dim=1)
-                
-            if layer_idx == self.n_layers -1:
+                output_scaling_factors = [
+                    m / n for (m, n) in zip(x.shape, skip_val.shape)
+                ]
+                output_scaling_factors = output_scaling_factors[-1 * self.n_dim :]
+                t = resample(
+                    skip_val, output_scaling_factors, list(range(-self.n_dim, 0))
+                )
+                x = torch.cat([x, t], dim=1)
+
+            if layer_idx == self.n_layers - 1:
                 cur_output = output_shape
             x = self.fno_blocks[layer_idx](x, output_shape=cur_output)
-            
 
             if layer_idx in self.horizontal_skips_map.values():
                 skip_outputs[layer_idx] = self.horizontal_skips[str(layer_idx)](x)

--- a/neuralop/utils.py
+++ b/neuralop/utils.py
@@ -152,7 +152,8 @@ def spectrum_2d(signal, n_observations, normalize=True):
 
     # Remove symmetric components from wavenumbers
     index = -1.0 * torch.ones((n_observations, n_observations))
-    index[0 : k_max + 1, 0 : k_max + 1] = sum_k[0 : k_max + 1, 0 : k_max + 1]
+    k_max1 = k_max + 1
+    index[0:k_max1, 0:k_max1] = sum_k[0:k_max1, 0:k_max1]
 
     spectrum = torch.zeros((T, n_observations))
     for j in range(1, n_observations + 1):
@@ -165,21 +166,33 @@ def spectrum_2d(signal, n_observations, normalize=True):
 
 Number = Union[float, int]
 
-def validate_output_scaling_factor(
-    output_scaling_factor: Optional[Union[Number, List[Number]]],
-    n_dim: int,
-    n_layers: int = 1,
-) -> Optional[List[List[float]]]:
-    if output_scaling_factor is None:
-        return None
-    if isinstance(output_scaling_factor, (float, int)):
-        return [[float(output_scaling_factor)] * n_dim] * n_layers
-    if (
-        isinstance(output_scaling_factor, list)
-        and len(output_scaling_factor) > 0
-        and all([isinstance(s, (float, int)) for s in output_scaling_factor])
-    ):
-        return [[float(s)] * n_dim for s in output_scaling_factor]
 
-    # TODO raise ValueError
+def validate_scaling_factor(
+    scaling_factor: Union[None, Number, List[Number]],
+    n_dim: int,
+    n_layers: int,
+) -> Union[None, List[float], List[List[float]]]:
+    """
+    Parameters
+    ----------
+    scaling_factor : None OR float OR list[float]
+    n_dim : int
+    n_layers : int
+        If less than 1, return a single list (rather than a list of lists)
+        with `factor` repeated `dim` times.
+    """
+    if scaling_factor is None:
+        return None
+    if isinstance(scaling_factor, (float, int)):
+        if n_layers < 1:
+            return [[float(scaling_factor)] * n_dim]
+
+        return [[float(scaling_factor)] * n_dim] * n_layers
+    if (
+        isinstance(scaling_factor, list)
+        and len(scaling_factor) > 0
+        and all([isinstance(s, (float, int)) for s in scaling_factor])
+    ):
+        return [[float(s)] * n_dim for s in scaling_factor]
+
     return None

--- a/neuralop/utils.py
+++ b/neuralop/utils.py
@@ -185,7 +185,7 @@ def validate_scaling_factor(
         return None
     if isinstance(scaling_factor, (float, int)):
         if n_layers < 1:
-            return [[float(scaling_factor)] * n_dim]
+            return [float(scaling_factor)] * n_dim
 
         return [[float(scaling_factor)] * n_dim] * n_layers
     if (

--- a/neuralop/utils.py
+++ b/neuralop/utils.py
@@ -1,5 +1,8 @@
+from typing import List, Optional, Union
+
 import torch
 import wandb
+
 
 # normalization, pointwise gaussian
 class UnitGaussianNormalizer:
@@ -14,29 +17,31 @@ class UnitGaussianNormalizer:
         self.mean = torch.mean(x, reduce_dim, keepdim=True).squeeze(0)
         self.std = torch.std(x, reduce_dim, keepdim=True).squeeze(0)
         self.eps = eps
-        
+
         if verbose:
-            print(f'UnitGaussianNormalizer init on {n_samples}, reducing over {reduce_dim}, samples of shape {shape}.')
-            print(f'   Mean and std of shape {self.mean.shape}, eps={eps}')
+            print(
+                f"UnitGaussianNormalizer init on {n_samples}, reducing over {reduce_dim}, samples of shape {shape}."
+            )
+            print(f"   Mean and std of shape {self.mean.shape}, eps={eps}")
 
     def encode(self, x):
         # x = x.view(-1, *self.sample_shape)
         x -= self.mean
-        x /= (self.std + self.eps)
+        x /= self.std + self.eps
         # x = (x.view(-1, *self.sample_shape) - self.mean) / (self.std + self.eps)
         return x
 
     def decode(self, x, sample_idx=None):
         if sample_idx is None:
-            std = self.std + self.eps # n
+            std = self.std + self.eps  # n
             mean = self.mean
         else:
             if len(self.mean.shape) == len(sample_idx[0].shape):
                 std = self.std[sample_idx] + self.eps  # batch*n
                 mean = self.mean[sample_idx]
             if len(self.mean.shape) > len(sample_idx[0].shape):
-                std = self.std[:,sample_idx]+ self.eps # T*batch*n
-                mean = self.mean[:,sample_idx]
+                std = self.std[:, sample_idx] + self.eps  # T*batch*n
+                mean = self.mean[:, sample_idx]
 
         # x is in shape of batch*n or T*batch*n
         # x = (x.view(self.sample_shape) * std) + mean
@@ -55,7 +60,7 @@ class UnitGaussianNormalizer:
         self.mean = self.mean.cpu()
         self.std = self.std.cpu()
         return self
-    
+
     def to(self, device):
         self.mean = self.mean.to(device)
         self.std = self.std.to(device)
@@ -64,78 +69,128 @@ class UnitGaussianNormalizer:
 
 def count_params(model):
     """Returns the number of parameters of a PyTorch model"""
-    return sum([p.numel()*2 if p.is_complex() else p.numel() for p in model.parameters()])
+    return sum(
+        [p.numel() * 2 if p.is_complex() else p.numel() for p in model.parameters()]
+    )
 
 
-def wandb_login(api_key_file='../config/wandb_api_key.txt', key=None):
+def wandb_login(api_key_file="../config/wandb_api_key.txt", key=None):
     if key is None:
         key = get_wandb_api_key(api_key_file)
 
     wandb.login(key=key)
 
-def set_wandb_api_key(api_key_file='../config/wandb_api_key.txt'):
-    import os
-    try:
-        os.environ['WANDB_API_KEY']
-    except KeyError:
-        with open(api_key_file, 'r') as f:
-            key = f.read()
-        os.environ['WANDB_API_KEY'] = key.strip()
 
-def get_wandb_api_key(api_key_file='../config/wandb_api_key.txt'):
+def set_wandb_api_key(api_key_file="../config/wandb_api_key.txt"):
     import os
+
     try:
-        return os.environ['WANDB_API_KEY']
+        os.environ["WANDB_API_KEY"]
     except KeyError:
-        with open(api_key_file, 'r') as f:
+        with open(api_key_file, "r") as f:
+            key = f.read()
+        os.environ["WANDB_API_KEY"] = key.strip()
+
+
+def get_wandb_api_key(api_key_file="../config/wandb_api_key.txt"):
+    import os
+
+    try:
+        return os.environ["WANDB_API_KEY"]
+    except KeyError:
+        with open(api_key_file, "r") as f:
             key = f.read()
         return key.strip()
 
+
 # Define the function to compute the spectrum
-def spectrum_2d(signal, n_observations , normalize=True):
+def spectrum_2d(signal, n_observations, normalize=True):
     """This function computes the spectrum of a 2D signal using the Fast Fourier Transform (FFT).
 
     Paramaters
     ----------
-    signal : a tensor of shape (T * n_observations * n_observations) 
-        A 2D discretized signal represented as a 1D tensor with shape (T * n_observations * n_observations), where T is the number of time steps and n_observations is the spatial size of the signal. 
-        T can be any number of channels that we reshape into and n_observations * n_observations is the spatial resolution.
+    signal : a tensor of shape (T * n_observations * n_observations)
+        A 2D discretized signal represented as a 1D tensor with shape
+        (T * n_observations * n_observations), where T is the number of time
+        steps and n_observations is the spatial size of the signal.
+
+        T can be any number of channels that we reshape into and
+        n_observations * n_observations is the spatial resolution.
     n_observations: an integer
         Number of discretized points. Basically the resolution of the signal.
-        
+
     Returns
     --------
-    spectrum: a tensor 
+    spectrum: a tensor
         A 1D tensor of shape (s,) representing the computed spectrum.
     """
     T = signal.shape[0]
     signal = signal.view(T, n_observations, n_observations)
-    
+
     if normalize:
         signal = torch.fft.fft2(signal)
     else:
-        signal = torch.fft.rfft2(signal, s=(n_observations, n_observations), normalized=False)
-    
+        signal = torch.fft.rfft2(
+            signal, s=(n_observations, n_observations), normalized=False
+        )
+
     # 2d wavenumbers following PyTorch fft convention
     k_max = n_observations // 2
-    wavenumers = torch.cat((torch.arange(start=0, end=k_max, step=1), \
-                            torch.arange(start=-k_max, end=0, step=1)), 0).repeat(n_observations, 1)
+    wavenumers = torch.cat(
+        (
+            torch.arange(start=0, end=k_max, step=1),
+            torch.arange(start=-k_max, end=0, step=1),
+        ),
+        0,
+    ).repeat(n_observations, 1)
     k_x = wavenumers.transpose(0, 1)
     k_y = wavenumers
-    
+
     # Sum wavenumbers
     sum_k = torch.abs(k_x) + torch.abs(k_y)
     sum_k = sum_k
-    
+
     # Remove symmetric components from wavenumbers
     index = -1.0 * torch.ones((n_observations, n_observations))
-    index[0:k_max + 1, 0:k_max + 1] = sum_k[0:k_max + 1, 0:k_max + 1]
-    
+    index[0 : k_max + 1, 0 : k_max + 1] = sum_k[0 : k_max + 1, 0 : k_max + 1]
+
     spectrum = torch.zeros((T, n_observations))
     for j in range(1, n_observations + 1):
         ind = torch.where(index == j)
         spectrum[:, j - 1] = (signal[:, ind[0], ind[1]].sum(dim=1)).abs() ** 2
-    
+
     spectrum = spectrum.mean(dim=0)
     return spectrum
 
+
+Number = Union[float, int]
+
+def validate_output_scaling_factor_1d(
+    output_scaling_factor: Optional[Union[Number, List[Number]]],
+    order: int,
+) -> Optional[List[float]]:
+    if output_scaling_factor is None:
+        return None
+    if isinstance(output_scaling_factor, (float, int)):
+        return [float(output_scaling_factor)] * len(order)
+
+    # TODO raise ValueError
+    return None
+
+
+def validate_output_scaling_factor_2d(
+    output_scaling_factor: Optional[Union[Number, List[Number]]],
+    n_dim: int,
+    n_layers: int,
+) -> Optional[List[List[float]]]:
+    if output_scaling_factor is None:
+        return None
+    if isinstance(output_scaling_factor, (float, int)):
+        return [[float(output_scaling_factor)] * n_dim] * n_layers
+    if isinstance(output_scaling_factor, list) and isinstance(
+        output_scaling_factor[0], (float, int)
+    ):
+        return [[float(s)] * n_dim for s in output_scaling_factor]
+
+    # TODO raise ValueError
+    return None

--- a/neuralop/utils.py
+++ b/neuralop/utils.py
@@ -170,21 +170,21 @@ Number = Union[float, int]
 def validate_scaling_factor(
     scaling_factor: Union[None, Number, List[Number]],
     n_dim: int,
-    n_layers: int,
+    n_layers: Optional[int] = None,
 ) -> Union[None, List[float], List[List[float]]]:
     """
     Parameters
     ----------
     scaling_factor : None OR float OR list[float]
     n_dim : int
-    n_layers : int
-        If less than 1, return a single list (rather than a list of lists)
+    n_layers : int or None; defaults to None
+        If None, return a single list (rather than a list of lists)
         with `factor` repeated `dim` times.
     """
     if scaling_factor is None:
         return None
     if isinstance(scaling_factor, (float, int)):
-        if n_layers < 1:
+        if n_layers is None:
             return [float(scaling_factor)] * n_dim
 
         return [[float(scaling_factor)] * n_dim] * n_layers

--- a/neuralop/utils.py
+++ b/neuralop/utils.py
@@ -165,30 +165,19 @@ def spectrum_2d(signal, n_observations, normalize=True):
 
 Number = Union[float, int]
 
-def validate_output_scaling_factor_1d(
-    output_scaling_factor: Optional[Union[Number, List[Number]]],
-    order: int,
-) -> Optional[List[float]]:
-    if output_scaling_factor is None:
-        return None
-    if isinstance(output_scaling_factor, (float, int)):
-        return [float(output_scaling_factor)] * len(order)
-
-    # TODO raise ValueError
-    return None
-
-
-def validate_output_scaling_factor_2d(
+def validate_output_scaling_factor(
     output_scaling_factor: Optional[Union[Number, List[Number]]],
     n_dim: int,
-    n_layers: int,
+    n_layers: int = 1,
 ) -> Optional[List[List[float]]]:
     if output_scaling_factor is None:
         return None
     if isinstance(output_scaling_factor, (float, int)):
         return [[float(output_scaling_factor)] * n_dim] * n_layers
-    if isinstance(output_scaling_factor, list) and isinstance(
-        output_scaling_factor[0], (float, int)
+    if (
+        isinstance(output_scaling_factor, list)
+        and len(output_scaling_factor) > 0
+        and all([isinstance(s, (float, int)) for s in output_scaling_factor])
     ):
         return [[float(s)] * n_dim for s in output_scaling_factor]
 


### PR DESCRIPTION
Mainly, refactor `FNOBlock.forward()` for readability:

* Create a separate method `FNOBlock.forward_with_preactivation()` where it is assumed `preactivation=True` for clarity of code flow. Likewise, assume `preactivation=False` in the new method `FNOBlock.forward_with_postactivation()`. The old method `forward()` now dispatches to one of these.
* In multiple places, we were checking `self.output_scaling_factors` and calling `resample` like boilerplate. Refactor this check and call (with a no-op return if `scaling_factors is None and output_shape is None`).
* Additionally, refactor out `output_scaling_factors` validation, which was being duplicated across 4 files.

Reviewer(s): @JeanKossaifi @zongyi-li 