### PR TITLE
fix example Trainer API calls

### DIFF
--- a/examples/plot_FNO_darcy.py
+++ b/examples/plot_FNO_darcy.py
@@ -15,6 +15,7 @@ import matplotlib.pyplot as plt
 import sys
 from neuralop.models import TFNO
 from neuralop import Trainer
+from neuralop.training import OutputEncoderCallback
 from neuralop.datasets import load_darcy_flow_small
 from neuralop.utils import count_params
 from neuralop import LpLoss, H1Loss
@@ -73,9 +74,9 @@ sys.stdout.flush()
 
 # %% 
 # Create the trainer
-trainer = Trainer(model, n_epochs=20,
+trainer = Trainer(model=model, n_epochs=20,
                   device=device,
-                  mg_patching_levels=0,
+                  callbacks=[OutputEncoderCallback(output_encoder)],             
                   wandb_log=False,
                   log_test_interval=3,
                   use_distributed=False,
@@ -85,11 +86,10 @@ trainer = Trainer(model, n_epochs=20,
 # %%
 # Actually train the model on our small Darcy-Flow dataset
 
-trainer.train(train_loader, test_loaders,
-              output_encoder,
-              model, 
-              optimizer,
-              scheduler, 
+trainer.train(train_loader=train_loader,
+              test_loaders=test_loaders,
+              optimizer=optimizer,
+              scheduler=scheduler, 
               regularizer=False, 
               training_loss=train_loss,
               eval_losses=eval_losses)

--- a/examples/plot_SFNO_swe.py
+++ b/examples/plot_SFNO_swe.py
@@ -70,9 +70,8 @@ sys.stdout.flush()
 
 # %% 
 # Create the trainer
-trainer = Trainer(model, n_epochs=20,
+trainer = Trainer(model=model, n_epochs=20,
                   device=device,
-                  mg_patching_levels=0,
                   wandb_log=False,
                   log_test_interval=3,
                   use_distributed=False,
@@ -82,11 +81,10 @@ trainer = Trainer(model, n_epochs=20,
 # %%
 # Actually train the model on our small Darcy-Flow dataset
 
-trainer.train(train_loader, test_loaders,
-              None,
-              model, 
-              optimizer,
-              scheduler, 
+trainer.train(train_loader=train_loader,
+              test_loaders=test_loaders,
+              optimizer=optimizer,
+              scheduler=scheduler, 
               regularizer=False, 
               training_loss=train_loss,
               eval_losses=eval_losses)

--- a/examples/plot_UNO_darcy.py
+++ b/examples/plot_UNO_darcy.py
@@ -14,6 +14,7 @@ import torch
 import matplotlib.pyplot as plt
 import sys
 from neuralop.models import TFNO, UNO
+from neuralop.training import OutputEncoderCallback
 from neuralop import Trainer
 from neuralop.datasets import load_darcy_flow_small
 from neuralop.utils import count_params
@@ -75,7 +76,7 @@ sys.stdout.flush()
 # Create the trainer
 trainer = Trainer(model, n_epochs=20,
                   device=device,
-                  mg_patching_levels=0,
+                  callbacks=[OutputEncoderCallback(output_encoder)],
                   wandb_log=False,
                   log_test_interval=3,
                   use_distributed=False,
@@ -85,11 +86,10 @@ trainer = Trainer(model, n_epochs=20,
 # %%
 # Actually train the model on our small Darcy-Flow dataset
 
-trainer.train(train_loader, test_loaders,
-              output_encoder,
-              model, 
-              optimizer,
-              scheduler, 
+trainer.train(train_loader=train_loader,
+              test_loaders=test_loaders,
+              optimizer=optimizer,
+              scheduler=scheduler, 
               regularizer=False, 
               training_loss=train_loss,
               eval_losses=eval_losses)


### PR DESCRIPTION
My last PR passes all tests but broke `make doc` because I didn't update the API in the `examples` folder. This PR fixes that.