### PR TITLE
Model checkpointing

### DIFF
--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -349,23 +349,23 @@ class ModelCheckpointCallback(Callback):
     Implements basic model checkpointing by saving a model every N epochs
     """
 
-    def __init__(self, ckpt_dir: Union[Path, str] = Path('./checkpoints'), interval: int = 1):
+    def __init__(self, checkpoint_dir: Union[Path, str] = Path('./checkpoints'), interval: int = 1):
         """
         Parameters
         ----------
-        ckpt_dir : str | pathlib.Path
+        checkpoint_dir : str | pathlib.Path
             folder in which to save checkpoints
         interval : int
             interval at which to check metric
         """
         super().__init()
 
-        if isinstance(ckpt_dir, str):
-            ckpt_dir = Path(ckpt_dir)
+        if isinstance(checkpoint_dir, str):
+            checkpoint_dir = Path(checkpoint_dir)
 
-        if not ckpt_dir.exists():
-            ckpt_dir.mkdir(parents=True)
-        self.ckpt_dir = ckpt_dir
+        if not checkpoint_dir.exists():
+            checkpoint_dir.mkdir(parents=True)
+        self.checkpoint_dir = checkpoint_dir
         self.interval = interval
 
     def on_init_end(self, *args, **kwargs):
@@ -376,8 +376,8 @@ class ModelCheckpointCallback(Callback):
 
     def on_epoch_end(self, *args, **kwargs):
         if self.state_dict['epoch'] % self.interval == 0:
-            ckpt_path = self.ckpt_dir / f"{self.state_dict['epoch']}"
-            torch.save(self.state_dict['model'], ckpt_path)
+            checkpoint_path = self.checkpoint_dir / f"{self.state_dict['epoch']}"
+            torch.save(self.state_dict['model'], checkpoint_path)
         
 
 class MonitorMetricCheckpointCallback(ModelCheckpointCallback):
@@ -385,24 +385,24 @@ class MonitorMetricCheckpointCallback(ModelCheckpointCallback):
     Implements model checkpointing with the addition of monitoring a metric
     """
 
-    def __init__(self, monitor: str, ckpt_dir: str = './checkpoints'):
+    def __init__(self, monitor: str, checkpoint_dir: str = './checkpoints'):
         """
         Parameters
         ----------
         monitor : str
             key name of validation metric to monitor
-        ckpt_path : str
+        checkpoint_path : str
             folder in which to save checkpoints
         """
 
         super().__init()
 
         self.monitor = monitor
-        if isinstance(ckpt_dir, str):
-            ckpt_dir = Path(ckpt_dir)
-        if not ckpt_dir.exists():
-            ckpt_dir.mkdir(parents=True)
-        self.ckpt_dir = ckpt_dir
+        if isinstance(checkpoint_dir, str):
+            checkpoint_dir = Path(checkpoint_dir)
+        if not checkpoint_dir.exists():
+            checkpoint_dir.mkdir(parents=True)
+        self.checkpoint_dir = checkpoint_dir
 
     def on_train_start(self, *args, **kwargs):
         self._update_state_dict(**kwargs)
@@ -418,7 +418,7 @@ class MonitorMetricCheckpointCallback(ModelCheckpointCallback):
         """
         epoch = self.state_dict['epoch']
         if errors[self.monitor] < self.state_dict['best_score']:
-            model_save_path = f"{self.ckpt_dir}/ep_{epoch}.pt"
+            model_save_path = f"{self.checkpoint_dir}/ep_{epoch}.pt"
             torch.save(self.state_dict['model'], model_save_path)
             print(f"Best value for {self.monitor} found, saving to {model_save_path}")
         

--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -362,7 +362,7 @@ class ModelCheckpointingCallback(Callback):
         ckpt_path : str
             path at which to save checkpoints
         epoch_interval : int
-            interval of epochs 
+            interval at which to check metric
         """
 
         self.monitor = monitor

--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -385,7 +385,7 @@ class MonitorMetricCheckpointCallback(ModelCheckpointCallback):
     Implements model checkpointing with the addition of monitoring a metric
     """
 
-    def __init__(self, monitor: str, checkpoint_dir: str = './checkpoints'):
+    def __init__(self, loss_key: str, checkpoint_dir: str = './checkpoints'):
         """
         Parameters
         ----------
@@ -397,7 +397,7 @@ class MonitorMetricCheckpointCallback(ModelCheckpointCallback):
 
         super().__init()
 
-        self.monitor = monitor
+        self.loss_key = loss_key
         if isinstance(checkpoint_dir, str):
             checkpoint_dir = Path(checkpoint_dir)
         if not checkpoint_dir.exists():
@@ -406,7 +406,7 @@ class MonitorMetricCheckpointCallback(ModelCheckpointCallback):
 
     def on_train_start(self, *args, **kwargs):
         self._update_state_dict(**kwargs)
-        assert self.monitor in self.state_dict['eval_losses'].keys(), \
+        assert self.loss_key in self.state_dict['eval_losses'].keys(), \
             "Error: ModelCheckpointingCallback can only monitor metrics\
                 tracked in eval_losses."
 
@@ -414,13 +414,13 @@ class MonitorMetricCheckpointCallback(ModelCheckpointCallback):
     
     def on_val_epoch_end(self, errors):
         """
-        save model if monitor metric is lower than best
+        save model if loss_key metric is lower than best
         """
         epoch = self.state_dict['epoch']
-        if errors[self.monitor] < self.state_dict['best_score']:
+        if errors[self.loss_key] < self.state_dict['best_score']:
             model_save_path = f"{self.checkpoint_dir}/ep_{epoch}.pt"
             torch.save(self.state_dict['model'].state_dict(), model_save_path)
-            print(f"Best value for {self.monitor} found, saving to {model_save_path}")
+            print(f"Best value for {self.loss_key} found, saving to {model_save_path}")
         
         
         

--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -349,7 +349,7 @@ class ModelCheckpointCallback(Callback):
     Implements basic model checkpointing by saving a model every N epochs
     """
 
-    def __init__(self, ckpt_dir: Union(Path, str) = Path('./checkpoints'), interval: int = 1):
+    def __init__(self, ckpt_dir: Union[Path, str] = Path('./checkpoints'), interval: int = 1):
         """
         Parameters
         ----------

--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -377,7 +377,7 @@ class ModelCheckpointCallback(Callback):
     def on_epoch_end(self, *args, **kwargs):
         if self.state_dict['epoch'] % self.interval == 0:
             checkpoint_path = self.checkpoint_dir / f"{self.state_dict['epoch']}"
-            torch.save(self.state_dict['model'], checkpoint_path)
+            torch.save(self.state_dict['model'].state_dict(), checkpoint_path)
         
 
 class MonitorMetricCheckpointCallback(ModelCheckpointCallback):
@@ -419,7 +419,7 @@ class MonitorMetricCheckpointCallback(ModelCheckpointCallback):
         epoch = self.state_dict['epoch']
         if errors[self.monitor] < self.state_dict['best_score']:
             model_save_path = f"{self.checkpoint_dir}/ep_{epoch}.pt"
-            torch.save(self.state_dict['model'], model_save_path)
+            torch.save(self.state_dict['model'].state_dict(), model_save_path)
             print(f"Best value for {self.monitor} found, saving to {model_save_path}")
         
         

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -21,6 +21,7 @@ class Trainer:
                  log_test_interval=1, 
                  log_output=False, 
                  use_distributed=False, 
+                 load_from_checkpoint=False,
                  verbose=True):
         """
         A general Trainer class to train neural-operators on given datasets
@@ -69,6 +70,8 @@ class Trainer:
                  use_distributed=use_distributed, 
                  verbose=verbose)
 
+        if load_from_checkpoint:
+            self.model = torch.load()
         self.model = model
         self.n_epochs = n_epochs
 

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -3,6 +3,7 @@ from torch.cuda import amp
 from timeit import default_timer
 import sys 
 import wandb
+import pathlib
 
 import neuralop.mpu.comm as comm
 
@@ -21,7 +22,7 @@ class Trainer:
                  log_test_interval=1, 
                  log_output=False, 
                  use_distributed=False, 
-                 load_from_checkpoint=False,
+                 checkpoint_to_load: pathlib.Path=None,
                  verbose=True):
         """
         A general Trainer class to train neural-operators on given datasets
@@ -70,8 +71,9 @@ class Trainer:
                  use_distributed=use_distributed, 
                  verbose=verbose)
 
-        if load_from_checkpoint:
-            self.model = torch.load()
+        if checkpoint_to_load:
+            self.model.load_state_dict(torch.load(checkpoint_to_load))
+
         self.model = model
         self.n_epochs = n_epochs
 


### PR DESCRIPTION
This PR implements two model checkpointing callbacks. One simply saves a model every N epochs, and the other monitors a metric from `eval_losses` to determine when to save a model.