### PR TITLE
Revert 4D_FNO changes until they are properly tested

### DIFF
--- a/neuralop/layers/mlp.py
+++ b/neuralop/layers/mlp.py
@@ -45,40 +45,27 @@ class MLP(nn.Module):
             else None
         )
 
-        # Decide if we're using Conv layers or Linear layers based on n_dim
-        if n_dim < 4:
-            Conv = getattr(nn, f"Conv{n_dim}d")
-            self.fcs = nn.ModuleList()
-            for i in range(n_layers):
-                if i == 0 and i == (n_layers - 1):
-                    self.fcs.append(Conv(self.in_channels, self.out_channels, 1))
-                elif i == 0:
-                    self.fcs.append(Conv(self.in_channels, self.hidden_channels, 1))
-                elif i == (n_layers - 1):
-                    self.fcs.append(Conv(self.hidden_channels, self.out_channels, 1))
-                else:
-                    self.fcs.append(Conv(self.hidden_channels, self.hidden_channels, 1))
-        else:
-            if n_layers == 1:
-                layers = [self.in_channels, self.out_channels]
+        Conv = getattr(nn, f"Conv{n_dim}d")
+        self.fcs = nn.ModuleList()
+        for i in range(n_layers):
+            if i == 0 and i == (n_layers - 1):
+                self.fcs.append(Conv(self.in_channels, self.out_channels, 1))
+            elif i == 0:
+                self.fcs.append(Conv(self.in_channels, self.hidden_channels, 1))
+            elif i == (n_layers - 1):
+                self.fcs.append(Conv(self.hidden_channels, self.out_channels, 1))
             else:
-                layers = [self.in_channels, self.hidden_channels, self.out_channels]
-            
-            self.fcs = nn.ModuleList()
-            for j in range(n_layers):
-                self.fcs.append(nn.Linear(layers[j], layers[j + 1]))
+                self.fcs.append(Conv(self.hidden_channels, self.hidden_channels, 1))
 
     def forward(self, x):
-        size = list(x.shape)
-        x = x.reshape(size[0], size[1], -1).permute(0, -1, 1)
         for i, fc in enumerate(self.fcs):
             x = fc(x)
             if i < self.n_layers - 1:
                 x = self.non_linearity(x)
             if self.dropout is not None:
-                x = self.dropout[i](x)  # Correctly use the dropout from the ModuleList
-        size[1] = self.out_channels
-        return x.permute(0, -1, 1).reshape(size)
+                x = self.dropout(x)
+
+        return x
 
 
 # Reimplementation of the MLP class using Linear instead of Conv

--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -200,39 +200,31 @@ class FNO(nn.Module):
 
         # if lifting_channels is passed, make lifting an MLP
         # with a hidden layer of size lifting_channels
-        if self.lifting_channels is not None:        
-                self.lifting = MLP(
+        if self.lifting_channels:
+            self.lifting = MLP(
                 in_channels=in_channels,
                 out_channels=self.hidden_channels,
                 hidden_channels=self.lifting_channels,
                 n_layers=2,
                 n_dim=self.n_dim,
             )
+        # otherwise, make it a linear layer
         else:
             self.lifting = MLP(
                 in_channels=in_channels,
                 out_channels=self.hidden_channels,
+                hidden_channels=self.hidden_channels,
                 n_layers=1,
                 n_dim=self.n_dim,
-            )                 
-
-        if self.projection_channels is not None:
-            self.projection = MLP(
-                in_channels=self.hidden_channels,
-                out_channels=out_channels,
-                hidden_channels=self.projection_channels,
-                n_layers=2,
-                n_dim=self.n_dim,
-                non_linearity=non_linearity,
             )
-        else:
-            self.projection = MLP(
-                in_channels=self.hidden_channels,
-                out_channels=out_channels,
-                n_layers=1,
-                n_dim=self.n_dim,
-                non_linearity=non_linearity,
-            )            
+        self.projection = MLP(
+            in_channels=self.hidden_channels,
+            out_channels=out_channels,
+            hidden_channels=self.projection_channels,
+            n_layers=2,
+            n_dim=self.n_dim,
+            non_linearity=non_linearity,
+        )
 
     def forward(self, x, output_shape=None, **kwargs):
         """TFNO's forward pass


### PR DESCRIPTION
Reverts neuraloperator/neuraloperator#225.

This PR has some bugs around the shaping and permutation of data in MLPs. I think it made it past checks because of the OSerror currently plaguing our CI pipeline. I propose reverting this PR until we have a working CI pipeline that can catch these errors. 