### PR TITLE
Fix typo in checkpoint init

### DIFF
--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -389,7 +389,7 @@ class ModelCheckpointCallback(Callback):
         interval : int
             interval at which to check metric
         """
-        super().__init()
+        super().__init__()
 
         if isinstance(checkpoint_dir, str):
             checkpoint_dir = Path(checkpoint_dir)
@@ -425,7 +425,7 @@ class MonitorMetricCheckpointCallback(ModelCheckpointCallback):
             folder in which to save checkpoints
         """
 
-        super().__init()
+        super().__init__()
 
         self.loss_key = loss_key
         if isinstance(checkpoint_dir, str):


### PR DESCRIPTION
There's a typo in the new checkpoint Callbacks, `super().__init()` instead of `super().__init__()`. When the Callbacks are run, they produce an error: `AttributeError: 'super' object has no attribute '_ModelCheckpointCallback__init'`. After this fix, I successfully ran a job and generated checkpoint files.