### PR TITLE
standard dataset to FNOGNO on regular grid dataset callback

### DIFF
--- a/config/cfd_config.yaml
+++ b/config/cfd_config.yaml
@@ -1,0 +1,77 @@
+cfd: &CFD
+
+  arch: 'fnogno'
+  sample_max: 5000
+
+  # Distributed computing
+  distributed:
+    use_distributed: False
+    wireup_info: 'mpi'
+    wireup_store: 'tcp'
+    model_parallel_size: 2
+    seed: 666
+    device: 'cuda:0'
+  
+  # Dataset related
+  data:
+    path: '/home/ubuntu/data/cfd/car-pressure-data'
+    entity_name: ''
+    load_attributes: ['press']
+    sdf_query_resolution: 32
+    n_train: 490
+    n_test: 100
+    input_points: 'query_points'
+    input_fields: ['distance']
+    output_points: 'centroids'
+    output_fields: ['press']
+    
+    # key : start, stop, none in each dim
+    output_indices: 
+      press:
+        - - None
+        - - 0
+          - 1
+    weights: 'triangle_areas'
+
+  fnogno:
+    data_channels: 1
+    out_channels: 1
+    gno_coord_dim: 3
+    gno_coord_embed_dim: 16
+    gno_radius: 0.033
+    gno_transform_type: 'linear' # linear_kernelonly, linear, nonlinear_kernelonly, nonlinear
+    fno_n_modes: [32, 32, 32]
+    fno_hidden_channels: 256
+    fno_use_mlp: True
+    fno_norm: 'instance_norm'
+    fno_ada_in_features: 32
+    fno_factorization: 'tucker'
+    fno_rank: 0.4
+    fno_domain_padding: 0.125
+    fno_mlp_expansion: 1.0
+    fno_output_scaling_factor: 1
+
+  opt:
+    n_epochs: 301
+    learning_rate: 1e-3
+    training_loss: 'l2' # weightedl2drag not working yet
+    testing_loss: 'l2' # ^
+    weight_decay: 1e-4
+    amp_autocast: False
+
+    scheduler_T_max: 500 # For cosine only, typically take n_epochs
+    scheduler_patience: 5 # For ReduceLROnPlateau only
+    scheduler: 'StepLR' # Or 'CosineAnnealingLR' OR 'ReduceLROnPlateau'
+    step_size: 50
+    gamma: 0.5
+  
+  # Weights and biases
+  wandb:
+    log: False #True
+    name: None # If None, config will be used but you can override it here
+    group: 'drag' 
+    project: ""
+    entity: ""
+    sweep: False
+    log_output: True
+    log_test_interval: 1

--- a/config/cfd_config.yaml
+++ b/config/cfd_config.yaml
@@ -40,8 +40,8 @@ cfd: &CFD
     gno_coord_embed_dim: 16
     gno_radius: 0.033
     gno_transform_type: 'linear' # linear_kernelonly, linear, nonlinear_kernelonly, nonlinear
-    fno_n_modes: [32, 32, 32]
-    fno_hidden_channels: 256
+    fno_n_modes: [16, 16, 16]
+    fno_hidden_channels: 64
     fno_use_mlp: True
     fno_norm: 'instance_norm'
     fno_ada_in_features: 32

--- a/neuralop/datasets/dict_dataset.py
+++ b/neuralop/datasets/dict_dataset.py
@@ -1,0 +1,21 @@
+from torch.utils.data import Dataset
+
+class DictDataset(Dataset):
+    def __init__(self,
+                 data_list: list,
+                 constant: dict = None,
+                 ):
+        
+        self.data_list = data_list
+        self.constant = constant
+
+    def __getitem__(self, index):
+        return_dict = self.data_list[index]
+
+        if self.constant is not None:
+            return_dict.update(self.constant)
+        
+        return return_dict
+        
+    def __len__(self):
+        return len(self.data_list)

--- a/neuralop/datasets/mesh_datamodule.py
+++ b/neuralop/datasets/mesh_datamodule.py
@@ -178,16 +178,18 @@ class MeshDataModule():
                         data[j][attr] = data[j][attr].to(torch.float32)
 
             #Compute Gaussian normalizers based on training data
-            self.normalizers = {}
+            normalizer_keys = []
             for attr in attributes:
                 if isinstance(data[0][attr], torch.Tensor):
-                    attr_data = [data[j][attr] for j in range(n_train)]
-                    self.normalizers[attr] = UnitGaussianNormalizer.from_dataset(attr_data, dim=0)
+                    normalizer_keys.append(attr)
+            # returns keyed dict of UnitGaussianNormalizer instances
+            self.normalizers = UnitGaussianNormalizer.from_dataset(data, dim=0, keys=normalizer_keys) 
 
-                    #Encode all data
-                    for j in range(len(data)):
-                        data[j][attr] = self.normalizers[attr](data[j][attr])
-
+            #Encode all data
+            for attr in normalizer_keys:
+                for j in range(len(data)):
+                    data[j][attr] = self.normalizers[attr].transform(data[j][attr])
+            
             if not bool(self.normalizers):
                 self.normalizers = None
         else:

--- a/neuralop/datasets/mesh_datamodule.py
+++ b/neuralop/datasets/mesh_datamodule.py
@@ -182,7 +182,7 @@ class MeshDataModule():
             for attr in attributes:
                 if isinstance(data[0][attr], torch.Tensor):
                     attr_data = [data[j][attr] for j in range(n_train)]
-                    self.normalizers[attr] = UnitGaussianNormalizer(attr_data, dim=0)
+                    self.normalizers[attr] = UnitGaussianNormalizer.from_data(attr_data, dims=0)
 
                     #Encode all data
                     for j in range(len(data)):

--- a/neuralop/datasets/mesh_datamodule.py
+++ b/neuralop/datasets/mesh_datamodule.py
@@ -1,0 +1,284 @@
+import torch
+
+import numpy as np
+import open3d as o3d
+
+from pathlib import Path
+from timeit import default_timer
+from torch.utils.data import DataLoader
+from .dict_dataset import DictDataset
+from .output_encoder import UnitGaussianNormalizer
+
+class MeshDataModule():
+    def __init__(self,
+                base_dir,
+                item_dir_name: str,
+                n_train: int = None,
+                n_test: int = None,
+                query_points = None,
+                attributes = None
+                ):
+
+        if isinstance(base_dir, str):
+            base_dir = Path(base_dir)
+
+        #Ensure path is valid
+        base_dir = base_dir.expanduser()
+        assert base_dir.exists(), "Path does not exist"
+        assert base_dir.is_dir(), "Path is not a directory"
+
+        #Read train and test indicies
+        with open(base_dir / 'train.txt') as file:
+            train_ind = file.readline().split(',')
+
+        with open(base_dir / 'test.txt') as file:
+            test_ind = file.readline().split(',')
+
+        if n_train is not None:
+            if n_train < len(train_ind):
+                train_ind = train_ind[0:n_train]
+
+        if n_test is not None:
+            if n_test < len(test_ind):
+                test_ind = test_ind[0:n_test]
+
+        '''#Suspect for now
+        train_ind[-1] = train_ind[-1][0:-1]
+        test_ind[-1] = test_ind[-1][0:-1]'''
+
+        # set train and test sizes
+        train_ind = train_ind[0:n_train]
+        test_ind = test_ind[0:n_test]
+        n_train = len(train_ind)
+        n_test = len(test_ind)
+        print('n_train n_test are', n_train, n_test)
+
+        mesh_ind = train_ind + test_ind 
+        #remove trailing newlines from train and test indices
+        mesh_ind = [x.rstrip() for x in mesh_ind]  
+
+        data_dir = base_dir / 'data'
+
+        #Load all meshes
+        '''meshes = [
+            o3d.io.read_triangle_mesh(str(data_dir / 
+                                      (item_dir_name + ind 
+                                      + '/tri_mesh.ply')))
+            for ind in mesh_ind 
+        ]'''
+        meshes = []
+        for ind in mesh_ind:
+            mesh = o3d.io.read_triangle_mesh(str(data_dir / 
+                                      (item_dir_name + ind 
+                                      + '/tri_mesh.ply')))
+            meshes.append(mesh)
+
+        #Dataset wide bounding box
+        min_b, max_b = self.get_global_bounding_box(meshes)
+
+        #are_watertight = self.are_watertight(meshes)
+        are_watertight = True
+
+        #Uniform query points if not provided
+        if isinstance(query_points, list) or isinstance(query_points, tuple):
+            tx = np.linspace(min_b[0], max_b[0], query_points[0])
+            ty = np.linspace(min_b[1], max_b[1], query_points[1])
+            tz = np.linspace(min_b[2], max_b[2], query_points[2])
+
+            query_points = np.stack(
+                np.meshgrid(tx, ty, tz, indexing="ij"), axis=-1
+            ).astype(np.float32)
+
+        #Compute data from meshes 
+        data = []
+        deleted_meshes = []
+        self.time_to_distance = 0.0
+        for i,mesh in enumerate(meshes):
+            item_dict = {}
+
+            mesh = mesh.compute_triangle_normals()
+            mesh = mesh.compute_vertex_normals()
+
+            item_dict['vertices'] = np.asarray(mesh.vertices)
+            item_dict['vertex_normals'] = np.asarray(mesh.vertex_normals)
+            item_dict['triangle_normals'] = np.asarray(mesh.triangle_normals)
+
+            centroids, area = self.compute_triangle_centroids(item_dict['vertices'],
+                                                              np.asarray(mesh.triangles))
+
+            item_dict['centroids'] = centroids
+            item_dict['triangle_areas'] = area
+
+            #Normalize vertex data based on global bound 
+            item_dict['vertices'] = self.range_normalize(item_dict['vertices'],
+                                                            min_b, max_b,
+                                                            0, 1)
+
+            item_dict['centroids'] = self.range_normalize(item_dict['centroids'],
+                                                            min_b, max_b,
+                                                            0, 1)
+
+            if query_points is not None:
+                tt = default_timer()
+                try:
+                    distance, closest = self.compute_distances(mesh,
+                                                            query_points,
+                                                            are_watertight)
+                except:
+                    deleted_meshes.append(mesh_ind[i])
+                    print(f"{i}-th mesh is empty and will not be added to the dataset")
+                    continue
+                self.time_to_distance += default_timer() - tt
+                item_dict['distance'] = np.expand_dims(distance, -1)
+                item_dict['closest_points'] = closest
+
+                #Normalize vertex data based on global bound 
+                item_dict['closest_points'] = self.range_normalize(item_dict['closest_points'],
+                                                            min_b, max_b,
+                                                            0, 1)
+            data.append(item_dict)
+
+        self.time_to_distance /= len(meshes)
+
+        del meshes
+
+        # remove all broken meshes from training set
+        n_train -= len(deleted_meshes)
+        print(f"{deleted_meshes=}")
+
+        #Bounds based on training data
+        min_dist, max_dist = self.get_bounds_from_data(data[0:n_train], 'distance')
+        min_area, max_area = self.get_bounds_from_data(data[0:n_train], 'triangle_areas')
+
+        for data_dict in data:
+            data_dict['distance'] = self.range_normalize(data_dict['distance'],
+                                                         min_dist, max_dist,
+                                                         1e-6, 1)
+            data_dict['normalized_triangle_areas'] = self.range_normalize(data_dict['triangle_areas'],
+                                                                          min_area, max_area,
+                                                                          1e-6, 1)
+
+        #Convert to torch
+        for data_dict in data:
+            for key in data_dict:
+                data_dict[key] = torch.from_numpy(data_dict[key]).to(torch.float32)
+
+        #Load non-mesh data
+        if attributes is not None:
+            for j, ind in enumerate(mesh_ind):
+                # skip corrupted meshes we caught while adding to dataset
+                if ind in deleted_meshes:
+                    print(f"{j}-th pressure field ind {ind} was deleted.")
+                    continue
+                for attr in attributes: 
+                    path = str(data_dir / (item_dir_name + ind + '/' + attr + '.npy'))
+                    data[j][attr] = torch.from_numpy((np.load(path)))
+
+                    if isinstance(data[j][attr], torch.Tensor):
+                        data[j][attr] = data[j][attr].to(torch.float32)
+
+            #Compute Gaussian normalizers based on training data
+            self.normalizers = {}
+            for attr in attributes:
+                if isinstance(data[0][attr], torch.Tensor):
+                    attr_data = [data[j][attr] for j in range(n_train)]
+                    self.normalizers[attr] = UnitGaussianNormalizer(attr_data, dim=0)
+
+                    #Encode all data
+                    for j in range(len(data)):
+                        data[j][attr] = self.normalizers[attr](data[j][attr])
+
+            if not bool(self.normalizers):
+                self.normalizers = None
+        else:
+            self.normalizers = None
+
+        #Set-up constant dict
+        query_points = self.range_normalize(query_points,
+                                            min_b, max_b,
+                                            0, 1)
+
+        query_points = torch.from_numpy(query_points).to(torch.float32)
+        constant = {'query_points': query_points}
+
+
+        #Datasets
+        self.train_data = DictDataset(data[0:n_train], constant)
+        self.test_data = DictDataset(data[n_train:], constant)
+
+
+    def get_global_bounding_box(self, meshes):
+        min_b = np.zeros((3, len(meshes)))
+        max_b = np.zeros((3, len(meshes)))
+        for j, mesh in enumerate(meshes):
+            try:
+                min_b[:,j] = mesh.get_min_bound()
+                max_b[:,j] = mesh.get_max_bound()
+            except IndexError:
+                print(f"{j}-th mesh could not be bounded. ")
+                pass
+
+        min_b = min_b.min(axis=1)
+        max_b = max_b.max(axis=1)
+
+        return min_b, max_b
+
+    def are_watertight(self, meshes):
+        for mesh in meshes:
+            if not mesh.is_watertight():
+                return False
+
+        return True
+
+    def compute_triangle_centroids(self, vertices, triangles):
+        A, B, C = (
+            vertices[triangles[:, 0]],
+            vertices[triangles[:, 1]],
+            vertices[triangles[:, 2]],
+        )
+
+        centroids = (A + B + C) / 3
+        areas = np.sqrt(np.sum(np.cross(B - A, C - A) ** 2, 1)) / 2
+
+        return centroids, areas
+
+    def compute_distances(self, mesh, query_points, signed_distance):
+        mesh = o3d.t.geometry.TriangleMesh.from_legacy(mesh)
+        scene = o3d.t.geometry.RaycastingScene()
+        _ = scene.add_triangles(mesh)
+
+        if signed_distance:
+            dist = scene.compute_signed_distance(query_points).numpy()
+        else:
+            dist = scene.compute_distance(query_points).numpy()
+
+        closest = scene.compute_closest_points(query_points)["points"].numpy()
+
+        return dist, closest
+
+    def range_normalize(self, data, min_b, max_b, new_min, new_max):
+        data = (data - min_b) / (max_b - min_b)
+        data = (new_max - new_min)*data + new_min
+
+        return data
+
+    def get_bounds_from_data(self, data, key):
+        global_min = data[0][key].min()
+        global_max = data[0][key].max()
+
+        for j in range(1, len(data)):
+            current_min = data[j][key].min()
+            current_max = data[j][key].max()
+
+            if current_min < global_min:
+                global_min = current_min
+            if current_max > global_max:
+                global_max = current_max
+
+        return global_min, global_max
+
+    def train_dataloader(self, **kwargs):
+        return DataLoader(self.train_data, **kwargs)
+
+    def test_dataloader(self, **kwargs):
+        return DataLoader(self.test_data, **kwargs)

--- a/neuralop/datasets/mesh_datamodule.py
+++ b/neuralop/datasets/mesh_datamodule.py
@@ -182,7 +182,7 @@ class MeshDataModule():
             for attr in attributes:
                 if isinstance(data[0][attr], torch.Tensor):
                     attr_data = [data[j][attr] for j in range(n_train)]
-                    self.normalizers[attr] = UnitGaussianNormalizer.from_data(attr_data, dims=0)
+                    self.normalizers[attr] = UnitGaussianNormalizer.from_dataset(attr_data, dim=0)
 
                     #Encode all data
                     for j in range(len(data)):

--- a/neuralop/datasets/output_encoder.py
+++ b/neuralop/datasets/output_encoder.py
@@ -101,7 +101,7 @@ class MultipleFieldOutputEncoder(OutputEncoder):
         self.encoders = {k:v.to(device) for k,v in self.encoders.items()}
 
 
-class TransformCallback(torch.nn.Module):
+class Transform(torch.nn.Module):
     """OutputEncoder: converts the output of a model
         into a form usable by some cost function.
     """
@@ -129,7 +129,7 @@ class TransformCallback(torch.nn.Module):
         pass
 
 
-class DictTransformCallback(OutputEncoder):
+class DictTransform(OutputEncoder):
     """When a model has multiple input and output fields, 
         apply a different transform to each field, 
         tries to apply the inverse_transform to each output
@@ -201,7 +201,7 @@ class DictTransformCallback(OutputEncoder):
         self.encoders = {k:v.to(device) for k,v in self.encoders.items()}
 
 
-class UnitGaussianNormalizer(torch.nn.Module):
+class UnitGaussianNormalizer(OutputEncoder):
     """
     UnitGaussianNormalizer normalizes data to be zero mean and unit std. 
     """
@@ -252,7 +252,6 @@ class UnitGaussianNormalizer(torch.nn.Module):
         n_samples = len(data_batch)
         while count < n_samples:
             samples = data_batch[count:count+batch_size]
-            print(samples.shape)
             # if batch_size == 1:
             #     samples = samples.unsqueeze(0)
             if self.n_elements:
@@ -267,7 +266,7 @@ class UnitGaussianNormalizer(torch.nn.Module):
         self.mean = torch.mean(data_batch, dim=self.dim, keepdim=True)
         self.squared_mean = torch.mean(data_batch**2, dim=self.dim, keepdim=True)
         self.std = torch.sqrt(self.squared_mean - self.mean**2)
-
+        print(self.mean)
     def incremental_update_mean_std(self, data_batch):
         n_elements = count_tensor_params(data_batch, self.dim)
 
@@ -283,7 +282,7 @@ class UnitGaussianNormalizer(torch.nn.Module):
         if x.ndim == self.ndim: #Normalize a batch of data
             return (x - self.mean)/(self.std + self.eps)
         elif x.ndim == self.ndim - 1: # Normalize a single sample
-            return (x - self.mean.squeeze(0))/(self.std + self.eps.squeeze(0))
+            return (x - self.mean.squeeze(0))/(self.std.squeeze(0) + self.eps)
         else:
             raise ValueError(f'Got sample of size {x.shape} but learned stats on samples of size {self.data_shape}')
     
@@ -301,19 +300,16 @@ class UnitGaussianNormalizer(torch.nn.Module):
     def cuda(self):
         self.mean = self.mean.cuda()
         self.std = self.std.cuda()
-        self.eps = self.eps.cuda()
         return self
 
     def cpu(self):
         self.mean = self.mean.cpu()
         self.std = self.std.cpu()
-        self.eps = self.eps.cpu()
         return self
     
     def to(self, device):
         self.mean = self.mean.to(device)
         self.std = self.std.to(device)
-        self.eps = self.eps.to(device)
         return self
     
     @classmethod
@@ -332,12 +328,14 @@ class UnitGaussianNormalizer(torch.nn.Module):
         keys : str list or None
             if not None, a normalizer is instanciated only for the given keys
         """
+        instances = {key: cls(dim=dim) for key in keys}
+
         for i, data_dict in enumerate(dataset):
             if not i:
                 if not keys:
                     keys = data_dict.keys()
                 instances = {key: cls(dim=dim) for key in keys}
             for key, sample in data_dict.items():
-                instances[key].partial_fit(sample.unsqueeze(0))
+                if key in keys:
+                    instances[key].partial_fit(sample.unsqueeze(0))
         return instances
-             

--- a/neuralop/datasets/output_encoder.py
+++ b/neuralop/datasets/output_encoder.py
@@ -78,14 +78,14 @@ class UnitGaussianNormalizer(OutputEncoder):
 
         elif isinstance(data, Iterable):
             total_n = count_tensor_params(data[0], dims)
-            mean = torch.mean(data[0], dims=dims, keepdim=True)
-            squared_mean = torch.mean(data[0]**2, dims=dims, keepdim=True)
+            mean = torch.mean(data[0], dim=tuple(dims), keepdim=True)
+            squared_mean = torch.mean(data[0]**2, dim=tuple(dims), keepdim=True)
 
             for j in range(1, len(data)):
                 current_n = count_tensor_params(data[j], dims)
 
-                mean = (1.0/(total_n + current_n))*(total_n*mean + torch.sum(data[j], dims=dims, keepdim=True))
-                squared_mean = (1.0/(total_n + current_n))*(total_n*squared_mean + torch.sum(data[j]**2, dims=dims, keepdim=True))
+                mean = (1.0/(total_n + current_n))*(total_n*mean + torch.sum(data[j], dim=tuple(dims), keepdim=True))
+                squared_mean = (1.0/(total_n + current_n))*(total_n*squared_mean + torch.sum(data[j]**2, dim=tuple(dims), keepdim=True))
 
                 total_n += current_n
             

--- a/neuralop/layers/segment_csr.py
+++ b/neuralop/layers/segment_csr.py
@@ -28,7 +28,7 @@ def segment_csr(src: torch.Tensor, indptr: torch.Tensor, reduce: Literal['mean',
     if torch.backends.cuda.is_built() and importlib.find_loader('torch_scatter') and use_scatter:
         """only import torch_scatter when cuda is available"""
         import torch_scatter.segment_csr as scatter_segment_csr
-        return scatter_segment_csr(src, indptr, reduce)
+        return scatter_segment_csr(src, indptr, reduce=reduce)
 
     else:
         n_nbrs = indptr[1:] - indptr[:-1] # end indices - start indices

--- a/neuralop/models/model_dispatcher.py
+++ b/neuralop/models/model_dispatcher.py
@@ -4,7 +4,7 @@ from .fno import TFNO, TFNO1d, TFNO2d, TFNO3d
 from .fno import FNO, FNO1d, FNO2d, FNO3d
 from .fno import SFNO
 from .uno import UNO
-# from .fnogno import FNOGNO
+from .fnogno import FNOGNO
 
 
 MODEL_ZOO = {
@@ -18,7 +18,7 @@ MODEL_ZOO = {
     "fno2d": FNO2d,
     "fno3d": FNO3d,
     "uno": UNO,
-    # "fnogno": FNOGNO
+    "fnogno": FNOGNO
 }
 
 

--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -131,6 +131,8 @@ class PipelineCallback(Callback):
             self.overrides_loss = False
             print("using standard method to compute loss.")
         
+        self.overrides_loss_idx = overrides_loss
+
     def _update_state_dict(self, **kwargs):
         for c in self.callbacks:
             c._update_state_dict(kwargs)
@@ -172,9 +174,12 @@ class PipelineCallback(Callback):
             c.on_before_loss(*args, **kwargs)
     
     def compute_training_loss(self, *args, **kwargs):
+        loss = 0.
         if self.overrides_loss:
-            for c in self.callbacks:
-                c.compute_training_loss(*args, **kwargs)
+            for i,c in enumerate(self.callbacks):
+                if self.overrides_loss_idx[i]:
+                    loss += c.compute_training_loss(*args, **kwargs)
+            return loss
         else:
             pass
     
@@ -207,9 +212,12 @@ class PipelineCallback(Callback):
             c.on_before_val_loss(*args, **kwargs)
     
     def compute_val_loss(self, *args, **kwargs):
+        loss = 0.
         if self.overrides_loss:
-            for c in self.callbacks:
-                c.compute_val_loss(*args, **kwargs)
+            for i,c in enumerate(self.callbacks):
+                if self.overrides_loss_idx[i]:
+                    c.compute_val_loss(*args, **kwargs)
+            return loss
         else:
             pass
     

--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -385,6 +385,31 @@ class OutputEncoderCallback(Callback):
     
     def on_before_val_loss(self, **kwargs):
         return self.on_before_loss(**kwargs)
+
+class TransformCallback(Callback):
+    
+    def __init__(self, transform):
+        """
+        Callback class for a training loop that involves
+        an output normalizer but no MG patching.
+
+        Parameters
+        -----------
+        encoder : neuralop.datasets.output_encoder.OutputEncoder
+            module to normalize model inputs/outputs
+        """
+        super().__init__()
+        self.transform = transform
+    
+    def on_batch_start(self, *args, **kwargs):
+        self._update_state_dict(**kwargs)
+    
+    def on_before_loss(self, out):
+        self.state_dict['out'] = self.transform.inverse_transform(out)
+        self.state_dict['sample']['y'] = self.transform.inverse_transform(self.state_dict['sample']['y'])
+    
+    def on_before_val_loss(self, **kwargs):
+        return self.on_before_loss(**kwargs)
         
 class CheckpointCallback(Callback):
     

--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -299,6 +299,7 @@ class SimpleWandBLoggerCallback(Callback):
         print(self.state_dict['msg'])
         sys.stdout.flush()
 
+        wandb_log = self.state_dict.get('wandb_log', False)
         if self.state_dict.get('wandb_log', False):
             for pg in self.state_dict['optimizer'].param_groups:
                 lr = pg['lr']

--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -9,10 +9,11 @@ logic of callbacks in Pytorch-Lightning (https://lightning.ai/docs/pytorch/stabl
 import os
 from pathlib import Path
 import sys
-from typing import List, Union, Literal
+from typing import List, Tuple, Union
 
 import torch
 import wandb
+import numpy as np
 
 from neuralop.training.patching import MultigridPatching2D
 
@@ -554,4 +555,81 @@ class CheckpointCallback(Callback):
             
             if self.state_dict['verbose']:
                 print(f"Saved training state to {save_path}")
+
+class RegularDatasetToFNOGNOCallback(Callback):
+    def __init__(self, out_p_gradient: bool=False, 
+                 pad: int=0,
+                 include_out_p_endpoint: bool=True,
+                 domain_lengths: Union[Union[Tuple[float], List[float]], float] = 1):
+        """RegularDatasetToFNOGNOCallback
+
+        Performs simple data preprocessing to convert a data batch
+        from a form expected by an FNO or similar model to that
+        expected by an FNOGNO.
+
+        Params
+        -------
+        out_p_gradient: bool, defaults to False
+            whether generated output grid requires_grad or not
+        pad: int, defaults to 0.
+            number of pixels/discretization units to pad on each side
+        include_out_p_endpoint: bool, defaults to True
+            whether to include the endpoint of out_p
+        domain_lengths: List or Tuple of float, or float
+            size of data domain along each dimension
+
+        TODO @COLIN: should this belong in datasets
+        under some "generate_out_p=True" flag?
+        """
+        super().__init__()
+        self.out_p_gradient = out_p_gradient
+        self.pad = pad
+        self.include_out_p_endpoint = include_out_p_endpoint
+        self.domain_lengths=domain_lengths
+    
+    def create_out_p(self, batch_size=16, train_resolution=(16,16), device=None, sample_random=None, bound_dist=0):
+        domain_lengths = self.domain_lengths
+        if not isinstance(self.domain_lengths, (tuple, list)):
+            domain_lengths = [domain_lengths] * len(train_resolution)
+
+        if sample_random is None:
+            include_endpoint = self.include_out_p_endpoint
+            if not isinstance(include_endpoint, (tuple, list)):
+                include_endpoint = [include_endpoint] * len(train_resolution)
+
+            tx = []
+            for resolution, domain_length, endpoint in zip(train_resolution, domain_lengths, include_endpoint):
+                if endpoint:
+                    tx.append(torch.linspace(0, domain_length, resolution))
+                else:
+                    tx.append(torch.linspace(0, domain_length, resolution + 1)[:-1])
+
+            out_p = torch.stack(
+                torch.meshgrid(*tx, indexing="ij"), axis=-1
+            ).astype(torch.float32)
+
+            # duplicate batch_size times
+            out_p = torch.tile(out_p, (batch_size, 1, 1, 1))
+            # convert to a list of coordinate points
+            out_p = out_p.reshape(batch_size, out_p.shape[1] * out_p.shape[2], 2)
+            out_p = out_p.to(device)
+        
+        else:
+            # TODO(jberner): make this more general for other boundary conditions
+            x = np.linspace(0, domain_lengths[1], train_resolution[1] + 1)[:-1]
+            x = torch.from_numpy(x).float().to(device)
+            boundary = torch.stack([torch.zeros_like(x), x], dim=1).tile([batch_size, 1, 1])
+
+            domain_lengths = torch.tensor(domain_lengths, device=device)
+            out_p = bound_dist + torch.rand(batch_size, sample_random, len(train_resolution), device=device) * (domain_lengths - 2 * bound_dist)
+            out_p = torch.cat([out_p, boundary], dim=1)
+        return out_p
+
+    
+    def on_batch_start(self, *args, **kwargs):
+        self._update_state_dict(**kwargs)
+        x = self.state_dict['sample']['x']
+        train_resolution = [s - 2 * self.pad for s in x.shape[-2:]]
+        out_p = self.create_out_p(batch_size=x.shape[0], train_resolution=train_resolution, device=self.device, sample_random=self.sample_random)
+        out_p.requires_grad_(self.out_p_gradient)
 

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -12,7 +12,7 @@ class Trainer:
     def __init__(self, *, 
                  model, 
                  n_epochs, 
-                 wandb_log=True, 
+                 wandb_log=False, 
                  device=None, 
                  amp_autocast=False, 
                  callbacks = None,
@@ -27,7 +27,8 @@ class Trainer:
         ----------
         model : nn.Module
         n_epochs : int
-        wandb_log : bool, default is True
+        wandb_log : bool, default is False
+            whether to log data to wandb
         device : torch.device
         amp_autocast : bool, default is False
         log_test_interval : int, default is 1

--- a/scripts/fetch_cfd_data.py
+++ b/scripts/fetch_cfd_data.py
@@ -1,0 +1,43 @@
+"""
+Script to fetch and preprocess car-CFD dataset
+this assumes that at ~/data/cfd, you have downloaded 
+the preprocessed folder car-pressure-data.zip
+"""
+import argparse
+import os
+import shutil
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument("--data_root", help="root directory in which car-pressure-data.zip is downloaded and unzipped")
+parser.add_argument("--verbose", "-v", action="store_true")
+
+args = parser.parse_args()
+
+if args.data_root:
+    data_root = args.data_root
+else:
+    home_dir = os.getenv("HOME")
+    data_root = f"{home_dir}/data/cfd/car-pressure-data"
+
+
+with open(f"{data_root}/watertight_meshes.txt", "r") as f:
+    mesh_inds = [x.rstrip() for x in f.readlines()]
+
+train_inds = ','.join(mesh_inds[:500])
+test_inds = ','.join(mesh_inds[500:])
+
+with open(f"{data_root}/train.txt", "w+") as f:
+    f.write(train_inds)
+    f.close()
+
+with open(f"{data_root}/test.txt", "w+") as f:
+    f.write(test_inds)
+    f.close()
+
+for ind in mesh_inds:
+    if args.verbose:
+        print(f"Copied file #{ind}/{len(mesh_inds)}", end='\r')
+    os.mkdir(f"{data_root}/data/{ind}/")
+    shutil.copyfile(f"{data_root}/data/mesh_{ind}.ply", f"{data_root}/data/{ind}/tri_mesh.ply")
+    shutil.copyfile(f"/{data_root}/data/press_{ind}.npy", f"{data_root}/data/{ind}/press.npy")

--- a/scripts/train_cfd.py
+++ b/scripts/train_cfd.py
@@ -10,7 +10,7 @@ from neuralop.training.meta_losses import SumAggregatorLoss, FieldwiseAggregator
 from neuralop.training.trainer import Trainer
 from neuralop.datasets.mesh_datamodule import MeshDataModule
 from copy import deepcopy
-from neuralop.training.callbacks import OutputEncoderCallback, Callback, SimpleWandBLoggerCallback
+from neuralop.training.callbacks import Callback, SimpleWandBLoggerCallback, TransformCallback
 
 # query points is [sdf_query_resolution] * 3 (taken from config ahmed)
 
@@ -108,8 +108,6 @@ elif config.opt.testing_loss == 'weightedl2':
 else:
     raise ValueError(f'Got {config.opt.testing_loss=}')
 
-encoder_callback = OutputEncoderCallback(encoder=output_encoder)
-
 # Handle data preprocessing to FNOGNO as a Callback object
         
 class CFDDataPreprocessingCallback(Callback):
@@ -178,7 +176,7 @@ trainer = Trainer(model=model,
                   n_epochs=config.opt.n_epochs,
                   device=device,
                   callbacks=[
-                      encoder_callback,
+                      TransformCallback(output_encoder),
                       CFDDataPreprocessingCallback(),
                       SimpleWandBLoggerCallback(**wandb_init_args)
                   ]

--- a/scripts/train_cfd.py
+++ b/scripts/train_cfd.py
@@ -194,5 +194,3 @@ trainer.train(
               #eval_losses={config.opt.testing_loss: test_loss_fn, 'drag': DragLoss},
               eval_losses={config.opt.testing_loss: test_loss_fn},
               regularizer=None,)
-
-model = model.cpu()

--- a/scripts/train_cfd.py
+++ b/scripts/train_cfd.py
@@ -1,0 +1,203 @@
+import torch
+import wandb
+import sys
+from configmypy import ConfigPipeline, YamlConfig, ArgparseConfig
+from neuralop.training import setup
+from neuralop import get_model
+from neuralop.utils import get_wandb_api_key
+from neuralop.training.losses import IregularLpqLoss, WeightedL2DragLoss, SumAggregatorLoss
+from neuralop.training.trainer import Trainer
+from neuralop.datasets.mesh_datamodule import MeshDataModule
+from copy import deepcopy
+from neuralop.training.callbacks import NoPatchingOutputEncoderCallback, Callback
+
+# query points is [sdf_query_resolution] * 3 (taken from config ahmed)
+
+    
+# Read the configuration
+config_name = 'cfd'
+pipe = ConfigPipeline([YamlConfig('./cfd_config.yaml', config_name=config_name, config_folder='../config'),
+                       ArgparseConfig(infer_types=True, config_name=None, config_file=None),
+                       YamlConfig(config_folder='../config')
+                      ])
+config = pipe.read_conf()
+
+#Set-up distributed communication, if using
+device, is_logger = setup(config)
+
+if config.data.sdf_query_resolution < config.fnogno.fno_n_modes[0]:
+    config.fnogno.fno_n_modes = [config.data.sdf_query_resolution]*3
+
+# output indices follow form in train_ahmed
+output_indices = {k:tuple([slice(*tuple(x)) for x in v]) for k,v in config.data.output_indices.items()}
+
+# only some channels of output encoder's decoded data
+# are grabbed in train_ahmed original
+
+#Set up WandB logging
+config_name = 'dragloss'
+if config.wandb.log and is_logger:
+    wandb.login(key=get_wandb_api_key())
+    if config.wandb.name:
+        wandb_name = config.wandb.name
+    else:
+        wandb_name = '_'.join(
+            f'{var}' for var in [config_name, config.data.sdf_query_resolution])
+        
+    wandb.init(config=config, name=wandb_name, group=config.wandb.group,
+               project=config.wandb.project, entity=config.wandb.entity)
+    
+    if config.wandb.sweep:
+        for key in wandb.config.keys():
+            config.params[key] = wandb.config[key]
+
+#Load CFD body data
+data_module = MeshDataModule(config.data.path, 
+                             config.data.entity_name, 
+                             query_points=[config.data.sdf_query_resolution]*3, 
+                             n_train=config.data.n_train, 
+                             n_test=config.data.n_test, 
+                             attributes=config.data.load_attributes,
+                             )
+
+if config.wandb.log:
+    wandb.log({'time_to_distance': data_module.time_to_distance})
+
+train_loader = data_module.train_dataloader(batch_size=1, shuffle=True)
+test_loader = data_module.test_dataloader(batch_size=1, shuffle=False)
+
+model = get_model(config)
+model = model.to(device)
+
+#Create the optimizer
+optimizer = torch.optim.Adam(model.parameters(), 
+                                lr=config.opt.learning_rate, 
+                                weight_decay=config.opt.weight_decay)
+
+if config.opt.scheduler == 'ReduceLROnPlateau':
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, factor=config.opt.gamma, patience=config.opt.scheduler_patience, mode='min')
+elif config.opt.scheduler == 'CosineAnnealingLR':
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=config.opt.scheduler_T_max)
+elif config.opt.scheduler == 'StepLR':
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, 
+                                                step_size=config.opt.step_size,
+                                                gamma=config.opt.gamma)
+else:
+    raise ValueError(f'Got {config.opt.scheduler=}')
+
+output_encoder = deepcopy(data_module.normalizers['press']).to(device)
+
+if config.opt.training_loss == 'l2':
+    train_loss_fn = lambda x, y, z : torch.sqrt(torch.sum((x - y)**2) / torch.sum(y**2))
+elif config.opt.training_loss == 'weightedl2' or config.opt.training_loss == 'weightedl2drag':
+    drag_loss = WeightedL2DragLoss(device=device, mappings=output_indices)
+    train_loss_fn = SumAggregatorLoss(drag_loss, IregularLpqLoss())
+else:
+    raise ValueError(f'Got {config.opt.training_loss=}')
+
+# Handle Drag Error in validation separately for now
+DragLoss = WeightedL2DragLoss(mappings = output_indices, device=device)
+
+if config.opt.testing_loss == 'l2':
+    test_loss_fn = lambda x, y, z : torch.sqrt(torch.sum((x - y)**2) / torch.sum(y**2))
+elif config.opt.testing_loss == 'weightedl2':
+    test_loss_fn = IregularLpqLoss()
+else:
+    raise ValueError(f'Got {config.opt.testing_loss=}')
+
+encoder_callback = NoPatchingOutputEncoderCallback(encoder=output_encoder)
+
+# Handle data preprocessing to FNOGNO as a Callback object
+        
+class CFDDataPreprocessingCallback(Callback):
+    """
+    Implements logic to preprocess data/handle model outputs
+    to train an FNOGNO on the CFD car-pressure dataset
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def on_batch_start(self, idx, sample):
+        # Turn a data dictionary returned by MeshDataModule's DictDataset
+        # into the form expected by the FNOGNO
+        self.state_dict['sample'] = sample
+        device = self.state_dict.get('device', 'cpu')
+        in_p = sample['query_points'].squeeze(0).to(device)
+        out_p = sample['centroids'].squeeze(0).to(device)
+
+        f = sample['distance'].squeeze(0).to(device)
+
+        weights = sample['triangle_areas'].squeeze(0).to(device)
+
+        #Output data
+        truth = sample['press'].squeeze(0)
+        if len(truth.shape) == 1:
+            truth = truth.unsqueeze(-1)
+        
+        # for now, grab the first 3682 vertices of the output mesh to correspond to pressure
+        output_vertices = truth.shape[0]
+        if out_p.shape[0] > output_vertices:
+            out_p = out_p[:output_vertices,:]
+
+        truth = truth.to(device)
+
+
+        inward_normals = -sample['triangle_normals'].squeeze(0).to(device)
+        flow_normals = torch.zeros((sample['triangle_areas'].shape[1], 3)).to(device)
+        flow_normals[:,0] = -1.0
+
+        '''
+        The current cleaned CFD dataset doesn't contain these.
+        
+        Revisit when preprocessing again, as they are part of another
+        MeshDataModule dataset.
+
+        flow_speed = sample['info']['velocity'].item()
+        reference_w = sample['info']['width'].item()
+        reference_h = sample['info']['height'].item()
+        reference_area = (reference_w*reference_h/2) * 1e-6
+        '''
+
+
+        self.state_dict['sample'].update(in_p = in_p,
+                                         out_p=out_p,
+                                         f=f,
+                                         y=truth,
+                                         inward_normals=inward_normals,
+                                         flow_normals=flow_normals,
+                                         flow_speed=None,
+                                         vol_elm=weights,
+                                         reference_area=None)
+        
+    def compute_training_loss(self, *args, **kwargs):
+        loss_fn = self.state_dict['training_loss']
+        self._update_state_dict(**kwargs)
+        return loss_fn(x = self.state_dict['out'], y = self.state_dict['sample']['y'], z=None)
+
+    def on_val_batch_start(self, *args, **kwargs):
+        return self.on_batch_start(*args, **kwargs)
+    
+    def compute_val_loss(self, *args, **kwargs):
+        return self.compute_training_loss(self, *args, **kwargs)
+
+trainer = Trainer(model=model, 
+                  n_epochs=config.opt.n_epochs,
+                  device=device,
+                  callbacks=[
+                      encoder_callback,
+                      CFDDataPreprocessingCallback()
+                  ]
+                  )
+
+trainer.train(
+              train_loader=train_loader,
+              test_loaders={'':test_loader},
+              optimizer=optimizer,
+              scheduler=scheduler,
+              training_loss=train_loss_fn,
+              #eval_losses={config.opt.testing_loss: test_loss_fn, 'drag': DragLoss},
+              eval_losses={config.opt.testing_loss: test_loss_fn},
+              regularizer=None,)
+
+model = model.cpu()


### PR DESCRIPTION
A small PR to help ease the implementation of PINO-FDM on main. 


Adds a callback that converts a DictDataset of the form `{'x': x, 'y': y}` to the form expected by an FNOGNO. 