### PR TITLE
Updates to saving and loading models

### DIFF
--- a/neuralop/training/__init__.py
+++ b/neuralop/training/__init__.py
@@ -2,3 +2,4 @@ from .trainer import Trainer
 from .torch_setup import setup
 from .callbacks import (Callback, BasicLoggerCallback,
         CheckpointCallback)
+from .load_training_state import load_training_state

--- a/neuralop/training/load_training_state.py
+++ b/neuralop/training/load_training_state.py
@@ -1,0 +1,56 @@
+"""
+Snippet to load all artifacts of training state as Modules
+without constraining to use inside a default Trainer
+"""
+from typing import Union
+from pathlib import Path
+
+import torch
+from torch import nn
+
+
+def load_training_state(save_dir: Union[str, Path], save_name: str,
+                        model: nn.Module,
+                        optimizer: nn.Module = None,
+                        scheduler: nn.Module = None,
+                        regularizer: nn.Module = None) -> dict:
+    """load_training_state returns model and optional other training modules
+    saved from prior training for downstream use
+
+    Parameters
+    ----------
+    save_dir : Union[str, Path]
+        directory from which to load training state (model, optional optimizer, scheduler, regularizer)
+    save_name : str
+        name of model to load
+    """
+    training_state = {}
+
+    if isinstance(save_dir, str):
+        save_dir = Path(save_dir)
+    
+    training_state['model'] = model.from_checkpoint(save_dir, save_name)
+    
+    # load optimizer if state exists
+    if optimizer is not None:
+        optimizer_pth = save_dir / "optimizer.pt"
+        if optimizer_pth.exists():
+            training_state['optimizer'] = optimizer.load_state_dict(torch.load(optimizer_pth))
+        else:
+            print(f"Warning: requested to load optimizer state, but no saved optimizer state exists in {save_dir}.")
+    
+    if scheduler is not None:
+        scheduler_pth = save_dir / "scheduler.pt"
+        if scheduler_pth.exists():
+            training_state['scheduler'] = scheduler.load_state_dict(torch.load(scheduler_pth))
+        else:
+            print(f"Warning: requested to load scheduler state, but no saved scheduler state exists in {save_dir}.")
+    
+    if regularizer is not None:
+        regularizer_pth = save_dir / "regularizer.pt"
+        if regularizer_pth.exists():
+            training_state['regularizer'] = scheduler.load_state_dict(torch.load(regularizer_pth))
+        else:
+            print(f"Warning: requested to load regularizer state, but no saved regularizer state exists in {save_dir}.")
+    
+    return training_state

--- a/neuralop/training/tests/test_callbacks.py
+++ b/neuralop/training/tests/test_callbacks.py
@@ -27,7 +27,7 @@ class DummyModel(BaseModel, name='Dummy'):
     Simple linear model to mock-up our model API
     """
 
-    def __init__(self, features):
+    def __init__(self, features, **kwargs):
         super().__init__()
         self.net = nn.Linear(features, 1)
 
@@ -118,7 +118,7 @@ def test_model_checkpoint_and_resume():
                           ]
     )
 
-    trainer.train(train_loader=train_loader, 
+    errors = trainer.train(train_loader=train_loader, 
                   test_loaders={'': test_loader}, 
                   optimizer=optimizer,
                   scheduler=scheduler,
@@ -126,4 +126,55 @@ def test_model_checkpoint_and_resume():
                   training_loss=l2loss,
                   eval_losses=eval_losses,
                   )
+    
+    
+# ensure that model accuracy after loading from checkpoint
+# is comparable to accuracy at time of save
+def test_load_from_checkpoint():
+    model = DummyModel(50)
 
+    train_loader = DataLoader(DummyDataset(100))
+    test_loader = DataLoader(DummyDataset(20))
+
+    trainer = Trainer(model=model,
+                      n_epochs=5,
+                      callbacks=[
+                          CheckpointCallback(save_dir='./full_states',
+                                                  save_optimizer=True,
+                                                  save_scheduler=True,
+                                                  save_best='h1') # monitor h1 loss
+                      ]
+    )
+
+    optimizer = torch.optim.Adam(model.parameters(), 
+                                lr=8e-3, 
+                                weight_decay=1e-4)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=30)
+
+    # Creating the losses
+    l2loss = LpLoss(d=2, p=2)
+    h1loss = H1Loss(d=2)
+
+    eval_losses={'h1': h1loss, 'l2': l2loss}
+
+    orig_model_eval_errors = trainer.train(train_loader=train_loader, 
+                  test_loaders={'': test_loader}, 
+                  optimizer=optimizer,
+                  scheduler=scheduler,
+                  regularizer=None,
+                  training_loss=l2loss,
+                  eval_losses=eval_losses
+                  )
+    
+    # create a new model from saved checkpoint and evaluate
+    loaded_model = DummyModel.from_checkpoint(save_folder='./full_states', save_name='best_model')
+    trainer = Trainer(model=loaded_model,
+                      n_epochs=1,
+    )
+
+    loaded_model_eval_errors = trainer.evaluate(loss_dict=eval_losses,
+                              data_loader=test_loader)
+
+    # log prefix is empty except for default underscore
+    assert orig_model_eval_errors['_h1'] - loaded_model_eval_errors['_h1'] < 0.1
+    

--- a/neuralop/training/tests/test_callbacks.py
+++ b/neuralop/training/tests/test_callbacks.py
@@ -1,5 +1,6 @@
 import os
-import pytest
+import shutil
+
 import torch
 from torch import nn
 from torch.utils.data import Dataset, DataLoader
@@ -68,8 +69,10 @@ def test_model_checkpoint_saves():
                   eval_losses=None,
                   )
     
-    assert sorted(os.listdir('./checkpoints')) == sorted(['model_state_dict.pt', 'model_metadata.pkl', 'optimizer.pt', 'scheduler.pt'])
+    assert sorted(os.listdir('./test_checkpoints')) == sorted(['model_state_dict.pt', 'model_metadata.pkl', 'optimizer.pt', 'scheduler.pt'])
 
+    # clean up dummy checkpoint directory after testing
+    shutil.rmtree('./test_checkpoints')
 
 def test_model_checkpoint_and_resume():
     model = DummyModel(50)
@@ -127,6 +130,9 @@ def test_model_checkpoint_and_resume():
                   eval_losses=eval_losses,
                   )
     
+    # clean up dummy checkpoint directory after testing
+    shutil.rmtree('./full_states')
+
     
 # ensure that model accuracy after loading from checkpoint
 # is comparable to accuracy at time of save
@@ -177,4 +183,7 @@ def test_load_from_checkpoint():
 
     # log prefix is empty except for default underscore
     assert orig_model_eval_errors['_h1'] - loaded_model_eval_errors['_h1'] < 0.1
+
+    # clean up dummy checkpoint directory after testing
+    shutil.rmtree('./full_states')
     


### PR DESCRIPTION
This PR adds:
- improvement to `neuralop/training/tests/test_callbacks.py` that cleans up artifacts after saving checkpoints
- warning message when overwriting saves the first time a trainer saves to a checkpoint
- ability to load training states of modules outside of a trainer in `neuralop/training/load_training_state.py`