### PR TITLE
Small fix in  examples/plot_darcy_flow.py

### DIFF
--- a/examples/plot_darcy_flow.py
+++ b/examples/plot_darcy_flow.py
@@ -29,12 +29,12 @@ train_dataset = train_loader.dataset
 # Visualizing the data
 # --------------------
 
-
 for res, test_loader in test_loaders.items():
-    print('res')
-    test_data = train_dataset[0]
-    x = test_data['x']
-    y = test_data['y']
+    print(res)
+    # Get first batch
+    batch = next(iter(test_loader))
+    x = batch['x']
+    y = batch['y']
 
     print(f'Testing samples for res {res} have shape {x.shape[1:]}')
 


### PR DESCRIPTION
While going through an example I noticed some small issue. The fix does not change the result but only what gets printed, before the resolution was hard-coded to 'res' and the `test_data` was actually set to the `train_dataset[0]`. Now actual batches from the test_loaders and their resolution get printed.