### PR TITLE
Fixes a bug in plotting train error

### DIFF
--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -272,7 +272,7 @@ class BasicLoggerCallback(Callback):
     def on_before_val(self, epoch, train_err, time, avg_loss, avg_lasso_loss, **kwargs):
         # track training err and val losses to print at interval epochs
         msg = f'[{epoch}] time={time:.2f}, avg_loss={avg_loss:.4f}, train_err={train_err:.4f}'
-        values_to_log = dict(train_err=train_err / self.state_dict['n_train'], time=time, avg_loss=avg_loss)
+        values_to_log = dict(train_err=train_err, time=time, avg_loss=avg_loss)
 
         self._update_state_dict(msg=msg, values_to_log=values_to_log)
         self._update_state_dict(avg_lasso_loss=avg_lasso_loss)


### PR DESCRIPTION
 Train error was being divided for the second time by n_train in BasicLoggerCallback. This lead to smaller values in plots of train error on wandb plots.