### PR TITLE
sum losses before backward

### DIFF
--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -186,7 +186,7 @@ class Trainer:
                 if regularizer:
                     loss += regularizer.loss
                 
-                loss.backward()
+                loss.sum().backward()
                 del out
 
                 optimizer.step()

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -190,10 +190,10 @@ class Trainer:
                 del out
 
                 optimizer.step()
-                train_err += loss.item()
+                train_err += loss.sum().item()
         
                 with torch.no_grad():
-                    avg_loss += loss.item()
+                    avg_loss += loss.sum().item()
                     if regularizer:
                         avg_lasso_loss += regularizer.loss
 


### PR DESCRIPTION
When the number of output channels is higher than one, the loss.backward() will return an error.
This small fix makes sure that this doesn't happen by calling loss.sum().backward() to make it compatible to multiple outputs