### PR TITLE
Deepcopy base model

### DIFF
--- a/.github/workflows/deploy_pypi.yml
+++ b/.github/workflows/deploy_pypi.yml
@@ -30,8 +30,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
-          python -m pip install torch_scatter torch_cluster -f https://data.pyg.org/whl/torch-2.0.0+cpu.html
       - name: Install package
         run: |
           python -m pip install -e .

--- a/.github/workflows/deploy_pypi.yml
+++ b/.github/workflows/deploy_pypi.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
+          python -m pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Install package
         run: |
           python -m pip install -e .

--- a/neuralop/models/base_model.py
+++ b/neuralop/models/base_model.py
@@ -76,6 +76,16 @@ class BaseModel(torch.nn.Module):
         instance._init_kwargs = kwargs
 
         return instance
+
+    def __deepcopy__(self, memo):
+        """
+        Custom deepcopy method returns model arch and copies the state
+        """
+        cls_init_kwargs = self._init_kwargs
+        new_instance = self.__class__(**cls_init_kwargs)
+        new_instance.load_state_dict(self.state_dict())
+        return new_instance
+
     
     def save_checkpoint(self, save_folder, save_name):
         """Saves the model state and init param in the given folder under the given name


### PR DESCRIPTION
The models in `neuralop.models` subclass `neuralop.models.BaseModel`, which adds lots of useful functionality but does not implement the `__deepcopy__` method necessary to copy a torch module's architecture and state. This PR adds a method to do that.