### PR TITLE
Fix docstring for `SpectralConv`

### DIFF
--- a/neuralop/layers/spectral_convolution.py
+++ b/neuralop/layers/spectral_convolution.py
@@ -187,11 +187,11 @@ class SpectralConv(BaseSpectralConv):
 
     Parameters
     ----------
-    in_channels : int, optional
+    in_channels : int
         Number of input channels
-    out_channels : int, optional
+    out_channels : int
         Number of output channels
-    max_n_modes : None or int tuple, default is None
+    n_modes : int or int tuple
         Number of modes to use for contraction in Fourier domain during training.
  
         .. warning::


### PR DESCRIPTION
Fixed 3 entries for the docstring of `SpectralConv` (`in_channels`, `out_channels`, `n_modes`) 

- There were 2 entries both called `max_n_modes` where the first one should've been `n_modes`.
- Removed the 'optional' (and default args) since they are not defined with any default arguments in the `__init__` function.