### PR TITLE
Fix numerical instability in  `UnitGaussianNormalizer`

### DIFF
--- a/neuralop/datasets/output_encoder.py
+++ b/neuralop/datasets/output_encoder.py
@@ -182,7 +182,7 @@ class UnitGaussianNormalizer(Transform):
         self.mean = (1.0 / (self.n_elements + n_elements)) * (
             self.n_elements * self.mean + torch.sum(data_batch, dim=dim, keepdim=True)
         )
-        self.squared_mean = (1.0 / (self.n_elements + n_elements - 1)) * (
+        self.squared_mean = (1.0 / (self.n_elements + n_elements)) * (
             self.n_elements * self.squared_mean
             + torch.sum(data_batch**2, dim=dim, keepdim=True)
         )

--- a/neuralop/datasets/tests/test_output_encoder.py
+++ b/neuralop/datasets/tests/test_output_encoder.py
@@ -1,49 +1,57 @@
 from ..output_encoder import UnitGaussianNormalizer
 import torch
 from torch.testing import assert_close
+from flaky import flaky
 
-
-def test_UnitGaussianNormalizer():
-    x = torch.rand(4, 3, 4, 5, 6)*2.5
+@flaky(max_runs=4, min_passes=3)
+def test_UnitGaussianNormalizer_created_from_stats(eps=1e-6):
+    x = torch.rand(16, 3, 40, 50, 60)*2.5
     mean = torch.mean(x, dim=[0, 2, 3, 4], keepdim=True)
     std = torch.std(x, dim=[0, 2, 3, 4], keepdim=True)
 
     # Init normalizer with ground-truth mean and std
-    normalizer = UnitGaussianNormalizer(mean=mean, std=std)
+    normalizer = UnitGaussianNormalizer(mean=mean, std=std, eps=eps)
     x_normalized = normalizer.transform(x)
     x_unnormalized = normalizer.inverse_transform(x_normalized)
 
-    eps = 1e-5
     assert_close(x_unnormalized, x)
     assert torch.mean(x_normalized) <= eps
     assert (torch.std(x_normalized) - 1) <= eps
 
+@flaky(max_runs=4, min_passes=3)
+def test_UnitGaussianNormalizer_from_data(eps=1e-6):
+    x = torch.rand(16, 3, 40, 50, 60)*2.5
+    mean = torch.mean(x, dim=[0, 2, 3, 4], keepdim=True)
+    std = torch.std(x, dim=[0, 2, 3, 4], keepdim=True)   
     # Init by fitting whole data at once
-    normalizer = UnitGaussianNormalizer(dim=[0, 2, 3, 4])
+    normalizer = UnitGaussianNormalizer(dim=[0, 2, 3, 4], eps=eps)
     normalizer.fit(x)
     x_normalized = normalizer.transform(x)
     x_unnormalized = normalizer.inverse_transform(x_normalized)
 
-    eps = 1e-3
     assert_close(x_unnormalized, x)
     assert torch.mean(x_normalized) <= eps
     assert (torch.std(x_normalized) - 1) <= eps
 
     assert_close(normalizer.mean, mean)
-    assert_close(normalizer.std, std, rtol=1e-3, atol=1e-3)
+    assert_close(normalizer.std, std, rtol=eps, atol=eps)
 
+@flaky(max_runs=4, min_passes=3)
+def test_UnitGaussianNormalizer_incremental_update(eps=1e-6):
+    x = torch.rand(16, 3, 40, 50, 60)*2.5
+    mean = torch.mean(x, dim=[0, 2, 3, 4], keepdim=True)
+    std = torch.std(x, dim=[0, 2, 3, 4], keepdim=True)   
     # Incrementally compute mean and var
-    normalizer = UnitGaussianNormalizer(dim=[0, 2, 3, 4])
+    normalizer = UnitGaussianNormalizer(dim=[0, 2, 3, 4], eps=eps)
     normalizer.partial_fit(x, batch_size=2)
     x_normalized = normalizer.transform(x)
     x_unnormalized = normalizer.inverse_transform(x_normalized)
 
-    eps = 1e-3
     assert_close(x_unnormalized, x)
     assert torch.mean(x_normalized) <= eps
     assert (torch.std(x_normalized) - 1) <= eps
 
     assert_close(normalizer.mean, mean)
     print(normalizer.std, std)
-    assert_close(normalizer.std, std, rtol=1e-2, atol=1e-2)
+    assert_close(normalizer.std, std, rtol=eps, atol=eps)
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,2 @@
+pytest
+flaky

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ config = {
         {'name': "Zongyi Li", 'email': "zongyili@caltech.edu"}
         ],
     'version': VERSION,
-    'install_requires': ['numpy', 'configmypy', 'pytest', 'black', 'tensorly', 'tensorly-torch', 'opt-einsum'],
+    'install_requires': ['numpy', 'configmypy', 'pytest', 'flaky', 'black', 'tensorly', 'tensorly-torch', 'opt-einsum'],
     'license': 'Modified BSD',
     'scripts': [],
     'include_package_data': True,


### PR DESCRIPTION
One small bug fix to `UnitGaussianNormalizer` and more granular, flaky tests. Also adds the `pytest` plug-in `flaky` to requirements.