### PR TITLE
Improve docstrings and comments for FNO + FNO block

### DIFF
--- a/neuralop/layers/fno_block.py
+++ b/neuralop/layers/fno_block.py
@@ -167,7 +167,7 @@ class FNOBlocks(nn.Module):
         else:
             raise ValueError(
                 f"Got norm={norm} but expected None or one of "
-                "[instance_norm, group_norm, layer_norm]"
+                "[instance_norm, group_norm, ada_in]"
             )
 
     def set_ada_in_embeddings(self, *embeddings):

--- a/neuralop/layers/fno_block.py
+++ b/neuralop/layers/fno_block.py
@@ -15,6 +15,79 @@ Number = Union[int, float]
 
 
 class FNOBlocks(nn.Module):
+    """FNOBlocks implements a sequence of Fourier layers
+    as described in "Fourier Neural Operator for Parametric
+    Partial Differential Equations (Li et al., 2021).
+
+    Parameters
+    ----------
+    Parameters
+        ----------
+        in_channels : int
+            input channels to Fourier layers
+        out_channels : int
+            output channels after Fourier layers
+        n_modes : int, List[int]
+            number of modes to keep along each dimension 
+            in frequency space. Can either be specified as
+            an int (for all dimensions) or an iterable with one
+            number per dimension
+        output_scaling_factor : Optional[Union[Number, List[Number]]], optional
+            factor by which to scale outputs for super-resolution, by default None
+        n_layers : int, optional
+            number of Fourier layers to apply in sequence, by default 1
+        max_n_modes : int, List[int], optional
+            maximum number of modes to keep along each dimension, by default None
+        fno_block_precision : str, optional
+            floating point precision to use for computations, by default "full"
+        use_mlp : bool, optional
+            whether to use mlp layers to parameterize skip connections, by default False
+        mlp_dropout : int, optional
+            dropout parameter for self.mlp, by default 0
+        mlp_expansion : float, optional
+            expansion parameter for self.mlp, by default 0.5
+        non_linearity : torch.nn.F module, optional
+            nonlinear activation function to use between layers, by default F.gelu
+        stabilizer : Literal["tanh"], optional
+            stabilizing module to use between certain layers, by default None
+            if "tanh", use tanh
+        norm : Literal["ada_in", "group_norm", "instance_norm"], optional
+        Normalization layer to use, by default None
+        ada_in_features : int, optional
+            number of features for adaptive instance norm above, by default None
+        preactivation : bool, optional
+            whether to call forward pass with pre-activation, by default False
+            if True, call nonlinear activation and norm before Fourier convolution
+            if False, call activation and norms after Fourier convolutions
+        fno_skip : str, optional
+            module to use for FNO skip connections, by default "linear"
+            see layers.skip_connections for more details
+        mlp_skip : str, optional
+            module to use for MLP skip connections, by default "soft-gating"
+            see layers.skip_connections for more details
+
+        SpectralConv Params
+        -------------------
+        separable : bool, optional
+            separable parameter for SpectralConv, by default False
+        factorization : str, optional
+            factorization parameter for SpectralConv, by default None
+        rank : float, optional
+            rank parameter for SpectralConv, by default 1.0
+        SpectralConv : BaseConv, optional
+            module to use for SpectralConv, by default SpectralConv
+        joint_factorization : bool, optional
+            whether to factorize all spectralConv weights as one tensor, by default False
+        fixed_rank_modes : bool, optional
+            fixed_rank_modes parameter for SpectralConv, by default False
+        implementation : str, optional
+            implementation parameter for SpectralConv, by default "factorized"
+        decomposition_kwargs : _type_, optional
+            kwargs for tensor decomposition in SpectralConv, by default dict()
+        fft_norm : str, optional
+            how to normalize discrete fast Fourier transform, by default "forward"
+            if "forward", normalize just the forward direction F(v(x)) by 1/n (number of total modes)
+    """
     def __init__(
         self,
         in_channels,
@@ -94,6 +167,7 @@ class FNOBlocks(nn.Module):
             n_layers=n_layers,
         )
 
+        # FNO
         self.fno_skips = nn.ModuleList(
             [
                 skip_connection(
@@ -193,9 +267,12 @@ class FNOBlocks(nn.Module):
             return self.forward_with_postactivation(x, index, output_shape)
 
     def forward_with_postactivation(self, x, index=0, output_shape=None):
+
+        # W(v(x)) from Fig.2 (b) of Li et al., 2021
         x_skip_fno = self.fno_skips[index](x)
         x_skip_fno = self.convs[index].transform(x_skip_fno, output_shape=output_shape)
 
+        # MLP parameterization of W(v(x)) Fig.2 (b) of Li et al., 2021
         if self.mlp is not None:
             x_skip_mlp = self.mlp_skips[index](x)
             x_skip_mlp = self.convs[index].transform(x_skip_mlp, output_shape=output_shape)
@@ -203,13 +280,17 @@ class FNOBlocks(nn.Module):
         if self.stabilizer == "tanh":
             x = torch.tanh(x)
 
+        # F^{-1} (R * F(v(x))) from Fig.2 (b) of Li et al., 2021
+        # for more details see layers.spectral_convolution.py
         x_fno = self.convs(x, index, output_shape=output_shape)
 
         if self.norm is not None:
             x_fno = self.norm[self.n_norms * index](x_fno)
 
+        # W(v(x)) + F^{-1} (R * F(v(x)))
         x = x_fno + x_skip_fno
 
+        # σ(x) from Li et al., 2021
         if (self.mlp is not None) or (index < (self.n_layers - 1)):
             x = self.non_linearity(x)
 
@@ -231,20 +312,27 @@ class FNOBlocks(nn.Module):
 
         if self.norm is not None:
             x = self.norm[self.n_norms * index](x)
-
+        
+        # W(v(x)) from Fig.2 (b) of Li et al., 2021
         x_skip_fno = self.fno_skips[index](x)
         x_skip_fno = self.convs[index].transform(x_skip_fno, output_shape=output_shape)
-
+        
+        # MLP parameterization of W(v(x)) from Fig.2 (b) of Li et al., 2021
         if self.mlp is not None:
             x_skip_mlp = self.mlp_skips[index](x)
             x_skip_mlp = self.convs[index].transform(x_skip_mlp, output_shape=output_shape)
 
         if self.stabilizer == "tanh":
             x = torch.tanh(x)
-
+        
+        # F^{-1} (R * F(v(x))) from Fig.2 (b) of Li et al., 2021
+        # for more details see layers.spectral_convolution.py
         x_fno = self.convs(x, index, output_shape=output_shape)
-        x = x_fno + x_skip_fno
 
+        # W(v(x)) + F^{-1} (R * F(v(x)))
+        x = x_fno + x_skip_fno
+        
+        # σ(x) from Li et al., 2021
         if self.mlp is not None:
             if index < (self.n_layers - 1):
                 x = self.non_linearity(x)

--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -229,7 +229,9 @@ class FNO(BaseModel, name='FNO'):
         )
 
     def forward(self, x, output_shape=None, **kwargs):
-        """TFNO's forward pass
+        """FNO's forward pass. Documentation here will correspond to
+        operations outlined in Fig. 2 of "Fourier Neural Operator for
+        Parametric Partial Differential Equations" (Li et al., 2021).
 
         Parameters
         ----------
@@ -247,17 +249,21 @@ class FNO(BaseModel, name='FNO'):
         elif isinstance(output_shape, tuple):
             output_shape = [None]*(self.n_layers - 1) + [output_shape]
 
+        # P(a(x)) from Fig.2 (a) of Li et al., 2021
         x = self.lifting(x)
 
         if self.domain_padding is not None:
             x = self.domain_padding.pad(x)
 
+        # Block architecture outlined in Fig.2 (b) of Li et al., 2021
+        # for more detailed documentation see neuralop.layers.fno_block.py
         for layer_idx in range(self.n_layers):
             x = self.fno_blocks(x, layer_idx, output_shape=output_shape[layer_idx])
 
         if self.domain_padding is not None:
             x = self.domain_padding.unpad(x)
-
+        
+        # Q(v(x)) from Fig.2 (a) of Li et al., 2021
         x = self.projection(x)
 
         return x

--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -52,7 +52,7 @@ class FNO(BaseModel, name='FNO'):
         expansion parameter of MLP layer, by default 0.5
     non_linearity : nn.Module, optional
         Non-Linearity module to use, by default F.gelu
-    norm : F.module, optional
+    norm : Literal["ada_in", "group_norm", "instance_norm"], optional
         Normalization layer to use, by default None
     preactivation : bool, default is False
         if True, use resnet-style preactivation


### PR DESCRIPTION
Adds explicit correspondence to "Fourier Neural Operator for Parameteric Partial Differential Equations (Li et al., 2021). Also fixes #326 and adds a full init docstring to `FNOBlocks`.