### PR TITLE
Update BasicLoggerCallback to function in more situations (eval-only, when `Trainer.verbose=True` but no callbacks passed)

### DIFF
--- a/neuralop/__init__.py
+++ b/neuralop/__init__.py
@@ -4,5 +4,5 @@ from .models import TFNO3d, TFNO2d, TFNO1d, TFNO
 from .models import get_model
 from .data import datasets, transforms
 from . import mpu
-from .training import Trainer, CheckpointCallback, IncrementalCallback
+from .training import Trainer
 from .losses import LpLoss, H1Loss, BurgersEqnLoss, ICLoss, WeightedSumLoss

--- a/neuralop/training/tests/test_callbacks.py
+++ b/neuralop/training/tests/test_callbacks.py
@@ -174,7 +174,7 @@ def test_load_from_checkpoint():
     eval_losses={'h1': h1loss, 'l2': l2loss}
 
     orig_model_eval_errors = trainer.train(train_loader=train_loader, 
-                  test_loaders={'': test_loader}, 
+                  test_loaders={'orig': test_loader}, 
                   optimizer=optimizer,
                   scheduler=scheduler,
                   regularizer=None,
@@ -189,10 +189,11 @@ def test_load_from_checkpoint():
     )
 
     loaded_model_eval_errors = trainer.evaluate(loss_dict=eval_losses,
-                              data_loader=test_loader)
+                                                data_loader=test_loader,
+                                                log_prefix="ckpt")
 
     # log prefix is empty except for default underscore
-    assert orig_model_eval_errors['_h1'] - loaded_model_eval_errors['_h1'] < 0.1
+    assert orig_model_eval_errors['orig_h1'] - loaded_model_eval_errors['ckpt_h1'] < 0.1
 
     # clean up dummy checkpoint directory after testing
     shutil.rmtree('./full_states')
@@ -223,7 +224,8 @@ def test_logger():
     eval_losses={'h1': h1loss, 'l2': l2loss}
 
     pre_train_errors = trainer.evaluate(loss_dict=eval_losses,
-                                        data_loader=test_loader)
+                                        data_loader=test_loader, 
+                                        log_prefix="default")
 
 # enure that the model incrementally increases in frequency modes
 def test_incremental():

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -3,7 +3,7 @@ from torch.cuda import amp
 from timeit import default_timer
 import pathlib
 
-from .callbacks import PipelineCallback
+from .callbacks import BasicLoggerCallback, PipelineCallback
 import neuralop.mpu.comm as comm
 from neuralop.losses import LpLoss
 
@@ -46,6 +46,10 @@ class Trainer:
         verbose : bool, default is False
         """
 
+        if not callbacks and log_output:
+             # no wandb logging is performed unless wandb kwargs are explicitly passed
+             # into the BasicLoggerCallback created at trainer instantiation. 
+            callbacks = [BasicLoggerCallback()]
         if callbacks:
             assert isinstance(
                 callbacks, list
@@ -61,8 +65,8 @@ class Trainer:
             self.overrides_loss = False
 
         if verbose:
-            print(f"{self.override_load_to_device=}")
-            print(f"{self.overrides_loss=}")
+            print(f"Override default load_to_device method: {self.override_load_to_device}")
+            print(f"Override default loss computation: {self.overrides_loss}")
 
         if self.callbacks:
             self.callbacks.on_init_start(

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -46,7 +46,7 @@ class Trainer:
         verbose : bool, default is False
         """
 
-        if not callbacks and log_output:
+        if not callbacks and verbose:
              # no wandb logging is performed unless wandb kwargs are explicitly passed
              # into the BasicLoggerCallback created at trainer instantiation. 
             callbacks = [BasicLoggerCallback()]

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -244,9 +244,9 @@ class Trainer:
                         avg_loss=avg_loss,
                         avg_lasso_loss=avg_lasso_loss,
                     )
-
+                errors = {}
                 for loader_name, loader in test_loaders.items():
-                    errors = self.evaluate(eval_losses, loader, log_prefix=loader_name)
+                    errors.update(**self.evaluate(eval_losses, loader, log_prefix=loader_name))
 
                 if self.callbacks:
                     self.callbacks.on_val_end()
@@ -284,7 +284,6 @@ class Trainer:
         self.model.eval()
 
         errors = {f"{log_prefix}_{loss_name}": 0 for loss_name in loss_dict.keys()}
-
         n_samples = 0
         with torch.no_grad():
             for idx, sample in enumerate(data_loader):
@@ -332,5 +331,4 @@ class Trainer:
             self.callbacks.on_val_epoch_end(errors=errors, sample=sample, out=out)
 
         del out
-
         return errors


### PR DESCRIPTION
#284 mentions that logging no longer happens by default because we moved logging to Callbacks. I think a default logging callback would be useful