### PR TITLE
Better docs for Callbacks

### DIFF
--- a/doc/source/user_guide/training.rst
+++ b/doc/source/user_guide/training.rst
@@ -14,7 +14,9 @@ provide a :code:`Trainer` class that automates much of this boilerplate logic.
 Things like loading a model to device, zeroing gradients and computing most loss 
 functions are taken care of.
 
-If you need to implement more domain-specific training logic, we also expose an
+Callbacks
+==========
+If you need to implement more domain-specific training logic within a trainer, we also expose an
 interface for stateful Callbacks that trigger events and track information
 throughout the lifetime of your Trainer. Each callback implements a series of 
 methods that are automatically called throughout the training loop, and you
@@ -36,7 +38,6 @@ so all you need to do on a multi-GPU system is the following:
 
 You may need to adjust the batch size, model parallel size and world size in 
 accordance with your specific use case. 
-
 
  
 

--- a/examples/plot_incremental_FNO_darcy.py
+++ b/examples/plot_incremental_FNO_darcy.py
@@ -1,5 +1,5 @@
 """
-Training a neural operator on Darcy-Flow - Author Robert Joseph George
+Training an Incremental FNO on Darcy Flow
 ========================================
 In this example, we demonstrate how to use the small Darcy-Flow example we ship with the package on Incremental FNO and Incremental Resolution
 """

--- a/examples/plot_sample_callbacks.py
+++ b/examples/plot_sample_callbacks.py
@@ -1,0 +1,97 @@
+"""
+Callbacks in the Trainer module
+=============================
+
+In this example, we demonstrate how to use Callbacks to configure
+domain-specific logic within the training loop of a Trainer.
+"""
+
+# %%
+# 
+import torch
+import matplotlib.pyplot as plt
+import sys
+from neuralop.models import TFNO
+from neuralop import Trainer
+from neuralop.training import Callback
+from neuralop.data.datasets import load_darcy_flow_small
+from neuralop.utils import count_model_params
+from neuralop import LpLoss, H1Loss
+
+device = 'cpu'
+
+
+# %%
+"""
+Let's set up the Trainer as before to train a TFNO on the small Darcy Flow dataset:
+"""
+# Loading the Navier-Stokes dataset in 128x128 resolution
+train_loader, test_loaders, data_processor = load_darcy_flow_small(
+        n_train=300, batch_size=32, 
+        test_resolutions=[16, 32], n_tests=[100, 50],
+        test_batch_sizes=[32, 32],
+)
+
+# %%
+# Create the model, optimizer, scheduler, and loss functions as before
+model = TFNO(n_modes=(16, 16), hidden_channels=32, projection_channels=64, factorization='tucker', rank=0.42)
+model = model.to(device)
+
+optimizer = torch.optim.Adam(model.parameters(), lr=8e-3, weight_decay=1e-4)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=30)
+
+l2loss = LpLoss(d=2, p=2)
+h1loss = H1Loss(d=2)
+train_loss = h1loss
+eval_losses={'h1': h1loss, 'l2': l2loss}
+
+# %%
+# Now, let's look at Callbacks in more depth. The Trainer class takes a list of Callback objects at creation time. These Callbacks allow you to keep track of the training state and implement more domain-specific behavior within the Trainer's automated loops.
+
+# %%
+# Let's start with a simple Callback that just prints to stdout at the beginning and end of each training epoch.
+
+# %% 
+class EpochPrintCallback(Callback):
+    """EpochPrintCallback is a simple callback that 
+       just prints out to the stdout at the start of each epoch.
+    """
+    def __init__(self):
+        super().__init__()
+
+    def on_epoch_start(self, epoch, *args, **kwargs):
+        self._update_state_dict(epoch=epoch) # update the Callback's internal state
+        print(f"Starting epoch {epoch}")
+        return
+    
+    def on_epoch_end(self, *args, **kwargs):
+        # the epoch persists as part of the Callback's state
+        print(f"Finishing epoch {self.state_dict['epoch']}")
+        return
+
+# Create the trainer
+trainer = Trainer(model=model, n_epochs=5,
+                  device=device,
+                  callbacks=[
+                    EpochPrintCallback()
+                        ],
+                  data_processor=data_processor,
+                  wandb_log=False,
+                  log_test_interval=1,
+                  use_distributed=False,
+                  verbose=True)
+
+
+# %%
+# Let's train the model and see what our callback outputs.
+
+trainer.train(train_loader=train_loader,
+              test_loaders={},
+              
+              optimizer=optimizer,
+              scheduler=scheduler, 
+              regularizer=False, 
+              training_loss=train_loss)
+
+# %%
+# We did that without modifying the trainer code at all! Callbacks also have access to the entire training state (model, optimizer, scheduler) through the arguments passed to them over the course of training. This enables all sorts of user-defined complex behavior. Take a look at the Incremental-FNO example for an example!

--- a/examples/sample_callbacks.py
+++ b/examples/sample_callbacks.py
@@ -1,0 +1,120 @@
+"""
+Callbacks in the Trainer module
+=============================
+
+In this example, we demonstrate how to use Callbacks to configure
+domain-specific logic within the training loop of a Trainer.
+"""
+
+# %%
+# 
+import torch
+import matplotlib.pyplot as plt
+import sys
+from neuralop.models import TFNO
+from neuralop import Trainer
+from neuralop.training import Callback
+from neuralop.data.datasets import load_darcy_flow_small
+from neuralop.utils import count_model_params
+from neuralop import LpLoss, H1Loss
+
+device = 'cpu'
+
+
+# %%
+"""
+Let's set up the Trainer as before to train a TFNO on the small Darcy Flow dataset:
+"""
+# Loading the Navier-Stokes dataset in 128x128 resolution
+train_loader, test_loaders, data_processor = load_darcy_flow_small(
+        n_train=1000, batch_size=32, 
+        test_resolutions=[16, 32], n_tests=[100, 50],
+        test_batch_sizes=[32, 32],
+)
+
+
+# %%
+# We create a tensorized FNO model
+
+model = TFNO(n_modes=(16, 16), hidden_channels=32, projection_channels=64, factorization='tucker', rank=0.42)
+model = model.to(device)
+
+n_params = count_model_params(model)
+print(f'\nOur model has {n_params} parameters.')
+sys.stdout.flush()
+
+
+# %%
+#Create the optimizer
+optimizer = torch.optim.Adam(model.parameters(), 
+                                lr=8e-3, 
+                                weight_decay=1e-4)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=30)
+
+
+# %%
+# Creating the losses
+l2loss = LpLoss(d=2, p=2)
+h1loss = H1Loss(d=2)
+
+train_loss = h1loss
+eval_losses={'h1': h1loss, 'l2': l2loss}
+
+# %%
+"""
+Now, let's look at Callbacks in more depth.
+
+The Trainer class takes a list of Callback objects at creation time. These Callbacks
+allow you to keep track of the training state and implement more domain-specific behavior 
+within the Trainer's automated loops.
+
+Each callback is triggered at the following points 
+"""
+# %% 
+# Create the trainer
+trainer = Trainer(model=model, n_epochs=20,
+                  device=device,
+                  callbacks=[
+                    CheckpointCallback(save_dir='./checkpoints',
+                                       save_interval=10,
+                                            save_optimizer=True,
+                                            save_scheduler=True)
+                        ],
+                  data_processor=data_processor,
+                  wandb_log=False,
+                  log_test_interval=3,
+                  use_distributed=False,
+                  verbose=True)
+
+
+# %%
+# Actually train the model on our small Darcy-Flow dataset
+
+trainer.train(train_loader=train_loader,
+              test_loaders={},
+              optimizer=optimizer,
+              scheduler=scheduler, 
+              regularizer=False, 
+              training_loss=train_loss)
+
+
+# resume training from saved checkpoint at epoch 10
+
+trainer = Trainer(model=model, n_epochs=20,
+                  device=device,
+                  data_processor=data_processor,
+                  callbacks=[
+                    CheckpointCallback(save_dir='./new_checkpoints',
+                                            resume_from_dir='./checkpoints/ep_10')
+                        ],             
+                  wandb_log=False,
+                  log_test_interval=3,
+                  use_distributed=False,
+                  verbose=True)
+
+trainer.train(train_loader=train_loader,
+              test_loaders={},
+              optimizer=optimizer,
+              scheduler=scheduler, 
+              regularizer=False, 
+              training_loss=train_loss)

--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -27,7 +27,52 @@ class Callback(object):
         update it throughout the lifetime of a Trainer class.
         Storing the state as a dict enables the Callback to keep track of
         references to underlying parts of the Trainer's process, such as
-        models, cost functions and output encoders
+        models, cost functions and output encoders.
+
+    Callbacks provide the following methods, each of which is triggered
+        at the corresponding point within the lifespan \
+        of a Trainer to which it is passed:
+    1. At the beginning of Trainer.__init__ (on_init_start)
+
+    2. At the end of Trainer.__init__ (on_init_end)
+
+    #### Inside Trainer.train() ####
+    3. At the beginning of the training loop (on_before_train, on_train_start)
+
+    4. At the beginning of each epoch loop (on_epoch_start)
+
+    5. At the beginning of each batch loop (on_batch_start)
+
+    6. Loading data to the proper device (on_load_to_device)
+
+    7. Before the model's forward call (on_before_forward)
+
+    8. Before computing training loss (on_before_loss)
+
+    9. Computing training loss (compute_training_loss)
+
+    10. At the end of the batch loop (on_batch_end)
+
+    11. At the end of the epoch loop (on_epoch_end)
+
+    12. At the end of the training loop (on_train_end)
+
+    #### Inside trainer.evaluate() ####
+    13. At the beginning of the eval loop (on_before_val)
+
+    14. At the beginning of the eval epoch loop (on_val_epoch_start)
+
+    15. At the beginning of the eval batch loop (on_val_batch_start)
+
+    16. Before computing eval loss (on_before_val_loss)
+
+    17. Computing eval loss (compute_val_loss)
+
+    18. At the end of the eval batch loop (on_val_batch_end)
+
+    19. At the end of the val epoch loop (on_val_epoch_end)
+
+    20. At the end of the val loop (on_val_end)
     """
 
     def __init__(self):
@@ -101,6 +146,7 @@ class Callback(object):
 
 
 class PipelineCallback(Callback):
+
     def __init__(self, callbacks: List[Callback]):
         """
         PipelineCallback handles logic for the case in which

--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -72,7 +72,7 @@ class Callback(object):
 
     19. At the end of the val epoch loop (on_val_epoch_end)
 
-    20. At the end of the val loop (on_val_end)
+    20. At the end of the val loop gi(on_val_end)
     """
 
     def __init__(self):


### PR DESCRIPTION
Improves docstring for `Callback` in `neuralop.training.callbacks.py` and adds a small example to showcase the simplest case of a Callback in training. Also fixes formatting for the IFNO example to be in line with the others (maybe we should update the website to credit all authors of examples/code)