### PR TITLE
Make test resolution error message consistent with conditional and fix test resolution size in docs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -82,7 +82,7 @@ To import the data:
 
    train_loader, test_loaders, data_processor = load_darcy_flow_small(
         n_train=1000, batch_size=32, 
-        test_resolutions=[32], n_tests=[100],
+        test_resolutions=[16], n_tests=[100],
         test_batch_sizes=[32],
         positional_encoding=True
 )

--- a/neuralop/data/datasets/darcy.py
+++ b/neuralop/data/datasets/darcy.py
@@ -52,7 +52,7 @@ def load_darcy_flow_small(
     for res in test_resolutions:
         if res not in [16, 32]:
             raise ValueError(
-                f"Only 32 and 64 are supported for test resolution, "
+                f"Only 16 and 32 are supported for test resolution, "
                 f"but got test_resolutions={test_resolutions}"
             )
     path = Path(__file__).resolve().parent.joinpath("data")


### PR DESCRIPTION
This PR addresses what I believe to be 2 bugs with the `test_resolutions` parameter of `load_darcy_flow_small`. 

Firstly, the conditional is `if res not in [16, 32]:` but the error message says `Only 32 and 64 are supported for test resolution`, which is inconsistent with the check. 

Second, in the docs, if you run the `load_darcy_flow_small` function with `test_resolutions=[32]`, it outputs the stack 

```
  File "/opt/homebrew/anaconda3/lib/python3.11/site-packages/neuralop/datasets/darcy.py", line 101, in load_darcy_pt
    idx = test_resolutions.index(train_resolution)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: 16 is not in list
```

which I think(?) is an index out of bounds error - so I changed the resolution to 16 so the example in the docs would actually work. 