### PR TITLE
`WeightedSumLoss` compatible with standard `Trainer`, migrate callbacks to stateless

### DIFF
--- a/neuralop/losses/meta_losses.py
+++ b/neuralop/losses/meta_losses.py
@@ -147,13 +147,15 @@ class SumLossOutput(dict):
         return self.sum().item()
 
     def backward(self):
-        self.sum()
-        self.sum_value.backward()
-        print(self)
+        self.sum().backward()
+        #self.sum_value
+        #print(self)
     
     def _log_tensors(self):
         for name, value in self.losses.items():
             print(f"{name=} {value=}")
+        if self.out_sum:
+            print(self.sum_value)
     
     def __format__(self, format_spec):
         msg = 'SumLoss['

--- a/neuralop/training/__init__.py
+++ b/neuralop/training/__init__.py
@@ -1,5 +1,5 @@
 from .trainer import Trainer
 from .torch_setup import setup
-from .callbacks import (Callback, BasicLoggerCallback,
+from .callbacks import (Callback,
         CheckpointCallback, IncrementalCallback)
 from .training_state import load_training_state, save_training_state

--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -22,19 +22,10 @@ class Callback(object):
     """
     Base callback class. Each abstract method is called in the trainer's
     training loop at the appropriate time.
-
-    Callbacks are stateful, meaning they keep track of a state and
-        update it throughout the lifetime of a Trainer class.
-        Storing the state as a dict enables the Callback to keep track of
-        references to underlying parts of the Trainer's process, such as
-        models, cost functions and output encoders
     """
 
     def __init__(self):
-        self.state_dict = {}
-
-    def _update_state_dict(self, **kwargs):
-        self.state_dict.update(kwargs)
+        pass
 
     def on_init_start(self, **kwargs):
         pass
@@ -234,92 +225,6 @@ class PipelineCallback(Callback):
     def on_val_end(self, *args, **kwargs):
         for c in self.callbacks:
             c.on_val_end(*args, **kwargs)
-
-
-class BasicLoggerCallback(Callback):
-    """
-    Callback that implements simple logging functionality
-    expected when passing verbose to a Trainer
-    """
-
-    def __init__(self, wandb_kwargs=None):
-        super().__init__()
-        if wandb_kwargs:
-            wandb.init(**wandb_kwargs)
-
-    def on_init_end(self, *args, **kwargs):
-        self._update_state_dict(**kwargs)
-
-    def on_train_start(self, **kwargs):
-        self._update_state_dict(**kwargs)
-
-        train_loader = self.state_dict["train_loader"]
-        test_loaders = self.state_dict["test_loaders"]
-        verbose = self.state_dict["verbose"]
-
-        n_train = len(train_loader.dataset)
-        self._update_state_dict(n_train=n_train)
-
-        if not isinstance(test_loaders, dict):
-            test_loaders = dict(test=test_loaders)
-
-        if verbose:
-            print(f"Training on {n_train} samples")
-            print(
-                f"Testing on {[len(loader.dataset) for loader in test_loaders.values()]} samples"
-                f"         on resolutions {[name for name in test_loaders]}."
-            )
-            sys.stdout.flush()
-
-    def on_epoch_start(self, epoch):
-        self._update_state_dict(epoch=epoch)
-
-    def on_batch_start(self, idx, **kwargs):
-        self._update_state_dict(idx=idx)
-
-    def on_before_loss(self, out, **kwargs):
-        if (
-            self.state_dict["epoch"] == 0
-            and self.state_dict["idx"] == 0
-            and self.state_dict["verbose"]
-        ):
-            print(f"Raw outputs of size {out.shape=}")
-
-    def on_before_val(self, epoch, train_err, time, avg_loss, avg_lasso_loss, **kwargs):
-        # track training err and val losses to print at interval epochs
-        msg = f"[{epoch}] time={time:.2f}, avg_loss={avg_loss:.4f}, train_err={train_err:.4f}"
-        values_to_log = dict(train_err=train_err, time=time, avg_loss=avg_loss)
-
-        self._update_state_dict(msg=msg, values_to_log=values_to_log)
-        self._update_state_dict(avg_lasso_loss=avg_lasso_loss)
-
-    def on_val_epoch_end(self, errors, **kwargs):
-        for loss_name, loss_value in errors.items():
-            if isinstance(loss_value, float):
-                self.state_dict["msg"] += f", {loss_name}={loss_value:.4f}"
-            else:
-                loss_value = {i: e.item() for (i, e) in enumerate(loss_value)}
-                self.state_dict["msg"] += f", {loss_name}={loss_value}"
-            self.state_dict["values_to_log"][loss_name] = loss_value
-
-    def on_val_end(self, *args, **kwargs):
-        if self.state_dict.get("regularizer", False):
-            avg_lasso = self.state_dict.get("avg_lasso_loss", 0.0)
-            avg_lasso /= self.state_dict.get("n_epochs")
-            self.state_dict["msg"] += f", avg_lasso={avg_lasso:.5f}"
-
-        print(self.state_dict["msg"])
-        sys.stdout.flush()
-
-        if self.state_dict.get("wandb_log", False):
-            for pg in self.state_dict["optimizer"].param_groups:
-                lr = pg["lr"]
-                self.state_dict["values_to_log"]["lr"] = lr
-            wandb.log(
-                self.state_dict["values_to_log"],
-                step=self.state_dict["epoch"] + 1,
-                commit=True,
-            )
 
 
 class CheckpointCallback(Callback):

--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -17,6 +17,8 @@ import wandb
 from .training_state import save_training_state, load_training_state
 from neuralop.utils import compute_rank, compute_stable_rank, compute_explained_variance
 
+from neuralop.losses.meta_losses import WeightedSumLoss
+
 
 class Callback(object):
     """
@@ -492,3 +494,14 @@ class IncrementalCallback(Callback):
             main_modes = incremental_final[0]
             modes_list = tuple([main_modes] * self.ndim)
             model.fno_blocks.convs.n_modes = tuple(modes_list)
+
+class LossBalancingCallback(Callback):
+    def __init__(self):
+        super().__init__()
+    
+    def compute_training_loss(self, out, sample, loss, model, **kwargs):
+        loss_vals = loss(out, **sample) # sumlossoutput
+        grads = {}
+        for name, val in loss_vals.losses.items()
+            grads[name] = torch.autograd.grad(outputs=val, inputs=model.parameters(), retain_graph=True)
+        

--- a/neuralop/training/callbacks.py
+++ b/neuralop/training/callbacks.py
@@ -499,6 +499,8 @@ class IncrementalCallback(Callback):
             model.fno_blocks.convs.n_modes = tuple(modes_list)
 
 class LossBalancingCallback(Callback):
+    # source: https://arxiv.org/pdf/2308.08468
+    # Wang et al., "An Expert's Guide to Training Physics-Informed Neural Networks"
     def __init__(self, alpha: float=0.9):
         super().__init__()
         self.alpha = alpha

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -224,12 +224,16 @@ class Trainer:
                             loss = training_loss(out, **sample)
                     else:
                         loss = training_loss(out, **sample)
-                print(loss)
                 if regularizer:
                     loss += regularizer.loss
-
+                '''
+                print(f"pre back {type(loss)=}")
+                print(f"pre back {loss}")
                 loss.backward()
-                print(f"{loss=}")
+                print(f"post back {loss}")
+                print(f"post back {type(loss)=}")'''
+
+                #loss._log_tensors()
                 del out
 
                 # free sample memory
@@ -241,7 +245,6 @@ class Trainer:
                     train_err += loss.item()
                 else:
                     train_err = loss + train_err
-                print(f"{train_err=}")
 
                 with torch.no_grad():
                     avg_loss += loss.item()
@@ -256,7 +259,6 @@ class Trainer:
             epoch_train_time = default_timer() - t1
 
             train_err /= len(train_loader)
-            print(f"{train_err=}")
             avg_loss /= n_samples
             if regularizer:
                 avg_lasso_loss /= n_samples

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -132,6 +132,7 @@ class Trainer:
 
         if self.callbacks:
             self.callbacks.on_train_start(
+                model=self.model,
                 train_loader=train_loader,
                 test_loaders=test_loaders,
                 optimizer=optimizer,
@@ -149,6 +150,12 @@ class Trainer:
             eval_losses = dict(l2=training_loss)
 
         errors = None
+
+        if self.verbose:
+            print(f'Training on {len(train_loader)} samples')
+            print(f'Testing on {[len(loader.dataset) for loader in test_loaders.values()]} samples'
+                  f'         on resolutions {[name for name in test_loaders]}.')
+            sys.stdout.flush()
 
         for epoch in range(self.n_epochs):
             if self.callbacks:
@@ -259,7 +266,7 @@ class Trainer:
                                      avg_loss=avg_loss,
                                      avg_lasso_loss=avg_lasso_loss)
                 #TODO: rename and/or reform
-                msg, values_to_log = self.callbacks.logging_method_name(msg, values_to_log)
+                #msg, values_to_log = self.callbacks.logging_method_name(msg, values_to_log)
             
                 for loader_name, loader in test_loaders.items():
                     errors = self.evaluate(eval_losses, loader, log_prefix=loader_name)

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -226,14 +226,9 @@ class Trainer:
                         loss = training_loss(out, **sample)
                 if regularizer:
                     loss += regularizer.loss
-                '''
-                print(f"pre back {type(loss)=}")
-                print(f"pre back {loss}")
+                
                 loss.backward()
-                print(f"post back {loss}")
-                print(f"post back {type(loss)=}")'''
 
-                #loss._log_tensors()
                 del out
 
                 # free sample memory
@@ -345,7 +340,7 @@ class Trainer:
         with torch.no_grad():
             for idx, sample in enumerate(data_loader):
                 if self.callbacks:
-                    sample, self.data_processor = self.callbacks.on_val_batch_start(
+                    sample = self.callbacks.on_val_batch_start(
                         idx=idx, sample=sample, data_processor=self.data_processor
                     )
 

--- a/scripts/train_burgers.py
+++ b/scripts/train_burgers.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 from neuralop import H1Loss, LpLoss, BurgersEqnLoss, ICLoss, WeightedSumLoss, Trainer, get_model
 from neuralop.data.datasets import load_burgers_1dtime
 from neuralop.data.transforms.data_processors import MGPatchingDataProcessor
-from neuralop.training import setup, BasicLoggerCallback
+from neuralop.training import setup
 from neuralop.utils import get_wandb_api_key, count_model_params
 
 
@@ -161,10 +161,6 @@ if config.verbose:
 
 # only perform MG patching if config patching levels > 0
 
-callbacks = [
-    BasicLoggerCallback(wandb_init_args)
-]
-
 data_processor = MGPatchingDataProcessor(model=model,
                                        levels=config.patching.levels,
                                        padding_fraction=config.patching.padding,
@@ -178,7 +174,7 @@ trainer = Trainer(
     data_processor=data_processor,
     device=device,
     amp_autocast=config.opt.amp_autocast,
-    callbacks=callbacks,
+    callbacks=None,
     log_test_interval=config.wandb.log_test_interval,
     log_output=config.wandb.log_output,
     use_distributed=config.distributed.use_distributed,

--- a/scripts/train_car_cfd.py
+++ b/scripts/train_car_cfd.py
@@ -10,7 +10,6 @@ from neuralop.training.trainer import Trainer
 from neuralop.data.datasets import MeshDataModule
 from neuralop.data.transforms.data_processors import DataProcessor
 from copy import deepcopy
-from neuralop.training.callbacks import BasicLoggerCallback
 
 # query points is [sdf_query_resolution] * 3 (taken from config ahmed)
 
@@ -172,9 +171,6 @@ trainer = Trainer(model=model,
                   n_epochs=config.opt.n_epochs,
                   data_processor=data_processor,
                   device=device,
-                  callbacks=[
-                      BasicLoggerCallback(wandb_kwargs=wandb_init_args)
-                  ],
                   wandb_log=config.wandb.log
                   )
 

--- a/scripts/train_darcy.py
+++ b/scripts/train_darcy.py
@@ -9,7 +9,6 @@ from neuralop import H1Loss, LpLoss, Trainer, get_model
 from neuralop.data.datasets import load_darcy_flow_small
 from neuralop.data.transforms.data_processors import MGPatchingDataProcessor
 from neuralop.training import setup
-from neuralop.training.callbacks import BasicLoggerCallback
 from neuralop.utils import get_wandb_api_key, count_model_params
 
 
@@ -160,10 +159,7 @@ trainer = Trainer(
     log_test_interval=config.wandb.log_test_interval,
     log_output=config.wandb.log_output,
     use_distributed=config.distributed.use_distributed,
-    verbose=config.verbose and is_logger,
-    callbacks=[
-        BasicLoggerCallback(wandb_args)
-              ]
+    verbose=config.verbose and is_logger
               )
 
 # Log parameter count

--- a/scripts/train_darcy.py
+++ b/scripts/train_darcy.py
@@ -6,6 +6,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 import wandb
 
 from neuralop import H1Loss, LpLoss, Trainer, get_model
+from neuralop.losses import WeightedSumLoss
 from neuralop.data.datasets import load_darcy_flow_small
 from neuralop.data.transforms.data_processors import MGPatchingDataProcessor
 from neuralop.training import setup
@@ -128,7 +129,7 @@ else:
 # Creating the losses
 l2loss = LpLoss(d=2, p=2)
 h1loss = H1Loss(d=2)
-if config.opt.training_loss == "l2":
+'''if config.opt.training_loss == "l2":
     train_loss = l2loss
 elif config.opt.training_loss == "h1":
     train_loss = h1loss
@@ -137,6 +138,9 @@ else:
         f'Got training_loss={config.opt.training_loss} '
         f'but expected one of ["l2", "h1"]'
     )
+'''
+train_loss = WeightedSumLoss([l2loss, h1loss])
+
 eval_losses = {"h1": h1loss, "l2": l2loss}
 
 if config.verbose and is_logger:

--- a/scripts/train_navier_stokes.py
+++ b/scripts/train_navier_stokes.py
@@ -156,12 +156,6 @@ if config.verbose:
     print(f"\n### Beginning Training...\n")
     sys.stdout.flush()
 
-# only perform MG patching if config patching levels > 0
-
-callbacks = [
-    BasicLoggerCallback(wandb_init_args)
-]
-
 
 trainer = Trainer(
     model=model,
@@ -169,7 +163,6 @@ trainer = Trainer(
     data_processor=data_processor,
     device=device,
     amp_autocast=config.opt.amp_autocast,
-    callbacks=callbacks,
     log_test_interval=config.wandb.log_test_interval,
     log_output=config.wandb.log_output,
     use_distributed=config.distributed.use_distributed,


### PR DESCRIPTION
This is a WIP. I have not fully decided how to design Callbacks in an abstract, clean and user-friendly way. But this PR contains working code to use loss-balancing from [1] while logging and backpropagating the outputs of a custom `SumLossOutput` object. 

This PR also removes the `BasicLoggerCallback` to simplify the interface of the trainer re: #284 

[1]. Wang et al., 2023. "An Expert's Guide to Training Physics-Informed Neural Networks," https://arxiv.org/pdf/2308.08468