### PR TITLE
Fix dataset docs by ensuring proper data root by default 

### DIFF
--- a/neuralop/data/datasets/darcy.py
+++ b/neuralop/data/datasets/darcy.py
@@ -8,6 +8,8 @@ from torch.utils.data import DataLoader
 from .pt_dataset import PTDataset
 from .web_utils import download_from_zenodo_record
 
+from neuralop.utils import get_project_root
+
 logger = logging.Logger(logging.root.level)
 
 class DarcyDataset(PTDataset):
@@ -84,11 +86,12 @@ class DarcyDataset(PTDataset):
                        output_subsampling_rate=subsampling_rate)
         
 # legacy Small Darcy Flow example
+example_data_root = get_project_root() / "neuralop/data/datasets/data"
 def load_darcy_flow_small(n_train,
     n_tests,
     batch_size,
     test_batch_sizes,
-    data_root = "./neuralop/data/datasets/data",
+    data_root = example_data_root,
     test_resolutions=[16, 32],
     grid_boundaries=[[0, 1], [0, 1]],
     positional_encoding=True,

--- a/neuralop/data/datasets/navier_stokes.py
+++ b/neuralop/data/datasets/navier_stokes.py
@@ -7,6 +7,7 @@ from torch.utils.data import DataLoader
 
 from .pt_dataset import PTDataset
 from .web_utils import download_from_zenodo_record
+from neuralop.utils import get_project_root
 
 logger = logging.Logger(logging.root.level)
 
@@ -78,12 +79,13 @@ class NavierStokesDataset(PTDataset):
                        input_subsampling_rate=subsampling_rate,
                        output_subsampling_rate=subsampling_rate)
 
+example_data_root = get_project_root() / "neuralop/datasets/data"
 # load navier stokes pt for backwards compatibility
 def load_navier_stokes_pt(n_train,
     n_tests,
     batch_size,
     test_batch_sizes,
-    data_root = "./neuralop/datasets/data",
+    data_root = example_data_root,
     train_resolution=128,
     test_resolutions=[128],
     grid_boundaries=[[0, 1], [0, 1]],

--- a/neuralop/utils.py
+++ b/neuralop/utils.py
@@ -1,9 +1,9 @@
 from typing import List, Optional, Union
 from math import prod
+from pathlib import Path
 import torch
 import wandb
 import warnings
-
 
 # normalization, pointwise gaussian
 class UnitGaussianNormalizer:
@@ -269,3 +269,7 @@ def compute_explained_variance(frequency_max, s):
     s_current = s.clone()
     s_current[frequency_max:] = 0
     return 1 - torch.var(s - s_current) / torch.var(s)
+
+def get_project_root():
+    root = Path(__file__).parent.parent
+    return root


### PR DESCRIPTION
my refactor of `load_darcy_flow_small` and `load_navier_stokes_pt` broke documentation because of a relative path problem. I added a project root finding util and fixed the default data roots in those legacy functions. 