### PR TITLE
Fix format of docstrings, update API doc to add dividers for clarity

### DIFF
--- a/doc/source/modules/api.rst
+++ b/doc/source/modules/api.rst
@@ -11,13 +11,12 @@ API reference
 .. _neuralop_models_ref:
 
 Models
-======
+------
 
 In :mod:`neuralop.models`, we provide neural operator models you can directly use on your applications.
 
-
 FNO
----
+^^^
 
 We provide a general Fourier Neural Operator (TFNO) that supports most usecases.
 
@@ -40,8 +39,10 @@ We also have dimension-specific classes:
     FNO2d
     FNO3d
 
+
+
 Tensorized FNO (TFNO)
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 N-D version: 
 
@@ -62,7 +63,7 @@ Dimension-specific classes:
     TFNO3d
 
 Spherical Fourier Neural Operators (SFNO)
------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autosummary::
     :toctree: generated
@@ -71,7 +72,7 @@ Spherical Fourier Neural Operators (SFNO)
     SFNO
 
 Geometry-Informed Neural Operators (GINO)
------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autosummary::
     :toctree: generated
@@ -80,7 +81,7 @@ Geometry-Informed Neural Operators (GINO)
     GINO
 
 U-shaped Neural Operators (U-NO)
---------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autosummary::
     :toctree: generated
@@ -103,7 +104,7 @@ in :mod:`neuralop.layers` building blocks,
 in the form of PyTorch layers, that you can use to build your own models:
 
 Neural operator Layers
-++++++++++++++++++++++
+----------------------
 
 **Spectral convolutions** (in Fourier domain):
 

--- a/doc/source/modules/api.rst
+++ b/doc/source/modules/api.rst
@@ -39,7 +39,7 @@ We also have dimension-specific classes:
     FNO2d
     FNO3d
 
-
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tensorized FNO (TFNO)
 ----------------------
@@ -62,6 +62,8 @@ Dimension-specific classes:
     TFNO2d
     TFNO3d
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Spherical Fourier Neural Operators (SFNO)
 --------------------------------------------
 
@@ -70,6 +72,8 @@ Spherical Fourier Neural Operators (SFNO)
     :template: class.rst
 
     SFNO
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Geometry-Informed Neural Operators (GINO)
 ------------------------------------------
@@ -80,14 +84,18 @@ Geometry-Informed Neural Operators (GINO)
 
     GINO
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 U-shaped Neural Operators (U-NO)
 ---------------------------------
 
 .. autosummary::
     :toctree: generated
     :template: class.rst
-
+    
     UNO
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Layers
 =======
@@ -130,6 +138,7 @@ Dimension-specific versions:
     SpectralConv2d
     SpectralConv3d
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Spherical convolutions**: (using Spherical Harmonics)
 
@@ -142,6 +151,8 @@ Dimension-specific versions:
     :template: class.rst
 
     SphericalConv
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To support geometry-informed (GINO) models, we also offer the ability to integrate kernels in the spatial domain, which we formulate as mappings between arbitrary coordinate meshes.
 
@@ -157,7 +168,9 @@ To support geometry-informed (GINO) models, we also offer the ability to integra
 
     IntegralTransform
 
-**Neighbor search and neighborhood reduction**
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Neighbor search**
 
 Find neighborhoods on arbitrary coordinate meshes:
 
@@ -177,6 +190,7 @@ Find neighborhoods on arbitrary coordinate meshes:
 
     native_neighbor_search
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Other resolution invariant operations
 -------------------------------------
@@ -193,6 +207,8 @@ Automatically apply resolution dependent domain padding:
 
     DomainPadding
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 .. automodule:: neuralop.layers.skip_connections
     :no-members:
     :no-inherited-members:
@@ -208,6 +224,8 @@ Automatically apply resolution dependent domain padding:
     :template: function.rst
 
     skip_connection
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
 Model Dispatching
@@ -226,6 +244,8 @@ It has the advantage of doing some checks on the parameters it receives.
     get_model
     available_models
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Training
 =========
 We provide functionality that automates the boilerplate code associated with 
@@ -241,21 +261,7 @@ training a machine learning model to minimize a loss function on a dataset:
 
     Trainer
 
-The general case (assuming no modifications) is covered above. To implement domain-specific 
-logic in your training loop while still using the automation and logging provided by a
-Trainer, we provide a Callback class and several examples of common domain-specific Callbacks.
-
-.. automodule:: neuralop.training.callbacks
-    :no-members:
-    :no-inherited-members:
-
-.. autosummary::
-    :toctree: generated
-    :template: class.rst
-
-    Callback
-    CheckpointCallback
-
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Data
 ========
@@ -272,6 +278,8 @@ We also ship a small dataset for testing:
     :template: function.rst
 
     load_darcy_flow_small
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 DataProcessors
 --------------
@@ -290,3 +298,5 @@ loss functions:
 
     DefaultDataProcessor
     MGPatchingDataProcessor
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/modules/api.rst
+++ b/doc/source/modules/api.rst
@@ -1,6 +1,6 @@
-=============
+#############
 API reference
-=============
+#############
 
 :mod:`neuralop`: Neural Operators in Python
 
@@ -11,12 +11,12 @@ API reference
 .. _neuralop_models_ref:
 
 Models
-------
+=======
 
 In :mod:`neuralop.models`, we provide neural operator models you can directly use on your applications.
 
 FNO
-^^^
+----
 
 We provide a general Fourier Neural Operator (TFNO) that supports most usecases.
 
@@ -42,7 +42,7 @@ We also have dimension-specific classes:
 
 
 Tensorized FNO (TFNO)
-^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 N-D version: 
 
@@ -63,7 +63,7 @@ Dimension-specific classes:
     TFNO3d
 
 Spherical Fourier Neural Operators (SFNO)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------------------------
 
 .. autosummary::
     :toctree: generated
@@ -72,7 +72,7 @@ Spherical Fourier Neural Operators (SFNO)
     SFNO
 
 Geometry-Informed Neural Operators (GINO)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------------------
 
 .. autosummary::
     :toctree: generated
@@ -81,7 +81,7 @@ Geometry-Informed Neural Operators (GINO)
     GINO
 
 U-shaped Neural Operators (U-NO)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------
 
 .. autosummary::
     :toctree: generated
@@ -90,7 +90,7 @@ U-shaped Neural Operators (U-NO)
     UNO
 
 Layers
-======
+=======
 
 .. automodule:: neuralop.layers
     :no-members:
@@ -104,7 +104,7 @@ in :mod:`neuralop.layers` building blocks,
 in the form of PyTorch layers, that you can use to build your own models:
 
 Neural operator Layers
-----------------------
+------------------------
 
 **Spectral convolutions** (in Fourier domain):
 
@@ -112,11 +112,19 @@ Neural operator Layers
     :no-members:
     :no-inherited-members:
 
+General SpectralConv layer:
+
 .. autosummary::
     :toctree: generated
     :template: class.rst
 
     SpectralConv
+
+Dimension-specific versions: 
+
+.. autosummary::
+    :toctree: generated
+    :template: class.rst
 
     SpectralConv1d
     SpectralConv2d
@@ -169,21 +177,9 @@ Find neighborhoods on arbitrary coordinate meshes:
 
     native_neighbor_search
 
-Given a CSR-formatted matrix, reduce data associated with index entries:
-
-.. automodule:: neuralop.layers.segment_csr
-    :no-members:
-    :no-inherited-members:
-
-.. autosummary::
-    :toctree: generated
-    :template: function.rst
-
-    segment_csr
-
 
 Other resolution invariant operations
-+++++++++++++++++++++++++++++++++++++
+-------------------------------------
 
 Automatically apply resolution dependent domain padding: 
 
@@ -215,7 +211,7 @@ Automatically apply resolution dependent domain padding:
 
 
 Model Dispatching
-=================
+===================
 We provide a utility function to create model instances from a configuration.
 It has the advantage of doing some checks on the parameters it receives.
 
@@ -231,7 +227,7 @@ It has the advantage of doing some checks on the parameters it receives.
     available_models
 
 Training
-========
+=========
 We provide functionality that automates the boilerplate code associated with 
 training a machine learning model to minimize a loss function on a dataset:
 
@@ -276,6 +272,9 @@ We also ship a small dataset for testing:
     :template: function.rst
 
     load_darcy_flow_small
+
+DataProcessors
+--------------
 
 Much like PyTorch's `Torchvision.Datasets` module, our `data` module also includes
 utilities to transform data from its raw form into the form expected by models and 

--- a/examples/plot_count_flops.py
+++ b/examples/plot_count_flops.py
@@ -1,6 +1,6 @@
 """
 Using `torchtnt` to count FLOPS
-=============================
+================================
 
 In this example, we demonstrate how to use torchtnt to estimate the number of floating-point
 operations per second (FLOPS) required for a model's forward and backward pass. 

--- a/neuralop/layers/integral_transform.py
+++ b/neuralop/layers/integral_transform.py
@@ -15,11 +15,14 @@ class IntegralTransform(nn.Module):
         (d) \int_{A(x)} k(x, y, f(y)) * f(y) dy
 
     x : Points for which the output is defined
+
     y : Points for which the input is defined
-    A(x) : A subset of all points y (depending on
-           each x) over which to integrate
+    A(x) : A subset of all points y (depending on\
+        each x) over which to integrate
+
     k : A kernel parametrized as a MLP
-    f : Input function to integrate against given
+    
+    f : Input function to integrate against given\
         on the points y
 
     If f is not given, a transform of type (a)

--- a/neuralop/layers/neighbor_search.py
+++ b/neuralop/layers/neighbor_search.py
@@ -5,7 +5,7 @@ from torch import nn
 #Uses open3d by default which, as of 07/23/2023, requires torch 1.13.1
 class NeighborSearch(nn.Module):
     """
-    eighborhood search between two arbitrary coordinate meshes.
+    Neighborhood search between two arbitrary coordinate meshes.
     For each point `x` in `queries`, returns a set of the indices of all points `y` in `data` 
     within the ball of radius r `B_r(x)`
 
@@ -70,11 +70,11 @@ class NeighborSearch(nn.Module):
 
 def native_neighbor_search(data: torch.Tensor, queries: torch.Tensor, radius: float):
     """
-
-    Parameters
-    ----------
     Native PyTorch implementation of a neighborhood search
     between two arbitrary coordinate meshes.
+     
+    Parameters
+    -----------
 
     data : torch.Tensor
         vector of data points from which to find neighbors


### PR DESCRIPTION
Simple fixes to documentation. No code changes, just a cleaner API reference. Removes unnecessary indents in module docstrings to fix RST build