### PR TITLE
Make `wandb` an optional dependency

### DIFF
--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -3,6 +3,7 @@ from functools import partialmethod
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ..layers.embeddings import GridEmbeddingND
 from ..layers.spectral_convolution import SpectralConv
 from ..layers.spherical_convolution import SphericalConv
 from ..layers.padding import DomainPadding
@@ -30,6 +31,11 @@ class FNO(BaseModel, name='FNO'):
         number of hidden channels of the projection block of the FNO, by default 256
     n_layers : int, optional
         Number of Fourier Layers, by default 4
+    spatial_pos_embed : str literal, optional
+        Whether to use/type of spatial positional embedding
+        to append to model inputs before forward pass:
+        1. "grid": GridEmbeddingND
+        2. None: none
     max_n_modes : None or int tuple, default is None
         * If not None, this allows to incrementally increase the number of
           modes in Fourier domain during training. Has to verify n <= N
@@ -101,6 +107,7 @@ class FNO(BaseModel, name='FNO'):
         lifting_channels=256,
         projection_channels=256,
         n_layers=4,
+        spatial_pos_embed="grid",
         output_scaling_factor=None,
         max_n_modes=None,
         fno_block_precision="full",
@@ -151,7 +158,9 @@ class FNO(BaseModel, name='FNO'):
         self.separable = separable
         self.preactivation = preactivation
         self.fno_block_precision = fno_block_precision
-
+        
+        
+        self.spatial_pos_embed = spatial_pos_embed
         if domain_padding is not None and (
             (isinstance(domain_padding, list) and sum(domain_padding) > 0)
             or (isinstance(domain_padding, (float, int)) and domain_padding > 0)
@@ -247,6 +256,7 @@ class FNO(BaseModel, name='FNO'):
         elif isinstance(output_shape, tuple):
             output_shape = [None]*(self.n_layers - 1) + [output_shape]
 
+        grid_embedding = 
         x = self.lifting(x)
 
         if self.domain_padding is not None:

--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -3,7 +3,6 @@ from functools import partialmethod
 import torch.nn as nn
 import torch.nn.functional as F
 
-from ..layers.embeddings import GridEmbeddingND
 from ..layers.spectral_convolution import SpectralConv
 from ..layers.spherical_convolution import SphericalConv
 from ..layers.padding import DomainPadding
@@ -31,11 +30,6 @@ class FNO(BaseModel, name='FNO'):
         number of hidden channels of the projection block of the FNO, by default 256
     n_layers : int, optional
         Number of Fourier Layers, by default 4
-    spatial_pos_embed : str literal, optional
-        Whether to use/type of spatial positional embedding
-        to append to model inputs before forward pass:
-        1. "grid": GridEmbeddingND
-        2. None: none
     max_n_modes : None or int tuple, default is None
         * If not None, this allows to incrementally increase the number of
           modes in Fourier domain during training. Has to verify n <= N
@@ -107,7 +101,6 @@ class FNO(BaseModel, name='FNO'):
         lifting_channels=256,
         projection_channels=256,
         n_layers=4,
-        spatial_pos_embed="grid",
         output_scaling_factor=None,
         max_n_modes=None,
         fno_block_precision="full",
@@ -158,9 +151,7 @@ class FNO(BaseModel, name='FNO'):
         self.separable = separable
         self.preactivation = preactivation
         self.fno_block_precision = fno_block_precision
-        
-        
-        self.spatial_pos_embed = spatial_pos_embed
+
         if domain_padding is not None and (
             (isinstance(domain_padding, list) and sum(domain_padding) > 0)
             or (isinstance(domain_padding, (float, int)) and domain_padding > 0)
@@ -256,7 +247,6 @@ class FNO(BaseModel, name='FNO'):
         elif isinstance(output_shape, tuple):
             output_shape = [None]*(self.n_layers - 1) + [output_shape]
 
-        grid_embedding = 
         x = self.lifting(x)
 
         if self.domain_padding is not None:

--- a/neuralop/tests/test_utils.py
+++ b/neuralop/tests/test_utils.py
@@ -5,10 +5,11 @@ import pytest
 
 # Only import wandb and use if installed
 wandb_available = False
-from importlib.util import find_spec
-if find_spec('wandb') is not None:
-    wandb_available = True
+try:
     import wandb
+    wandb_available = True
+except ModuleNotFoundError:
+    wandb_available = False
 
 import os
 import torch

--- a/neuralop/tests/test_utils.py
+++ b/neuralop/tests/test_utils.py
@@ -2,7 +2,14 @@ from ..utils import get_wandb_api_key, wandb_login
 from ..utils import count_model_params, count_tensor_params
 from pathlib import Path
 import pytest
-import wandb
+
+# Only import wandb and use if installed
+wandb_available = False
+from importlib.util import find_spec
+if find_spec('wandb') is not None:
+    wandb_available = True
+    import wandb
+
 import os
 import torch
 from torch import nn
@@ -76,33 +83,34 @@ def test_get_wandb_api_key():
 
 
 def test_ArgparseConfig(monkeypatch):
-    def login(key):
-        if key == 'my_secret_key':
-            return True
+    if wandb_available:
+        def login(key):
+            if key == 'my_secret_key':
+                return True
 
-        raise ValueError('Wrong key')
+            raise ValueError('Wrong key')
 
-    monkeypatch.setattr(wandb, "login", login)
+        monkeypatch.setattr(wandb, "login", login)
 
-    # Make sure no env var key set
-    os.environ.pop("WANDB_API_KEY", None)
+        # Make sure no env var key set
+        os.environ.pop("WANDB_API_KEY", None)
 
-    # Read from file
-    filepath = Path(__file__).parent.joinpath('test_config_key.txt').as_posix()
-    assert wandb_login(filepath) is None
+        # Read from file
+        filepath = Path(__file__).parent.joinpath('test_config_key.txt').as_posix()
+        assert wandb_login(filepath) is None
 
-    # Read from env var
-    os.environ["WANDB_API_KEY"] = 'my_secret_key'
-    assert wandb_login() is None
+        # Read from env var
+        os.environ["WANDB_API_KEY"] = 'my_secret_key'
+        assert wandb_login() is None
 
-    # Read from env var
-    os.environ["WANDB_API_KEY"] = 'wrong_key'
-    assert wandb_login(key='my_secret_key') is None
+        # Read from env var
+        os.environ["WANDB_API_KEY"] = 'wrong_key'
+        assert wandb_login(key='my_secret_key') is None
 
-    # Read from env var
-    os.environ["WANDB_API_KEY"] = 'wrong_key'
-    with pytest.raises(ValueError):
-        wandb_login()
+        # Read from env var
+        os.environ["WANDB_API_KEY"] = 'wrong_key'
+        with pytest.raises(ValueError):
+            wandb_login()
 
 class DummyDataset(Dataset):
     # Simple linear regression problem, PyTorch style

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -8,10 +8,11 @@ import sys
 
 # Only import wandb and use if installed
 wandb_available = False
-from importlib.util import find_spec
-if find_spec('wandb') is not None:
-    wandb_available = True
+try:
     import wandb
+    wandb_available = True
+except ModuleNotFoundError:
+    wandb_available = False
 
 import neuralop.mpu.comm as comm
 from neuralop.losses import LpLoss

--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -5,7 +5,13 @@ from timeit import default_timer
 from pathlib import Path
 from typing import Union
 import sys
-import wandb
+
+# Only import wandb and use if installed
+wandb_available = False
+from importlib.util import find_spec
+if find_spec('wandb') is not None:
+    wandb_available = True
+    import wandb
 
 import neuralop.mpu.comm as comm
 from neuralop.losses import LpLoss
@@ -55,7 +61,9 @@ class Trainer:
         self.model = model
         self.n_epochs = n_epochs
         # only log to wandb if a run is active
-        self.wandb_log = (wandb_log and wandb.run is not None)
+        self.wandb_log = False
+        if wandb_available:
+            self.wandb_log = (wandb_log and wandb.run is not None)
         self.eval_interval = eval_interval
         self.log_output = log_output
         self.verbose = verbose
@@ -309,7 +317,7 @@ class Trainer:
 
         # on last batch, log model outputs
         if self.log_output:
-                errors[f"{log_prefix}_outputs"] = wandb.Image(outs)
+            errors[f"{log_prefix}_outputs"] = wandb.Image(outs)
         
         return errors
     

--- a/neuralop/utils.py
+++ b/neuralop/utils.py
@@ -2,7 +2,14 @@ from typing import List, Optional, Union
 from math import prod
 from pathlib import Path
 import torch
-import wandb
+
+# Only import wandb and use if installed
+wandb_available = False
+from importlib.util import find_spec
+if find_spec('wandb') is not None:
+    wandb_available = True
+    import wandb
+
 import warnings
 
 # normalization, pointwise gaussian

--- a/neuralop/utils.py
+++ b/neuralop/utils.py
@@ -5,10 +5,11 @@ import torch
 
 # Only import wandb and use if installed
 wandb_available = False
-from importlib.util import find_spec
-if find_spec('wandb') is not None:
-    wandb_available = True
+try:
     import wandb
+    wandb_available = True
+except ModuleNotFoundError:
+    wandb_available = False
 
 import warnings
 


### PR DESCRIPTION
Changes wandb-related tests and utils to only source if wandb is installed. This should help with pip builds.