### PR TITLE
Fix inscrutable einsum error in SpectralConv.forward when `separable=True`

### DIFF
--- a/neuralop/layers/spectral_convolution.py
+++ b/neuralop/layers/spectral_convolution.py
@@ -204,7 +204,8 @@ class SpectralConv(BaseSpectralConv):
 
     separable : bool, default is True
         whether to use separable contraction
-        only checked if `implementation` == 'reconstructed'
+        if True, contracts factors of factorized 
+        tensor weight individually
     init_std : float or 'auto', default is 'auto'
         std to use for the init
     n_layers : int, optional


### PR DESCRIPTION
Changes to how the `SpectralConv` layer's tensor contraction function is chosen based on `implementation`, `factorization`, and `separable` to avoid einsum symbols and dense contract being incorrect.

Fixes issue #382 

### bug

Normally a `SpectralConv` is created with the option `separable=False` and its weights have shape `(in_channels, out_channels, modes_1, ...)`. When `separable=True`, the weights have shape `(channels, modes_1, ...)`. The indexing of weight into `weight[slices_w]` around lines 440-460 did not take this into account, leading to bugs in either the factorized tensor contraction einsums or in the slicing required before calling `self._contract`. 

### fix
In order to fix this I changed the indexing and slices mentioned above to ensure that slices are the proper length for the correct cases. I also made sure the proper tensor contraction function was being returned by `self.get_contract_fun` and added unit tests for all separable tensor cases.