### PR TITLE
Fix `SpectralConv` docs

### DIFF
--- a/neuralop/layers/spectral_convolution.py
+++ b/neuralop/layers/spectral_convolution.py
@@ -184,11 +184,11 @@ class SpectralConv(BaseSpectralConv):
 
     Parameters
     ----------
-    in_channels : int, optional
+    in_channels : int
         Number of input channels
-    out_channels : int, optional
+    out_channels : int
         Number of output channels
-    n_modes : None or int tuple, default is None
+    n_modes : int or int tuple
         Number of modes to use for contraction in Fourier domain during training.
  
         .. warning::


### PR DESCRIPTION
As discussed in #319 
- remove `optional` from in/out channels and n_modes (no default values)
- correct n_modes to `int or int tuple` instead of `None or int tuple`, which seems to have been copied over from `max_n_modes`