### PR TITLE
Change spectralConv factorization to remove explicitly complex-factorized tensors

### DIFF
--- a/neuralop/layers/spectral_convolution.py
+++ b/neuralop/layers/spectral_convolution.py
@@ -308,11 +308,8 @@ class SpectralConv(BaseSpectralConv):
                 fixed_rank_modes = None
         self.fft_norm = fft_norm
 
-        # Make sure we are using a Complex Factorized Tensor to parametrize the conv
         if factorization is None:
             factorization = "Dense"  # No factorization
-        if not factorization.lower().startswith("complex"):
-            factorization = f"Complex{factorization}"
 
         if separable:
             if in_channels != out_channels:
@@ -333,6 +330,7 @@ class SpectralConv(BaseSpectralConv):
                 rank=self.rank,
                 factorization=factorization,
                 fixed_rank_modes=fixed_rank_modes,
+                dtype=torch.cfloat,
                 **tensor_kwargs,
             )
             self.weight.normal_(0, init_std)
@@ -345,6 +343,7 @@ class SpectralConv(BaseSpectralConv):
                         factorization=factorization,
                         fixed_rank_modes=fixed_rank_modes,
                         **tensor_kwargs,
+                        dtype=torch.cfloat
                     )
                     for _ in range(n_layers)
                 ]

--- a/neuralop/layers/tests/test_spectral_convolution.py
+++ b/neuralop/layers/tests/test_spectral_convolution.py
@@ -8,7 +8,7 @@ from ..spectral_convolution import (SpectralConv3d, SpectralConv2d,
 
 
 
-@pytest.mark.parametrize('factorization', ['ComplexDense', 'ComplexCP', 'ComplexTucker', 'ComplexTT'])
+@pytest.mark.parametrize('factorization', ['Dense', 'CP', 'Tucker', 'TT'])
 @pytest.mark.parametrize('implementation', ['factorized', 'reconstructed'])
 @pytest.mark.parametrize('separable', [False, True])
 @pytest.mark.parametrize('dim', [1,2,3,4])
@@ -33,6 +33,9 @@ def test_SpectralConv(factorization, implementation, separable, dim):
         3, 3, modes[:dim], n_layers=1, bias=False, implementation='reconstructed', factorization=None)
 
     x = torch.randn(2, 3, *(12, )*dim)
+
+    assert torch.is_complex(conv._get_weight(0))
+    assert torch.is_complex(conv_dense._get_weight(0))
 
     # this closeness test only works if the weights in full form have the same shape
     if not separable:


### PR DESCRIPTION
TensorLy's `ComplexFactorizedTensor` object includes a backend with a `register_parameter` hook that forces a complex tensor `x` of shape `(b, c, i, j,...)` to be viewed as a 2-channel stack of real params of shape `(b, c, i, j, ..., 2)` using `torch.view_as_real(param)`. Optimizing in the real domain creates differences in analytical gradients when computing momentum. Since the stabilization of PyTorch's `cfloat`, it is simpler to pass tensors directly with `dtype=torch.cfloat`. Additional PR coming soon with correct Adam momentum. 