### PR TITLE
Minimal working `DistributedDataParallel`

### DIFF
--- a/config/navier_stokes_config.yaml
+++ b/config/navier_stokes_config.yaml
@@ -17,16 +17,16 @@ default: &DEFAULT
   # FNO related
   fno2d:
     data_channels: 1
-    n_modes_height: 24
-    n_modes_width: 24
+    n_modes_height: 64
+    n_modes_width: 64
     hidden_channels: 64
     projection_channels: 256
     n_layers: 4
-    domain_padding: 0.078125
+    domain_padding: 0 #0.078125
     domain_padding_mode: 'one-sided' #symmetric
     fft_norm: 'forward'
     norm: None
-    skip: 'soft-gating'
+    skip: 'linear'
     implementation: 'reconstructed'
     
     use_mlp: 1
@@ -52,7 +52,7 @@ default: &DEFAULT
     amp_autocast: False
 
     scheduler_T_max: 500 # For cosine only, typically take n_epochs
-    scheduler_patience: 5 # For ReduceLROnPlateau only
+    scheduler_patience: 50 # For ReduceLROnPlateau only
     scheduler: 'StepLR' # Or 'CosineAnnealingLR' OR 'ReduceLROnPlateau'
     step_size: 100
     gamma: 0.5
@@ -63,9 +63,9 @@ default: &DEFAULT
     batch_size: 16
     n_train: 10000
     train_resolution: 128
-    n_tests: [2000, 1000] #, 1000]
-    test_resolutions: [128, 1024] #, 1024] 
-    test_batch_sizes: [16, 4] #, 1]
+    n_tests: [2000] #, 1000] #, 1000]
+    test_resolutions: [128] #, 1024] #, 1024] 
+    test_batch_sizes: [16] #, 4] #, 1]
     encode_input: True
     encode_output: True
 

--- a/doc/source/user_guide/training.rst
+++ b/doc/source/user_guide/training.rst
@@ -19,18 +19,21 @@ can easily be implemented. For more specific documentation, check the API refere
 
 Distributed Training
 =====================
-We also provide a simple way to use PyTorch's :code:`DistributedDataParallel`
-functionality to hold data across multiple GPUs. We use PyTorch's MPI backend,
-so all you need to do on a multi-GPU system is the following:
+We also provide a simple way to use PyTorch's :code:`DistributedDataParallel` (DDP)
+functionality to hold data across multiple GPUs. We use PyTorch's  `torchrun`
+elastic distributed process launcher. All our example scripts are written to initialize DDP 
+in the background, so all that is required is installing one additional dependency and running
+the following (assuming you are running on a single node):  
 
 ::
     
-    pip install mpi4py
+    conda install openmpi -c conda-forge
 
-    mpiexec --allow-run-as-root -n N_GPUS python my_script.py
+    torchrun --standalone --nproc_per_node=NUM_GPUS --nnodes=1 myscript.py
 
 You may need to adjust the batch size, model parallel size and world size in 
-accordance with your specific use case. 
+accordance with your specific use case. For multi-node jobs, refer to documentation
+on using `torchrun` with your specific cluster setup. 
 
 
  

--- a/neuralop/training/torch_setup.py
+++ b/neuralop/training/torch_setup.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 import neuralop.mpu.comm as comm
 
@@ -19,6 +21,10 @@ def setup(config):
         device : torch.device
         is_logger : bool
     """
+    # We use Torchrun for spawning MP jobs, and torchrun auto-initializes env vars. 
+    # Check for override in case config option conflicts with the fact that we are inside a torch distributed elastic run.
+    if os.getenv("LOCAL_RANK") is not None:
+        config.distributed.use_distributed = True 
     if config.distributed.use_distributed:
         comm.init(config, verbose=config.verbose)
 


### PR DESCRIPTION
Requires `openmpi` (from `conda-forge`) to be compatible with Slurm. This update changes DDP to use the flexible `torchrun` process launcher instead of older, more complicated wireup strategies.