### PR TITLE
Build dev documentation at test time for all pull requests

### DIFF
--- a/.github/workflows/build_doc_dev.yml
+++ b/.github/workflows/build_doc_dev.yml
@@ -1,7 +1,6 @@
 name: Build documentation
 
-on:
-  push:
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
We pushed a PR that builds the doc on every push. I changed the doc job to run and only push on success for all pull requests as well, as per our discussion