### PR TITLE
Implement FNO within `GINO` as an `FNOBlock` instead of a full `FNO`

### DIFF
--- a/neuralop/models/fnogno.py
+++ b/neuralop/models/fnogno.py
@@ -2,10 +2,10 @@ import torch
 import torch.nn.functional as F
 
 from .base_model import BaseModel
-from .fno import FNO
 
 from ..layers.channel_mlp import ChannelMLP
 from ..layers.embeddings import SinusoidalEmbedding2D
+from ..layers.fno_block import FNOBlocks
 from ..layers.spectral_convolution import SpectralConv
 from ..layers.integral_transform import IntegralTransform
 from ..layers.neighbor_search import NeighborSearch
@@ -100,13 +100,7 @@ class FNOGNO(BaseModel, name="FNOGNO"):
         * `factorized` : the input is directly contracted with the factors of the decomposition
     fno_decomposition_kwargs : dict, defaults to dict()
         Optionaly additional parameters to pass to the tensor decomposition.
-    fno_domain_padding : float | None, defaults to None
-        If not None, percentage of padding to use.
-    fno_domain_padding_mode : str {'symmetric', 'one-sided'}, defaults to 'one-sided'
-        How to perform domain padding.
-    fno_fft_norm : str, defaults to 'forward'
-        normalization parameter of torch.fft to use in FNO. Defaults to 'forward'
-    fno_SpectralConv : nn.Module, defaults to SpectralConv
+    fno_conv_module : nn.Module, defaults to SpectralConv
          Spectral Convolution module to use.
     """
 
@@ -148,10 +142,7 @@ class FNOGNO(BaseModel, name="FNOGNO"):
         fno_fixed_rank_modes=False,
         fno_implementation="factorized",
         fno_decomposition_kwargs=dict(),
-        fno_domain_padding=None,
-        fno_domain_padding_mode="one-sided",
-        fno_fft_norm="forward",
-        fno_SpectralConv=SpectralConv,
+        fno_conv_module=SpectralConv,
         **kwargs,
     ):
         super().__init__()
@@ -197,41 +188,45 @@ class FNOGNO(BaseModel, name="FNOGNO"):
             self.adain_pos_embed = None
             self.ada_in_dim = None
 
-        self.fno = FNO(
-            n_modes=fno_n_modes,
-            hidden_channels=fno_hidden_channels,
-            in_channels=in_channels + self.in_coord_dim,
-            out_channels=fno_hidden_channels,
-            positional_embedding=None,
-            lifting_channels=fno_lifting_channels,
-            projection_channels=1,
-            n_layers=fno_n_layers,
-            output_scaling_factor=fno_output_scaling_factor,
-            incremental_n_modes=fno_incremental_n_modes,
-            fno_block_precision=fno_block_precision,
-            use_channel_mlp=fno_use_channel_mlp,
-            channel_mlp={"expansion": fno_channel_mlp_expansion, "dropout": fno_channel_mlp_dropout},
-            non_linearity=fno_non_linearity,
-            stabilizer=fno_stabilizer,
-            norm=fno_norm,
-            ada_in_features=self.ada_in_dim,
-            preactivation=fno_preactivation,
-            fno_skip=fno_skip,
-            channel_mlp_skip=fno_channel_mlp_skip,
-            separable=fno_separable,
-            factorization=fno_factorization,
-            rank=fno_rank,
-            joint_factorization=fno_joint_factorization,
-            fixed_rank_modes=fno_fixed_rank_modes,
-            implementation=fno_implementation,
-            decomposition_kwargs=fno_decomposition_kwargs,
-            domain_padding=fno_domain_padding,
-            domain_padding_mode=fno_domain_padding_mode,
-            fft_norm=fno_fft_norm,
-            SpectralConv=fno_SpectralConv,
-            **kwargs,
+        # Create lifting for FNOBlock separately
+        self.lifting = ChannelMLP(in_channels=in_channels + self.in_coord_dim,
+                                  hidden_channels=fno_lifting_channels,
+                                  out_channels=fno_hidden_channels,
+                                  n_layers=3)
+        
+        self.fno_hidden_channels = fno_hidden_channels
+        self.fno_blocks = FNOBlocks(
+                n_modes=fno_n_modes,
+                hidden_channels=fno_hidden_channels,
+                in_channels=fno_hidden_channels,
+                out_channels=fno_hidden_channels,
+                positional_embedding=None,
+                n_layers=fno_n_layers,
+                output_scaling_factor=fno_output_scaling_factor,
+                incremental_n_modes=fno_incremental_n_modes,
+                fno_block_precision=fno_block_precision,
+                use_channel_mlp=fno_use_channel_mlp,
+                channel_mlp_expansion=fno_channel_mlp_expansion,
+                channel_mlp_dropout=fno_channel_mlp_dropout,
+                non_linearity=fno_non_linearity,
+                stabilizer=fno_stabilizer, 
+                norm=fno_norm,
+                ada_in_features=self.ada_in_dim,
+                preactivation=fno_preactivation,
+                fno_skip=fno_skip,
+                channel_mlp_skip=fno_channel_mlp_skip,
+                separable=fno_separable,
+                factorization=fno_factorization,
+                rank=fno_rank,
+                joint_factorization=fno_joint_factorization, 
+                fixed_rank_modes=fno_fixed_rank_modes,
+                implementation=fno_implementation,
+                decomposition_kwargs=fno_decomposition_kwargs,
+                domain_padding=None,
+                domain_padding_mode=None,
+                conv_module=fno_conv_module,
+                **kwargs
         )
-        del self.fno.projection
 
         self.nb_search_out = NeighborSearch(use_open3d=gno_use_open3d)
         self.gno_radius = gno_radius
@@ -293,19 +288,13 @@ class FNOGNO(BaseModel, name="FNOGNO"):
             else:
                 ada_in_embed = ada_in
 
-            self.fno.fno_blocks.set_ada_in_embeddings(ada_in_embed)
+            self.fno_blocks.set_ada_in_embeddings(ada_in_embed)
 
         # Apply FNO blocks
 
-        in_p = self.fno.lifting(in_p)
-        if self.fno.domain_padding is not None:
-            in_p = self.fno.domain_padding.pad(in_p)
-
-        for layer_idx in range(self.fno.n_layers):
-            in_p = self.fno.fno_blocks(in_p, layer_idx)
-
-        if self.fno.domain_padding is not None:
-            in_p = self.fno.domain_padding.unpad(in_p)
+        in_p = self.lifting(in_p)
+        for layer_idx in range(self.fno_blocks.n_layers):
+            in_p = self.fno_blocks(in_p, layer_idx)
 
         if self.gno_batched:
             return in_p
@@ -352,11 +341,11 @@ class FNOGNO(BaseModel, name="FNOGNO"):
             batch_size = latent_embed.shape[0]
             latent_embed = latent_embed.permute(
                 0, *self.in_coord_dim_reverse_order, 1
-            ).reshape((batch_size, -1, self.fno.hidden_channels))
+            ).reshape((batch_size, -1, self.fno_hidden_channels))
         else:
             latent_embed = latent_embed.permute(
                 *self.in_coord_dim_reverse_order, 0
-            ).reshape((-1, self.fno.hidden_channels))
+            ).reshape((-1, self.fno_hidden_channels))
 
         # (n_out, fno_hidden_channels)
         out = self.gno(

--- a/neuralop/models/gino.py
+++ b/neuralop/models/gino.py
@@ -198,7 +198,7 @@ class GINO(nn.Module):
         else:
             self.adain_pos_embed = None
             self.ada_in_dim = None
-        
+
         self.lifting = ChannelMLP(in_channels=self.fno_in_channels,
                                   hidden_channels=lifting_channels,
                                   out_channels=fno_hidden_channels,

--- a/neuralop/models/gino.py
+++ b/neuralop/models/gino.py
@@ -142,7 +142,7 @@ class GINO(nn.Module):
             fno_incremental_n_modes=None,
             fno_block_precision='full',
             fno_use_channel_mlp=False, 
-            fno_channel_mlp_dropout=0, 
+            fno_channel_mlp_dropout=0,
             fno_channel_mlp_expansion=0.5,
             fno_non_linearity=F.gelu,
             fno_stabilizer=None, 

--- a/neuralop/models/gino.py
+++ b/neuralop/models/gino.py
@@ -5,10 +5,10 @@ import time
 
 from torch import nn
 
-from .fno import FNO
 
 from ..layers.channel_mlp import ChannelMLP
 from ..layers.embeddings import SinusoidalEmbedding2D
+from ..layers.fno_block import FNOBlocks
 from ..layers.spectral_convolution import SpectralConv
 from ..layers.integral_transform import IntegralTransform
 from ..layers.neighbor_search import NeighborSearch
@@ -60,7 +60,7 @@ class GINO(nn.Module):
             to use in FNO, by default (16, 16, 16)
         fno_hidden_channels : int, optional
             hidden channels for use in FNO, by default 64
-        fno_lifting_channels : int, optional
+        lifting_channels : int, optional
             number of channels in FNO's pointwise lifting, by default 256
         fno_projection_channels : int, optional
             number of channels in FNO's pointwise projection, by default 256
@@ -113,13 +113,7 @@ class GINO(nn.Module):
             * `factorized` : the input is directly contracted with the factors of the decomposition
         fno_decomposition_kwargs : dict, defaults to dict()
             Optionaly additional parameters to pass to the tensor decomposition.
-        fno_domain_padding : float | None, defaults to None
-            If not None, percentage of padding to use.
-        fno_domain_padding_mode : str {'symmetric', 'one-sided'}, defaults to 'one-sided'
-            How to perform domain padding.
-        fno_fft_norm : str, defaults to 'forward'
-            normalization parameter of torch.fft to use in FNO. Defaults to 'forward'
-        fno_SpectralConv : nn.Module, defaults to SpectralConv
+        fno_conv_module : nn.Module, defaults to SpectralConv
             Spectral Convolution module to use.
         """
     def __init__(
@@ -142,8 +136,7 @@ class GINO(nn.Module):
             fno_in_channels=3,
             fno_n_modes=(16, 16, 16), 
             fno_hidden_channels=64,
-            fno_lifting_channels=256,
-            fno_projection_channels=256,
+            lifting_channels=256,
             fno_n_layers=4,
             fno_output_scaling_factor=None,
             fno_incremental_n_modes=None,
@@ -166,10 +159,7 @@ class GINO(nn.Module):
             fno_fixed_rank_modes=False,
             fno_implementation='factorized',
             fno_decomposition_kwargs=dict(),
-            fno_domain_padding=None,
-            fno_domain_padding_mode='one-sided',
-            fno_fft_norm='forward',
-            fno_SpectralConv=SpectralConv,
+            fno_conv_module=SpectralConv,
             **kwargs
         ):
         
@@ -178,6 +168,7 @@ class GINO(nn.Module):
         self.out_channels = out_channels
         self.gno_coord_dim = gno_coord_dim
         self.fno_hidden_channels = fno_hidden_channels
+        self.lifting_channels = lifting_channels
 
         # TODO: make sure this makes sense in all contexts
         fno_in_channels = self.in_channels
@@ -207,20 +198,23 @@ class GINO(nn.Module):
             self.adain_pos_embed = None
             self.ada_in_dim = None
         
-        self.fno = FNO(
+        self.lifting = ChannelMLP(in_channels=self.in_channels,
+                                  hidden_channels=self.lifting_channels,
+                                  out_channels=fno_in_channels)
+        
+        self.fno_blocks = FNOBlocks(
                 n_modes=fno_n_modes,
                 hidden_channels=fno_hidden_channels,
                 in_channels=fno_in_channels,
                 out_channels=fno_hidden_channels,
                 positional_embedding=None,
-                lifting_channels=fno_lifting_channels,
-                projection_channels=fno_projection_channels,
                 n_layers=fno_n_layers,
                 output_scaling_factor=fno_output_scaling_factor,
                 incremental_n_modes=fno_incremental_n_modes,
                 fno_block_precision=fno_block_precision,
                 use_channel_mlp=fno_use_channel_mlp,
-                ChannelMLP={"expansion": fno_channel_mlp_expansion, "dropout": fno_channel_mlp_dropout},
+                channel_mlp_expansion=fno_channel_mlp_expansion,
+                channel_mlp_dropout=fno_channel_mlp_dropout,
                 non_linearity=fno_non_linearity,
                 stabilizer=fno_stabilizer, 
                 norm=fno_norm,
@@ -235,13 +229,11 @@ class GINO(nn.Module):
                 fixed_rank_modes=fno_fixed_rank_modes,
                 implementation=fno_implementation,
                 decomposition_kwargs=fno_decomposition_kwargs,
-                domain_padding=fno_domain_padding,
-                domain_padding_mode=fno_domain_padding_mode,
-                fft_norm=fno_fft_norm,
-                SpectralConv=fno_SpectralConv,
+                domain_padding=None,
+                domain_padding_mode=None,
+                conv_module=fno_conv_module,
                 **kwargs
         )
-        del self.fno.projection
 
         self.nb_search_out = NeighborSearch(use_open3d=gno_use_open3d)
         self.gno_radius = gno_radius
@@ -311,17 +303,12 @@ class GINO(nn.Module):
             else:
                 ada_in_embed = ada_in
 
-            self.fno.fno_blocks.set_ada_in_embeddings(ada_in_embed)
+            self.fno_blocks.set_ada_in_embeddings(ada_in_embed)
 
         #Apply FNO blocks
-        in_p = self.fno.lifting(in_p)
-        if self.fno.domain_padding is not None:
-            in_p = self.fno.domain_padding.pad(in_p)
-        for layer_idx in range(self.fno.n_layers):
-            in_p = self.fno.fno_blocks(in_p, layer_idx)
+        in_p = self.lifting(in_p)
+        in_p = self.fno_blocks(in_p)
 
-        if self.fno.domain_padding is not None:
-            in_p = self.fno.domain_padding.unpad(in_p)
         return in_p 
 
     def integrate_latent(self, in_p, out_p, latent_embed):
@@ -347,23 +334,18 @@ class GINO(nn.Module):
             out_p_embed = self.pos_embed(out_p.reshape(-1, )).reshape((n_out, -1))
         else:
             out_p_embed = out_p #.reshape((n_out, -1))
-        
-        print(f"{latent_embed.shape=}")
-        
+                
         #latent_embed shape b, c, n_1, n_2, ..., n_k
-        latent_embed = latent_embed.permute(0, *self.in_coord_dim_reverse_order, 1).reshape(batch_size, -1, self.fno.hidden_channels)
+        latent_embed = latent_embed.permute(0, *self.in_coord_dim_reverse_order, 1).reshape(batch_size, -1, self.fno_hidden_channels)
         # shape b, n_out, channels
-        print(f"{latent_embed.shape=} after permute")
         if self.out_gno_tanh in ['latent_embed', 'both']:
             latent_embed = torch.tanh(latent_embed)
         #(n_out, fno_hidden_channels)
-        print("---going into output GNO---")
         out = self.gno_out(y=in_p_embed, 
                     neighbors=in_to_out_nb,
                     x=out_p_embed,
                     f_y=latent_embed,)
                     #weighting_fn=self.gno_weighting_fn)
-        print(f"{out.shape=}")
         out = out.permute(0, 2, 1)
         # Project pointwise to out channels
         #(b, n_in, out_channels)

--- a/neuralop/models/tests/test_gino.py
+++ b/neuralop/models/tests/test_gino.py
@@ -44,7 +44,6 @@ def test_gino(gno_transform_type, gno_coord_dim, batch_size):
         fno_n_modes=fno_n_modes[:gno_coord_dim],
         # keep the FNO model small for runtime
         fno_lifting_channels=lifting_channels,
-        fno_projection_channels=projection_channels,
         fno_norm="ada_in", #TODO: Parametrize this
     ).to(device)
 
@@ -86,6 +85,7 @@ def test_gino(gno_transform_type, gno_coord_dim, batch_size):
     n_unused_params = 0
     for param in model.parameters():
         if param.grad is None:
+            print(f"{param=}")
             n_unused_params += 1
     assert n_unused_params == 0, f"{n_unused_params} parameters were unused!"
     if batch_size > 1:

--- a/neuralop/models/tests/test_gino.py
+++ b/neuralop/models/tests/test_gino.py
@@ -85,7 +85,6 @@ def test_gino(gno_transform_type, gno_coord_dim, batch_size):
     n_unused_params = 0
     for param in model.parameters():
         if param.grad is None:
-            print(f"{param=}")
             n_unused_params += 1
     assert n_unused_params == 0, f"{n_unused_params} parameters were unused!"
     if batch_size > 1:


### PR DESCRIPTION
We already delete the FNO's projection. It's cleaner to create an `FNOBlock` and a `lifting` layer separately ourselves. Domain padding is not necessary in the `GINO`.