### PR TITLE
Add FC more explicitly for dimensions other than 2

### DIFF
--- a/neuralop/layers/fourier_continuation.py
+++ b/neuralop/layers/fourier_continuation.py
@@ -63,11 +63,17 @@ class FCLegendre(nn.Module):
 
         return torch.cat((x, ext), dim=-2)
     
+    def extend1d(self, x):
+        return self.extend_left_right(x)
+    
     def extend2d(self, x):
         x = self.extend_left_right(x)
         x = self.extend_top_bottom(x)
 
         return x
     
-    def forward(self, x):
-        return self.extend2d(x)
+    def forward(self, x, dim):
+        if dim == 1:
+            return self.extend1d(x)
+        if dim == 2:
+            return self.extend2d(x)


### PR DESCRIPTION
The Fourier Continuation layer is only explicitly written for 2D inputs.

The continuation is done along each dimension separately, so the code could actually be used for 1D inputs or higher dimensional inputs with minor changes.

Could we make the use of the FC layer more explicit for other dimensions?

I suggested a simple code update to have 1D FC, but you might want to make it more general and have the forward take as an input a tuple of dimensions along which the FC is performed.