### PR TITLE
(fix) auto-build and push docs to new git repo for website

### DIFF
--- a/.github/workflows/build_doc_dev.yml
+++ b/.github/workflows/build_doc_dev.yml
@@ -63,7 +63,7 @@ jobs:
         git rm -r dev/*
         mkdir -p dev
         echo "Copying to folder"
-        cp -r ../doc/_build/html/* dev/
+        cp -r ../doc/build/html/* dev/
         echo "Pushing to git"
         git add dev
         git commit -m "Github action: auto-update."

--- a/.github/workflows/build_doc_stable.yml
+++ b/.github/workflows/build_doc_stable.yml
@@ -68,7 +68,7 @@ jobs:
       fi
       mkdir -p stable
       echo "Copying to folder"
-      cp -r ../doc/_build/html/* stable/
+      cp -r ../doc/build/html/* stable/
       echo "Pushing to git"
       git add dev
       git commit -m "Github action: auto-update."


### PR DESCRIPTION
Location was broken, causing the job to fail. Provided the correct folder now