### PR TITLE
(fix) set commit=False for first log of training recipes

### DIFF
--- a/scripts/train_burgers.py
+++ b/scripts/train_burgers.py
@@ -194,7 +194,7 @@ if is_logger:
             to_log["n_params_baseline"] = (config.n_params_baseline,)
             to_log["compression_ratio"] = (config.n_params_baseline / n_params,)
             to_log["space_savings"] = 1 - (n_params / config.n_params_baseline)
-        wandb.log(to_log)
+        wandb.log(to_log, commit=False)
         wandb.watch(model)
 
 

--- a/scripts/train_car_cfd.py
+++ b/scripts/train_car_cfd.py
@@ -174,7 +174,7 @@ trainer = Trainer(model=model,
                   )
 
 if config.wandb.log:
-    wandb.log({'time_to_distance': data_module.time_to_distance})
+    wandb.log({'time_to_distance': data_module.time_to_distance}, commit=False)
 
 trainer.train(
               train_loader=train_loader,

--- a/scripts/train_darcy.py
+++ b/scripts/train_darcy.py
@@ -175,7 +175,7 @@ if is_logger:
             to_log["n_params_baseline"] = (config.n_params_baseline,)
             to_log["compression_ratio"] = (config.n_params_baseline / n_params,)
             to_log["space_savings"] = 1 - (n_params / config.n_params_baseline)
-        wandb.log(to_log)
+        wandb.log(to_log, commit=False)
         wandb.watch(model)
 
 trainer.train(

--- a/scripts/train_navier_stokes.py
+++ b/scripts/train_navier_stokes.py
@@ -184,7 +184,7 @@ if is_logger:
             to_log["n_params_baseline"] = (config.n_params_baseline,)
             to_log["compression_ratio"] = (config.n_params_baseline / n_params,)
             to_log["space_savings"] = 1 - (n_params / config.n_params_baseline)
-        wandb.log(to_log)
+        wandb.log(to_log, commit=False)
         wandb.watch(model)
 
 


### PR DESCRIPTION
Currently all training recipes log a set of static parameters to wandb before running training. This will cause the trainer to drop the first step of actual training metrics. Fix: set `commit=False` in that first log statement 