### PR TITLE
Bug fix in MGPatchingDataProcessor.to(device)

### DIFF
--- a/neuralop/data/transforms/data_processors.py
+++ b/neuralop/data/transforms/data_processors.py
@@ -344,6 +344,7 @@ class MGPatchingDataProcessor(DataProcessor):
             self.in_normalizer = self.in_normalizer.to(self.device)
         if self.out_normalizer:
             self.out_normalizer = self.out_normalizer.to(self.device)
+        return self
 
     def preprocess(self, data_dict, batched=True):
         """


### PR DESCRIPTION
Used to return none, now returns self for compat/trainer behavior