### PR TITLE
(fix) Remove `from_checkpoint` in `load_training_state` to avoid overwriting model

### DIFF
--- a/neuralop/training/trainer.py
+++ b/neuralop/training/trainer.py
@@ -588,7 +588,6 @@ class Trainer:
         """
         if isinstance(save_dir, str):
             save_dir = Path(save_dir)
-        print(f"{save_dir=} {type(save_dir)}")
 
         # check for save model exists
         if (save_dir / "best_model_state_dict.pt").exists():

--- a/neuralop/training/training_state.py
+++ b/neuralop/training/training_state.py
@@ -43,8 +43,8 @@ def load_training_state(save_dir: Union[str, Path],
 
     Returns
     -------
-    dict of training state
-        keyed `{'model': model, etc}`
+    tuple of training state
+        ``model, optimizer, scheduler, regularizer, epoch``
         
     """
     if not map_location:
@@ -71,8 +71,9 @@ def load_training_state(save_dir: Union[str, Path],
         model = model.to(device=f"cuda:{device_id}")
         torch.cuda.empty_cache()
     else:
-        model = model.from_checkpoint(save_dir.absolute().as_posix(), save_name, map_location=map_location)
-    
+        save_pth = save_dir / f"{save_name}_state_dict.pt"
+        model.load_state_dict(torch.load(save_pth.absolute().as_posix()))
+
     # load optimizer if state exists
     if optimizer is not None:
         optimizer_pth = save_dir / "optimizer.pt"


### PR DESCRIPTION
Thanks to authors of #480 and @JeanKossaifi for catching this. 