### PR TITLE
Fix pyproject.toml to enable pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["neuralop"]
+include = ["neuralop*"]
 
 # Dynamic versioning from neuralop.__init__
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Thank you for mentaining a nice library.

When we `pip install neuraloperator`, currently we cannot install the main body of the library and we just get:
```
root@971493d5a2e0:/# ls /usr/local/lib/python3.13/site-packages/neuralop
__init__.py  __pycache__  utils.py
```

This is caused by the `tool.setuptoold.packages.find` part of `pyproject.toml` setting. This PR fix it. We just need `*` at the end.
cf. https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration
