### PR TITLE
added sources to include for sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,10 @@ requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["neuralop"]
+include = [
+    "neuralop",
+    "neuralop.*",    
+]
 
 # Dynamic versioning from neuralop.__init__
 [tool.setuptools.dynamic]


### PR DESCRIPTION
This fixes the sdist build to ensure that all submodules under `neuralop` are packaged. Please see [my comment](https://github.com/neuraloperator/neuraloperator/issues/62#issuecomment-2565677911) on why this is an issue and how this PR fixes it.

Fixes #62