### PR TITLE
add secret for test pypi (remove deprecated trusted publisher config)

### DIFF
--- a/.github/workflows/deploy_pypi.yml
+++ b/.github/workflows/deploy_pypi.yml
@@ -60,9 +60,6 @@ jobs:
       name: testpypi
       url: https://test.pypi.org/p/neuraloperator
 
-    permissions:
-      id-token: write
-
     steps:
     - name: Download all the dists
       uses: actions/download-artifact@v4
@@ -73,7 +70,8 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
-
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+  
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI

--- a/.github/workflows/deploy_pypi.yml
+++ b/.github/workflows/deploy_pypi.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -28,6 +27,12 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: |
           python -m build
+      - name: Install neuralop from built wheel and ensure it passes all tests
+        run: |
+          python -m pip uninstall neuraloperator -yyy
+          WHEEL_FILE=$(ls dist/*.whl | head -1)
+          python -m pip install $WHEEL_FILE
+          pytest neuralop
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
@JeanKossaifi : the simplest way for us to fix the Test-PyPI part of our action is to add a secret to Secrets --> Actions named `TEST_PYPI_API_KEY`, which I've changed the workflow to use. 