### PR TITLE
GINO/FNOGNO train recipes closer to paper results

### DIFF
--- a/config/fnogno_carcfd_config.yaml
+++ b/config/fnogno_carcfd_config.yaml
@@ -15,16 +15,10 @@ cfd: &CFD
   # Dataset related
   data:
     root: /home/YOURNAME/data/car-pressure-data/
-    entity_name: ''
-    load_attributes: ['press']
     sdf_query_resolution: 32
     n_train: 500
-    n_test: 50
-    input_points: 'query_points'
-    input_fields: ['distance']
-    output_points: 'centroids'
-    output_fields: ['press']
-    weights: 'triangle_areas' # unused with pressure only
+    n_test: 111
+    download: True
 
   fnogno:
     data_channels: 1

--- a/config/gino_carcfd_config.yaml
+++ b/config/gino_carcfd_config.yaml
@@ -16,9 +16,9 @@ cfd: &CFD
   data:
     root: /home/YOURNAME/data/car-pressure-data/
     sdf_query_resolution: 32
-    n_train: 50
-    n_test: 500
-    download: False
+    n_train: 500
+    n_test: 111
+    download: True
 
   gino:
     data_channels: 0

--- a/neuralop/data/datasets/car_cfd_dataset.py
+++ b/neuralop/data/datasets/car_cfd_dataset.py
@@ -1,6 +1,8 @@
 from typing import List, Union
 from pathlib import Path
 
+import torch
+
 from .mesh_datamodule import MeshDataModule
 from .web_utils import download_from_zenodo_record
 
@@ -82,3 +84,11 @@ class CarCFDDataset(MeshDataModule):
             query_res=query_res,
             attributes=['press']
         )
+
+        # process data list to remove specific vertices from pressure to match number of vertices
+        for i, data in enumerate(self.train_data.data_list):
+            press = data['press']
+            self.train_data.data_list[i]['press'] = torch.cat((press[:,0:16], press[:,112:]), axis=1)
+        for i, data in enumerate(self.test_data.data_list):
+            press = data['press']
+            self.test_data.data_list[i]['press'] = torch.cat((press[:,0:16], press[:,112:]), axis=1)

--- a/scripts/train_fnogno_carcfd.py
+++ b/scripts/train_fnogno_carcfd.py
@@ -143,9 +143,10 @@ class CFDDataProcessor(DataProcessor):
         return sample
     
     def postprocess(self, out, sample):
-        out = self.normalizer.inverse_transform(out)
-        y = self.normalizer.inverse_transform(sample['y'].squeeze(0))
-        sample['y'] = y
+        if not self.training:
+            out = self.normalizer.inverse_transform(out)
+            y = self.normalizer.inverse_transform(sample['y'].squeeze(0))
+            sample['y'] = y
 
         return out, sample
     

--- a/scripts/train_gino_carcfd.py
+++ b/scripts/train_gino_carcfd.py
@@ -118,13 +118,11 @@ class GINOCFDDataProcessor(DataProcessor):
         #Output data
         truth = sample['press'].squeeze(0).unsqueeze(-1)
 
-        # Take the first 3682 vertices of the output mesh to correspond to pressure
-        # if there are less than 3682 vertices, take the maximum number of truth points
+        # Take the first 3586 vertices of the output mesh to correspond to pressure
+        # if there are less than 3586 vertices, take the maximum number of truth points
         output_vertices = truth.shape[1]
         if out_p.shape[0] > output_vertices:
             out_p = out_p[:output_vertices,:]
-        elif out_p.shape[0] < output_vertices:
-            truth = truth[:, :out_p.shape[0], ...]
 
         truth = truth.to(device)
 
@@ -140,9 +138,10 @@ class GINOCFDDataProcessor(DataProcessor):
         return sample
     
     def postprocess(self, out, sample):
-        out = self.normalizer.inverse_transform(out)
-        y = self.normalizer.inverse_transform(sample['y'].squeeze(0))
-        sample['y'] = y
+        if not self.training:
+            out = self.normalizer.inverse_transform(out)
+            y = self.normalizer.inverse_transform(sample['y'].squeeze(0))
+            sample['y'] = y
 
         return out, sample
     
@@ -180,6 +179,5 @@ trainer.train(
               optimizer=optimizer,
               scheduler=scheduler,
               training_loss=train_loss_fn,
-              #eval_losses={config.opt.testing_loss: test_loss_fn, 'drag': DragLoss},
               eval_losses={config.opt.testing_loss: test_loss_fn},
               regularizer=None,)


### PR DESCRIPTION
Thanks to Xinyi for finding this bug. The `CarCFDDataset` contains extra vertices in the `pressure` attribute that need to be manually removed. The error is now far closer to what is claimed in the GINO paper.

In response to #515 