### PR TITLE
remove zarr required dep for compatibility with HPC clusters

### DIFF
--- a/neuralop/data/datasets/zarr_dataset.py
+++ b/neuralop/data/datasets/zarr_dataset.py
@@ -1,5 +1,8 @@
 import torch
-import zarr
+try:
+    import zarr
+except ModuleNotFoundError as e:
+    raise e("trying to import zarr_dataset without optional dependency zarr. Please install and try again.")
 from torch.utils.data import Dataset
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "numpy>=1.25",
     "opt-einsum",
     "h5py",
-    "zarr",
 ]
 requires-python = ">=3.9"
 readme = "README.rst"


### PR DESCRIPTION
Installations on new clusters with NVIDIA Grace CPUs fail on installing `numcodecs`, which is a dependency of `zarr` . Our `zarr_dataset` is currently unused in the main build, so for now let's remove the dependency and make it optional for users who wish to use the `zarr_dataset`