### PR TITLE
Reintroduce the use_channel_mlp option

### DIFF
--- a/neuralop/layers/local_no_block.py
+++ b/neuralop/layers/local_no_block.py
@@ -69,6 +69,8 @@ class LocalNOBlocks(nn.Module):
         maximum number of modes to keep along each dimension, by default None
     local_no_block_precision : str, optional
         floating point precision to use for computations, by default "full"
+    use_channel_mlp : bool, optional
+        Whether to use an MLP layer after each block, by default True
     channel_mlp_dropout : int, optional
         dropout parameter for self.channel_mlp, by default 0
     channel_mlp_expansion : float, optional

--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -36,7 +36,7 @@ class FNO(BaseModel, name='FNO'):
     out_channels : int
         Number of channels in output function
     hidden_channels : int
-        width of the FNO (i.e. number of channels), by default 256
+        width of the FNO (i.e. number of channels)
     n_layers : int, optional
         Number of Fourier Layers, by default 4
 
@@ -47,11 +47,11 @@ class FNO(BaseModel, name='FNO'):
     lifting_channel_ratio : int, optional
         ratio of lifting channels to hidden_channels, by default 2
         The number of liting channels in the lifting block of the FNO is
-        lifting_channel_ratio * hidden_channels (e.g. default 512)
+        lifting_channel_ratio * hidden_channels (e.g. default 2 * hidden_channels)
     projection_channel_ratio : int, optional
         ratio of projection channels to hidden_channels, by default 2
         The number of projection channels in the projection block of the FNO is
-        projection_channel_ratio * hidden_channels (e.g. default 512)
+        projection_channel_ratio * hidden_channels (e.g. default 2 * hidden_channels)
     positional_embedding : Union[str, nn.Module], optional
         Positional embedding to apply to last channels of raw input
         before being passed through the FNO. Defaults to "grid"
@@ -72,6 +72,8 @@ class FNO(BaseModel, name='FNO'):
     complex_data : bool, optional
         Whether data is complex-valued (default False)
         if True, initializes complex-valued modules.
+    use_channel_mlp : bool, optional
+        Whether to use an MLP layer after each FNO block, by default True
     channel_mlp_dropout : float, optional
         dropout parameter for ChannelMLP in FNO Block, by default 0
     channel_mlp_expansion : float, optional
@@ -172,6 +174,7 @@ class FNO(BaseModel, name='FNO'):
         non_linearity: nn.Module=F.gelu,
         norm: Literal ["ada_in", "group_norm", "instance_norm"]=None,
         complex_data: bool=False,
+        use_channel_mlp: bool=True,
         channel_mlp_dropout: float=0,
         channel_mlp_expansion: float=0.5,
         channel_mlp_skip: Literal['linear', 'identity', 'soft-gating']="soft-gating",
@@ -268,6 +271,7 @@ class FNO(BaseModel, name='FNO'):
             out_channels=hidden_channels,
             n_modes=self.n_modes,
             resolution_scaling_factor=resolution_scaling_factor,
+            use_channel_mlp=use_channel_mlp,
             channel_mlp_dropout=channel_mlp_dropout,
             channel_mlp_expansion=channel_mlp_expansion,
             non_linearity=non_linearity,

--- a/neuralop/models/fnogno.py
+++ b/neuralop/models/fnogno.py
@@ -68,7 +68,7 @@ class FNOGNO(BaseModel, name="FNOGNO"):
         if passed, sets n_modes separately for each FNO layer.
     fno_block_precision : str, defaults to 'full'
         data precision to compute within fno block
-    fno_use_channel_mlp : bool, defaults to False
+    fno_use_channel_mlp : bool, defaults to True
         Whether to use a ChannelMLP layer after each FNO block.
     fno_channel_mlp_dropout : float, defaults to 0
         dropout parameter of above ChannelMLP.
@@ -137,6 +137,7 @@ class FNOGNO(BaseModel, name="FNOGNO"):
         fno_resolution_scaling_factor=None,
         fno_incremental_n_modes=None,
         fno_block_precision="full",
+        fno_use_channel_mlp=True,
         fno_channel_mlp_dropout=0,
         fno_channel_mlp_expansion=0.5,
         fno_non_linearity=F.gelu,
@@ -223,6 +224,7 @@ class FNOGNO(BaseModel, name="FNOGNO"):
                 resolution_scaling_factor=fno_resolution_scaling_factor,
                 incremental_n_modes=fno_incremental_n_modes,
                 fno_block_precision=fno_block_precision,
+                use_channel_mlp=fno_use_channel_mlp,
                 channel_mlp_expansion=fno_channel_mlp_expansion,
                 channel_mlp_dropout=fno_channel_mlp_dropout,
                 non_linearity=fno_non_linearity,

--- a/neuralop/models/local_no.py
+++ b/neuralop/models/local_no.py
@@ -31,7 +31,7 @@ class LocalNO(BaseModel, name='LocalNO'):
     out_channels : int
         Number of channels in output function
     hidden_channels : int
-        width of the Local NO (i.e. number of channels), by default 256
+        width of the Local NO (i.e. number of channels)
     default_in_shape : Tuple[int]
         Default input shape on spatiotemporal dimensions for structured DISCO convolutions
     n_layers : int, optional
@@ -66,11 +66,11 @@ class LocalNO(BaseModel, name='LocalNO'):
     lifting_channel_ratio : int, optional
         ratio of lifting channels to hidden_channels, by default 2
         The number of liting channels in the lifting block of the Local FNO is
-        lifting_channel_ratio * hidden_channels (e.g. default 512)
+        lifting_channel_ratio * hidden_channels (e.g. default 2 * hidden_channels )
     projection_channel_ratio : int, optional
         ratio of projection channels to hidden_channels, by default 2
         The number of projection channels in the projection block of the Local FNO is
-        projection_channel_ratio * hidden_channels (e.g. default 512)
+        projection_channel_ratio * hidden_channels (e.g. default 2 * hidden_channels )
     positional_embedding : Union[str, nn.Module], optional
         Positional embedding to apply to last channels of raw input
         before being passed through the Local FNO. Defaults to "grid"
@@ -91,14 +91,16 @@ class LocalNO(BaseModel, name='LocalNO'):
     complex_data : bool, optional
         Whether data is complex-valued (default False)
         if True, initializes complex-valued modules.
+    use_channel_mlp : bool, optional
+        Whether to use an MLP layer after each LocalNO block, by default False
     channel_mlp_dropout : float, optional
-        dropout parameter for ChannelMLP in FNO Block, by default 0
+        dropout parameter for ChannelMLP in LocalNO Block, by default 0
     channel_mlp_expansion : float, optional
-        expansion parameter for ChannelMLP in FNO Block, by default 0.5
+        expansion parameter for ChannelMLP in LocalNO Block, by default 0.5
     channel_mlp_skip : str {'linear', 'identity', 'soft-gating'}, optional
         Type of skip connection to use in channel-mixing mlp, by default 'soft-gating'
     local_no_skip : str {'linear', 'identity', 'soft-gating'}, optional
-        Type of skip connection to use in FNO layers, by default 'linear'
+        Type of skip connection to use in LocalNO layers, by default 'linear'
     resolution_scaling_factor : Union[Number, List[Number]], optional
         layer-wise factor by which to scale the domain resolution of function, by default None
         
@@ -197,6 +199,7 @@ class LocalNO(BaseModel, name='LocalNO'):
         non_linearity: nn.Module=F.gelu,
         norm: str=None,
         complex_data: bool=False,
+        use_channel_mlp: bool=False,
         channel_mlp_dropout: float=0,
         channel_mlp_expansion: float=0.5,
         channel_mlp_skip: str="soft-gating",
@@ -304,6 +307,7 @@ class LocalNO(BaseModel, name='LocalNO'):
             conv_padding_mode=conv_padding_mode,
             fin_diff_kernel_size=fin_diff_kernel_size,
             mix_derivatives=mix_derivatives,
+            use_channel_mlp=use_channel_mlp,
             channel_mlp_dropout=channel_mlp_dropout,
             channel_mlp_expansion=channel_mlp_expansion,
             non_linearity=non_linearity,


### PR DESCRIPTION
Reintroduce the option to activate or deactivate the ChannelMLP (by default True so existing codes still work)

I have encountered examples where FNO works significantly better without the ChannelMLP

I think there might have been discussions to rename it as ChannelMixing ? 
This could be the opportunity to do it at the same time


(Also cleaned up some outdated default values in the docstrings)