### PR TITLE
(fix) Run burgers_1dtime properly

### DIFF
--- a/config/burgers_config.yaml
+++ b/config/burgers_config.yaml
@@ -4,7 +4,7 @@ default: &DEFAULT
   # For computing compression
   n_params_baseline: None
   verbose: True
-  arch: 'tfno2d'
+  arch: 'fno'
 
   #Distributed computing
   distributed:
@@ -15,10 +15,10 @@ default: &DEFAULT
     seed: 666
 
   # FNO related
-  tfno2d:
-    data_channels: 3
-    n_modes_height: 15
-    n_modes_width: 15
+  fno:
+    data_channels: 1
+    out_channels: 1
+    n_modes: [8, 8]
     hidden_channels: 24
     lifting_channel_ratio: 1
     projection_channel_ratio: 1
@@ -31,8 +31,6 @@ default: &DEFAULT
     implementation: 'factorized'
     separable: 0
     preactivation: 0
-    half_prec_fourier: False
-    half_prec_inverse: False
     stabilizer: None
 
     use_channel_mlp: 1
@@ -63,7 +61,7 @@ default: &DEFAULT
 
   # Dataset related
   data:
-    folder: '/home/ubuntu/data/burgers/burgers.npz' 
+    folder: 'neuralop/data/datasets/data/' 
     batch_size: 16
     n_train: 800
     test_batch_sizes: [16]

--- a/neuralop/data/datasets/__init__.py
+++ b/neuralop/data/datasets/__init__.py
@@ -1,7 +1,7 @@
 from .darcy import DarcyDataset, load_darcy_flow_small
 from .navier_stokes import NavierStokesDataset, load_navier_stokes_pt 
 from .pt_dataset import PTDataset
-from .burgers import Burgers1dTimeDataset
+from .burgers import Burgers1dTimeDataset, load_mini_burgers_1dtime
 from .dict_dataset import DictDataset
 from .mesh_datamodule import MeshDataModule
 from .car_cfd_dataset import CarCFDDataset

--- a/scripts/train_burgers.py
+++ b/scripts/train_burgers.py
@@ -9,7 +9,7 @@ from neuralop import H1Loss, LpLoss, BurgersEqnLoss, ICLoss, WeightedSumLoss, Tr
 from neuralop.data.datasets import load_mini_burgers_1dtime
 from neuralop.data.transforms.data_processors import MGPatchingDataProcessor
 from neuralop.training import setup, AdamW
-from neuralop.utils import get_wandb_api_key, count_model_params
+from neuralop.utils import get_wandb_api_key, count_model_params, get_project_root
 
 
 # Read the configuration
@@ -70,10 +70,11 @@ if config.verbose:
     pipe.log()
     sys.stdout.flush()
 
+data_path = get_project_root() / config.data.folder
 # Load the Burgers dataset
-train_loader, test_loaders, output_encoder = load_mini_burgers_1dtime(data_path=config.data.folder,
+train_loader, test_loaders, data_processor = load_mini_burgers_1dtime(data_path=data_path,
         n_train=config.data.n_train, batch_size=config.data.batch_size, 
-        n_test=config.data.n_tests[0], batch_size_test=config.data.test_batch_sizes[0],
+        n_test=config.data.n_tests[0], test_batch_size=config.data.test_batch_sizes[0],
         temporal_subsample=config.data.get("temporal_subsample", 1),
         spatial_subsample=config.data.get("spatial_subsample", 1),
         )
@@ -158,13 +159,15 @@ if config.verbose:
     sys.stdout.flush()
 
 # only perform MG patching if config patching levels > 0
-data_processor = MGPatchingDataProcessor(model=model,
-                                       levels=config.patching.levels,
-                                       padding_fraction=config.patching.padding,
-                                       stitching=config.patching.stitching,
-                                       device=device,
-                                       in_normalizer=output_encoder,
-                                       out_normalizer=output_encoder)
+if config.patching.levels > 0:
+    data_processor = MGPatchingDataProcessor(model=model,
+                                        levels=config.patching.levels,
+                                        padding_fraction=config.patching.padding,
+                                        stitching=config.patching.stitching,
+                                        device=device,
+                                        in_normalizer=data_processor.in_normalizer,
+                                        out_normalizer=data_processor.out_normalizer)
+
 trainer = Trainer(
     model=model,
     n_epochs=config.opt.n_epochs,


### PR DESCRIPTION
#552 raises an important issue - the new PTdataset does not include the proper code to preprocess the 1d burgers' dataset.

* Adds `Burgers1dTimeDataProcessor` to repeat data correctly
* Reformats config for general `FNO` instead of `tfno2d`
* Proper data path