### PR TITLE
(fix) torch load with weights only set to false (serialize gelu)

### DIFF
--- a/neuralop/models/base_model.py
+++ b/neuralop/models/base_model.py
@@ -156,7 +156,7 @@ class BaseModel(torch.nn.Module):
     def load_checkpoint(self, save_folder, save_name, map_location=None):
         save_folder = Path(save_folder)
         state_dict_filepath = save_folder.joinpath(f'{save_name}_state_dict.pt').as_posix()
-        self.load_state_dict(torch.load(state_dict_filepath, map_location=map_location))
+        self.load_state_dict(torch.load(state_dict_filepath, map_location=map_location, weights_only=False))
     
     @classmethod
     def from_checkpoint(cls, save_folder, save_name, map_location=None):


### PR DESCRIPTION
Compatibility with PyTorch 2.6, which changes the default argument for `weights_only` in `torch.load` from `False` to `True`. This breaks with our defaults because `weights_only` loading mode does not support serializing the `GELU` object. 