### PR TITLE
(fix) set use_scatter=False in segmentcsr tests

### DIFF
--- a/neuralop/layers/tests/test_segment_csr.py
+++ b/neuralop/layers/tests/test_segment_csr.py
@@ -22,7 +22,7 @@ def test_native_segcsr_shapes(batch_size):
         indptr = indptr.repeat([batch_size] + [1]*indptr.ndim)
     else:
         src = src.squeeze(0)
-    out = segment_csr(src, indptr, reduction='sum', use_scatter=True)
+    out = segment_csr(src, indptr, reduction='sum', use_scatter=False)
     
     if batch_size == 1:
         assert out.shape == (len(indptr) - 1, n_channels)
@@ -33,12 +33,12 @@ def test_native_segcsr_reductions():
     src = torch.ones([10, 3])
     indptr = torch.tensor([0,3,8,10], dtype=torch.long)
 
-    out_sum = segment_csr(src, indptr, reduction='sum', use_scatter=True)
+    out_sum = segment_csr(src, indptr, reduction='sum', use_scatter=False)
     assert out_sum.shape == (3,3)
     diff = out_sum - torch.tensor([[3, 5, 2]]).T * torch.ones([3,3])
     assert not diff.nonzero().any()
     
-    out_mean = segment_csr(src, indptr, reduction='mean', use_scatter=True)
+    out_mean = segment_csr(src, indptr, reduction='mean', use_scatter=False)
     assert out_mean.shape == (3,3)
     diff = out_mean - torch.ones([3,3])
     assert not diff.nonzero().any()

--- a/neuralop/models/tests/test_gino.py
+++ b/neuralop/models/tests/test_gino.py
@@ -1,8 +1,14 @@
 import torch
-from torch.autograd import grad
 import pytest
 from tensorly import tenalg
 tenalg.set_backend("einsum")
+
+# Parameterize use of torch_scatter if it is built
+try: 
+    from torch_scatter import segment_csr
+    use_torch_scatter = [True, False]
+except:
+    use_torch_scatter = [False]
 
 from ..gino import GINO
 
@@ -28,7 +34,8 @@ fno_ada_in_features = 4
     "gno_transform_type", ["linear", "nonlinear_kernelonly", "nonlinear"]
 )
 @pytest.mark.parametrize("latent_feature_dim", [None, 2])
-def test_gino(gno_transform_type, latent_feature_dim, gno_coord_dim, gno_pos_embed_type, batch_size, fno_norm):
+@pytest.mark.parametrize("use_torch_scatter", use_torch_scatter)
+def test_gino(gno_transform_type, latent_feature_dim, gno_coord_dim, gno_pos_embed_type, batch_size, fno_norm, use_torch_scatter):
     if torch.backends.cuda.is_built():
         device = torch.device("cuda:0")
     else:
@@ -40,6 +47,7 @@ def test_gino(gno_transform_type, latent_feature_dim, gno_coord_dim, gno_pos_emb
         latent_feature_channels=latent_feature_dim,
         in_gno_radius=0.3,# make this large to ensure neighborhoods overlap with queries on the domain
         out_gno_radius=0.3,
+        use_torch_scatter=use_torch_scatter,
         projection_channels=projection_channels,
         gno_coord_dim=gno_coord_dim,
         gno_pos_embed_type=gno_pos_embed_type,


### PR DESCRIPTION
Test native behavior. The defaults work out here on the runner but this will fix breaking tests on local machines