### PR TITLE
Feat/layers laplace conv

### DIFF
--- a/neuralop/layers/shape_enforcer.py
+++ b/neuralop/layers/shape_enforcer.py
@@ -1,0 +1,90 @@
+import torch
+import torch.nn.functional as F
+from typing import Optional, Tuple, List
+
+
+class ShapeEnforcer(torch.nn.Module):
+    """
+    A PyTorch module that enforces a specific output shape on the tensor
+    by cropping or padding the spatial/temporal dimensions.
+
+    This class is useful in scenarios where you need consistent output shapes
+    after operations like spectral or wavelet transforms, where dimensions might
+    not match the desired size naturally.
+
+    Parameters
+    ----------
+    start_dim : int, optional
+        The dimension index at which to start enforcing the shape.
+        For example, with typical 2D data `[B, C, H, W]`, `start_dim=2`.
+        For 1D data `[B, C, L]`, `start_dim=2`. Default is 2.
+
+    Methods
+    -------
+    forward(x: torch.Tensor, output_shape: Optional[List[int]] = None) -> torch.Tensor
+        Enforces the desired shape on the input tensor.
+    """
+
+    def __init__(self, start_dim: int = 2):
+        """
+        Initialize the ShapeEnforcer module.
+
+        Parameters
+        ----------
+        start_dim : int, optional
+            The dimension index at which to start enforcing the shape.
+            Default is 2.
+        """
+        super(ShapeEnforcer, self).__init__()
+        self.start_dim = start_dim
+
+    def forward(
+        self, x: torch.Tensor, output_shape: Optional[List[int]] = None
+    ) -> torch.Tensor:
+        """
+        Forward method to enforce the desired shape on the input tensor.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of shape `[B, C, D1, D2, ..., DN]`.
+        output_shape : List[int], optional
+            The desired shape of the tensor's spatial/temporal dimensions,
+            e.g., `[D_out1, D_out2, ...]`. If None, the tensor is returned unchanged.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor with shapes from `self.start_dim` onward forced to match `output_shape`.
+        """
+        if output_shape is None:
+            return x  # No shape enforcement required
+
+        # -- 1) Crop if needed --
+        # Build slicing for each dimension
+        slices = [slice(None)] * self.start_dim  # keep [B, C, ...] as is
+        for i, size_desired in enumerate(output_shape):
+            current_size = x.shape[self.start_dim + i]
+            # If current is bigger, crop
+            if current_size > size_desired:
+                slices.append(slice(0, size_desired))
+            else:
+                slices.append(slice(0, current_size))
+        x = x[tuple(slices)]
+
+        # -- 2) Pad if needed --
+        # F.pad expects a pad-list in reverse order: [dimN_left, dimN_right, dimN-1_left, ...]
+        pad_list = []
+        for i in reversed(range(len(output_shape))):
+            size_desired = output_shape[i]
+            current_size = x.shape[self.start_dim + i]
+            if current_size < size_desired:
+                pad_amount = size_desired - current_size
+                # Pad only on the "end" (right side).
+                pad_list.extend([0, pad_amount])
+            else:
+                pad_list.extend([0, 0])
+        if any(pad_list):
+            x = F.pad(x, pad_list, mode="constant", value=0.0)
+
+        return x

--- a/neuralop/layers/spectral_convolution_laplace.py
+++ b/neuralop/layers/spectral_convolution_laplace.py
@@ -1,4 +1,3 @@
-
 import torch
 import torch.nn as nn
 import numpy as np
@@ -12,22 +11,19 @@ from .base_spectral_conv import BaseSpectralConv
 Number = Union[int, float]
 
 
-def _compute_dt(
-    shape, 
-    start_points: List=None, 
-    end_points: List=None
-    ):
+def _compute_dt(shape, start_points: List = None, end_points: List = None):
     """
     Compute uniform spacing (dt) for each dimension based on domain lengths, step sizes,
     start points, and end points. Defaults to a unit domain if not specified.
 
     Parameters:
+    ----------
     shape (Sequence[int]): The shape of the input excluding batch and channel, i.e. (d_1, d_2, ..., d_n).
-    step_sizes (Sequence[float], optional): Step sizes for each dimension. Defaults to shape-based uniform spacing.
     start_points (Sequence[float], optional): Start points for each dimension. Defaults to 0.0 for all dimensions.
     end_points (Sequence[float], optional): End points for each dimension. Defaults to 1.0 for all dimensions.
 
     Returns:
+    -------
     dt_list (Sequence[float]): A list of spacings, one per dimension.
     grid (List[torch.Tensor]): A list of grid points for each dimension based on the spacing and domain.
     """
@@ -40,13 +36,18 @@ def _compute_dt(
 
     # Validate that start_points and end_points match the number of dimensions
     if len(start_points) != dim or len(end_points) != dim:
-        raise ValueError("Start points and end points must match the number of input dimensions ({dim}).")
+        raise ValueError(
+            "Start points and end points must match the number of input dimensions ({dim})."
+        )
 
     # Compute domain lengths from start and end points
     domain_lengths = [end_points[i] - start_points[i] for i in range(dim)]
 
     # Generate grid points for each dimension using torch.linspace
-    grid = [torch.linspace(start_points[i], end_points[i], steps=shape[i]) for i in range(dim)]
+    grid = [
+        torch.linspace(start_points[i], end_points[i], steps=shape[i])
+        for i in range(dim)
+    ]
 
     # Compute dt directly from the grid
     dt_list = [(grid[i][1] - grid[i][0]).item() for i in range(dim)]
@@ -54,15 +55,64 @@ def _compute_dt(
     return dt_list, grid
 
 
-
 # ====================================
 #  Laplace layer: pole-residue operation is used to calculate the poles and residues of the output
 # ====================================
 class SpectralConvLaplace1D(BaseSpectralConv):
+    """Implements 1D Laplace-based Spectral Convolution.
+
+    This class implements a spectral convolution layer using pole-residue formulation
+    for 1D data. Instead of using standard Fourier transforms, it uses pole-residue
+    operations to calculate the response in the frequency domain.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input channels
+    out_channels : int
+        Number of output channels
+    n_modes : int or int tuple
+        Number of modes to use for pole-residue calculation
+    complex_data : bool, optional
+        whether data takes on complex values in the spatial domain, by default False
+    max_n_modes : int tuple or None, default is None
+        Maximum number of modes to keep in the Laplace layer
+    bias : bool, default is True
+        whether to include bias term
+    separable : bool, default is False
+        whether to use separable implementation
+    resolution_scaling_factor : float or float list, optional
+        Factor to scale the output resolution
+    xno_block_precision : str, default is "full"
+        Precision to use for the convolution block
+    rank : float, optional
+        Rank parameter, by default 0.5
+    factorization : str or None, optional
+        Type of factorization to use
+    implementation : str, default is "reconstructed"
+        Implementation approach for the convolution
+    fixed_rank_modes : bool, default is False
+        Whether to use fixed rank modes
+    decomposition_kwargs : dict, optional
+        Additional parameters for decomposition
+    init_std : str or float, default is "auto"
+        Standard deviation for weight initialization
+    fft_norm : str, default is "forward"
+        Normalization method for FFT
+    device : torch.device, optional
+        Device to use for computation
+    linspace_steps : list, optional
+        Number of steps for each dimension
+    linspace_startpoints : list, optional
+        Start points for each dimension
+    linspace_endpoints : list, optional
+        End points for each dimension
+    """
+
     def __init__(
-        self, 
-        in_channels, 
-        out_channels, 
+        self,
+        in_channels,
+        out_channels,
         n_modes,
         complex_data=False,
         max_n_modes=None,
@@ -77,56 +127,68 @@ class SpectralConvLaplace1D(BaseSpectralConv):
         decomposition_kwargs: Optional[dict] = None,
         init_std="auto",
         fft_norm="forward",
-        device=None, 
-        linspace_steps=None, 
-        linspace_startpoints=None, 
-        linspace_endpoints=None, 
-        
-        ):
+        device=None,
+        linspace_steps=None,
+        linspace_startpoints=None,
+        linspace_endpoints=None,
+    ):
         super(SpectralConvLaplace1D, self).__init__(device=device)
-        
-        
+
+        # Store grid parameters for domain specification
         self.linspace_steps = linspace_steps
         self.linspace_startpoints = linspace_startpoints
         self.linspace_endpoints = linspace_endpoints
         self.n_modes = n_modes
-        
+
         self.order = len(self.n_modes)
-        self.resolution_scaling_factor: Union[
-            None, List[List[float]]
-        ] = validate_scaling_factor(resolution_scaling_factor, self.order)
-        
-        max_n_modes, = self.n_modes
+        self.resolution_scaling_factor: Union[None, List[List[float]]] = (
+            validate_scaling_factor(resolution_scaling_factor, self.order)
+        )
+
+        # Set up and initialize weight parameters
+        (max_n_modes,) = self.n_modes
         self.max_n_modes = self.n_modes
-        
+
         self.scale = 1 / (in_channels * out_channels)
-        
+
         # Initialize single weight tensor combining poles and residues
-        
+        # Weight format: [in_channels, out_channels, poles + residues]
         total_modes = max_n_modes + 1 * max_n_modes
         self.weight = nn.Parameter(
-            self.scale * torch.rand(
-                in_channels, 
-                out_channels, 
-                total_modes, 
-                dtype=torch.cfloat, 
-                )
+            self.scale
+            * torch.rand(
+                in_channels,
+                out_channels,
+                total_modes,
+                dtype=torch.cfloat,
+            )
         )
-        
+
         self.shape_enforcer = ShapeEnforcer()
-       
-    
-    def transform(
-        self, 
-        x, 
-        output_shape=None
-        ):
-        
+
+    def transform(self, x, output_shape=None):
+        """Transform the input tensor to match desired output shape.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor
+        output_shape : tuple, optional
+            Desired output spatial dimensions, by default None
+
+        Returns
+        -------
+        torch.Tensor
+            Transformed tensor
+        """
         in_shape = list(x.shape[2:])
 
         if self.resolution_scaling_factor is not None and output_shape is None:
             out_shape = tuple(
-                [round(s * r) for (s, r) in zip(in_shape, self.resolution_scaling_factor)]
+                [
+                    round(s * r)
+                    for (s, r) in zip(in_shape, self.resolution_scaling_factor)
+                ]
             )
         elif output_shape is not None:
             out_shape = output_shape
@@ -137,130 +199,193 @@ class SpectralConvLaplace1D(BaseSpectralConv):
             return x
         else:
             return resample(x, 1.0, list(range(2, x.ndim)), output_shape=out_shape)
-    
-    def output_PR(
-        self, 
-        lambda1,
-        alpha, 
-        weights_pole, 
-        weights_residue
-        ):   
-        
-        Hw=torch.zeros(
+
+    def output_PR(self, lambda1, alpha, weights_pole, weights_residue):
+        """Calculate output using pole-residue formulation.
+
+        Parameters
+        ----------
+        lambda1 : torch.Tensor
+            Frequency domain grid points
+        alpha : torch.Tensor
+            FFT of input
+        weights_pole : torch.Tensor
+            Pole weights
+        weights_residue : torch.Tensor
+            Residue weights
+
+        Returns
+        -------
+        tuple
+            Tuple of (transient part, steady-state part)
+        """
+        # Initialize output tensor for frequency response
+        Hw = torch.zeros(
             weights_residue.shape[0],
             weights_residue.shape[0],
             weights_residue.shape[2],
-            lambda1.shape[0], 
-            device=alpha.device, 
-            dtype=torch.cfloat
+            lambda1.shape[0],
+            device=alpha.device,
+            dtype=torch.cfloat,
         )
-        
-        term1=torch.div(1,
-                        torch.sub(lambda1,
-                                  weights_pole
-                        )
-                        )
 
-        Hw=weights_residue*term1
+        # Calculate pole-residue representation in the Laplace domain
+        term1 = torch.div(1, torch.sub(lambda1, weights_pole))
+        Hw = weights_residue * term1
 
-        output_residue1=torch.einsum("bix,xiok->box", 
-                                     alpha, 
-                                     Hw
-                                     ) 
-        output_residue2=torch.einsum("bix,xiok->bok", 
-                                     alpha, 
-                                     -Hw
-                                     ) 
-        
-        return output_residue1,output_residue2    
+        # Compute both transient and steady-state parts
+        output_residue1 = torch.einsum("bix,xiok->box", alpha, Hw)
+        output_residue2 = torch.einsum("bix,xiok->bok", alpha, -Hw)
 
-    def forward(
-        self, 
-        x: torch.Tensor, 
-        output_shape: Optional[Tuple[int]] = None
-    ):
-        
+        return output_residue1, output_residue2
+
+    def forward(self, x: torch.Tensor, output_shape: Optional[Tuple[int]] = None):
+        """Forward pass for 1D Laplace spectral convolution.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of shape (batch_size, channels, L)
+        output_shape : tuple, optional
+            Desired output spatial dimensions, by default None
+
+        Returns
+        -------
+        torch.Tensor
+            Output tensor of shape (batch_size, out_channels, L) or output_shape
+        """
         batchsize, channels, *mode_sizes = x.shape
-                
-        modes1, = self.n_modes
+
+        # Setup computation parameters
+        (modes1,) = self.n_modes
         L = x.shape[-1]
-        
-        # Ensure we do not exceed the actual resolution
         modes1 = min(modes1, L)
-        
-        # if self.linspace_steps is None:
-        #     self.linspace_steps = x.shape[2:]
         self.linspace_steps = x.shape[2:]
-            
+
+        # Compute the grid and spacing for the domain
         dt_list, shape = _compute_dt(
-            shape=self.linspace_steps, 
-            start_points=self.linspace_startpoints, end_points=self.linspace_endpoints
+            shape=self.linspace_steps,
+            start_points=self.linspace_startpoints,
+            end_points=self.linspace_endpoints,
         )
-        
-        t = shape[0]
-        t = t.to(x.device)
-        dt = dt_list[0]        
-        
+        t = shape[0].to(x.device)
+        dt = dt_list[0]
+
+        # Transform to frequency domain and compute frequency grid
         alpha = torch.fft.fft(x, dim=-1)
-        lambda0=torch.fft.fftfreq(t.shape[0], dt, device=alpha.device)*2*np.pi*1j
-        # lambda1=lambda0[:modes1].unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
-        lambda1=lambda0.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
-        
-        # Slice alpha and weights to match the truncated modes
-        # alpha = alpha[:, :, :modes1]
-        
-        
-        weights_pole = self.weight[:, :, :modes1].view(self.weight.size(0), self.weight.size(1), modes1)
-        weights_residue = self.weight[:, :, modes1:(modes1 * 2)].view(self.weight.size(0), self.weight.size(1), modes1)
-    
-        # Obtain output poles and residues for transient part and steady-state part
-        output_residue1,output_residue2= self.output_PR(lambda1, 
-                                                        alpha, 
-                                                        weights_pole, 
-                                                        weights_residue
-                                                        )
-    
-        # Obtain time histories of transient response and steady-state response
+        lambda0 = (
+            torch.fft.fftfreq(t.shape[0], dt, device=alpha.device) * 2 * np.pi * 1j
+        )
+        lambda1 = lambda0.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
+
+        # Extract pole and residue weights from the combined weight tensor
+        weights_pole = self.weight[:, :, :modes1].view(
+            self.weight.size(0), self.weight.size(1), modes1
+        )
+        weights_residue = self.weight[:, :, modes1 : (modes1 * 2)].view(
+            self.weight.size(0), self.weight.size(1), modes1
+        )
+
+        # Calculate frequency response using pole-residue formulation
+        output_residue1, output_residue2 = self.output_PR(
+            lambda1, alpha, weights_pole, weights_residue
+        )
+
+        # Convert transient part back to time domain
         x1 = torch.fft.ifft(output_residue1, n=x.size(-1))
         x1 = torch.real(x1)
-        
-        x2=torch.zeros(output_residue2.shape[0],
-                       output_residue2.shape[1],
-                       t.shape[0],
-                       device=alpha.device,
-                       dtype=torch.cfloat)    
-        
-        term1=torch.einsum("iok,az->iokz", 
-                           weights_pole, 
-                           t.type(torch.complex64).reshape(1,-1))
-        term2=torch.exp(term1) 
-        
-        x2=torch.einsum("bok,iokz->boz",
-                        output_residue2,
-                        term2)
-        x2=torch.real(x2)
-        x2=x2/x.size(-1)
-        
-        x = x1+x2
-        
+
+        # Calculate steady-state response in time domain
+        x2 = torch.zeros(
+            output_residue2.shape[0],
+            output_residue2.shape[1],
+            t.shape[0],
+            device=alpha.device,
+            dtype=torch.cfloat,
+        )
+        # Apply exponential terms for time-domain calculation
+        term1 = torch.einsum(
+            "iok,az->iokz", weights_pole, t.type(torch.complex64).reshape(1, -1)
+        )
+        term2 = torch.exp(term1)
+        x2 = torch.einsum("bok,iokz->boz", output_residue2, term2)
+        x2 = torch.real(x2) / x.size(-1)
+
+        # Combine transient and steady-state responses
+        x = x1 + x2
+
+        # Adjust output shape if needed
         if self.resolution_scaling_factor is not None and output_shape is None:
-            mode_sizes = tuple([round(s * r) for (s, r) in zip(mode_sizes, self.resolution_scaling_factor)])
-            
+            mode_sizes = tuple(
+                [
+                    round(s * r)
+                    for (s, r) in zip(mode_sizes, self.resolution_scaling_factor)
+                ]
+            )
         if output_shape is not None:
             mode_sizes = output_shape
-            
-        # Ensuring the ouputshape is matched with desired, if it's specified
+
+        # Ensure the output has the correct shape
         if list(x.shape[2:]) != mode_sizes:
             x = self.shape_enforcer(x, output_shape=mode_sizes)
-            
+
         return x
 
 
 class SpectralConvLaplace2D(BaseSpectralConv):
+    """Implements 2D Laplace-based Spectral Convolution.
+
+    This class implements a spectral convolution layer using pole-residue formulation
+    for 2D data. It extends the concepts of the 1D version to handle 2D spatial domains.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input channels
+    out_channels : int
+        Number of output channels
+    n_modes : tuple
+        Number of modes to use for pole-residue calculation (modes1, modes2)
+    complex_data : bool, optional
+        whether data takes on complex values in the spatial domain, by default False
+    max_n_modes : tuple or None, default is None
+        Maximum number of modes to keep in the Laplace layer
+    bias : bool, default is True
+        whether to include bias term
+    separable : bool, default is False
+        whether to use separable implementation
+    resolution_scaling_factor : float or float list, optional
+        Factor to scale the output resolution
+    xno_block_precision : str, default is "full"
+        Precision to use for the convolution block
+    rank : float, optional
+        Rank parameter, by default 0.5
+    factorization : str or None, optional
+        Type of factorization to use
+    implementation : str, default is "reconstructed"
+        Implementation approach for the convolution
+    fixed_rank_modes : bool, default is False
+        Whether to use fixed rank modes
+    decomposition_kwargs : dict, optional
+        Additional parameters for decomposition
+    init_std : str or float, default is "auto"
+        Standard deviation for weight initialization
+    fft_norm : str, default is "forward"
+        Normalization method for FFT
+    device : torch.device, optional
+        Device to use for computation
+    linspace_steps : list, optional
+        Number of steps for each dimension
+    linspace_startpoints : list, optional
+        Start points for each dimension
+    linspace_endpoints : list, optional
+        End points for each dimension
+    """
+
     def __init__(
-        self, 
-        in_channels, 
-        out_channels, 
+        self,
+        in_channels,
+        out_channels,
         n_modes,
         complex_data=False,
         max_n_modes=None,
@@ -276,61 +401,63 @@ class SpectralConvLaplace2D(BaseSpectralConv):
         init_std="auto",
         fft_norm="forward",
         device=None,
-        linspace_steps=None, 
-        linspace_startpoints=None, 
-        linspace_endpoints=None
-        ):
-        
+        linspace_steps=None,
+        linspace_startpoints=None,
+        linspace_endpoints=None,
+    ):
         super(SpectralConvLaplace2D, self).__init__(device=device)
-        
+
+        # Store grid parameters for domain specification
         self.linspace_steps = linspace_steps
         self.linspace_startpoints = linspace_startpoints
         self.linspace_endpoints = linspace_endpoints
-        
         self.n_modes = n_modes
 
         self.order = len(self.n_modes)
-        self.resolution_scaling_factor: Union[
-            None, List[List[float]]
-        ] = validate_scaling_factor(resolution_scaling_factor, self.order)
-        
-        """
-            Commulating all weights into a single weight attribute on the class, and break it down for different applications like weights_pole1, etc. in convolution process. 
-        """
+        self.resolution_scaling_factor: Union[None, List[List[float]]] = (
+            validate_scaling_factor(resolution_scaling_factor, self.order)
+        )
+
+        # Set up dimensions and weight parameters
         max_modes1, max_modes2 = self.n_modes
         self.max_n_modes = self.n_modes
-        
-        # if max_n_modes is None:
-        #     max_modes1, max_modes2 = self.n_modes
-        # elif isinstance(max_n_modes, int):
-        #     max_modes1, max_modes2 = max_n_modes
-
         self.scale = 1 / (in_channels * out_channels)
-        
+
         # Initialize single weight tensor combining poles and residues
         # Shape: (in_channels, out_channels, modes1 + modes2 + modes1 * modes2)
+        # The tensor contains weights for poles in dimension 1, poles in dimension 2,
+        # and residues for all combinations of poles
         total_modes = max_modes1 + max_modes2 + (max_modes1 * max_modes2)
         self.weight = nn.Parameter(
-            self.scale * torch.rand(
-                in_channels, 
-                out_channels, 
-                total_modes, 
-                dtype=torch.cfloat
-            )
+            self.scale
+            * torch.rand(in_channels, out_channels, total_modes, dtype=torch.cfloat)
         )
-        
+
         self.shape_enforcer = ShapeEnforcer()
-        
-    def transform(
-        self, 
-        x, 
-        output_shape=None
-    ):
+
+    def transform(self, x, output_shape=None):
+        """Transform the input tensor to match desired output shape.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor
+        output_shape : tuple, optional
+            Desired output spatial dimensions, by default None
+
+        Returns
+        -------
+        torch.Tensor
+            Transformed tensor
+        """
         in_shape = list(x.shape[2:])
 
         if self.resolution_scaling_factor is not None and output_shape is None:
             out_shape = tuple(
-                [round(s * r) for (s, r) in zip(in_shape, self.resolution_scaling_factor)]
+                [
+                    round(s * r)
+                    for (s, r) in zip(in_shape, self.resolution_scaling_factor)
+                ]
             )
         elif output_shape is not None:
             out_shape = output_shape
@@ -341,150 +468,221 @@ class SpectralConvLaplace2D(BaseSpectralConv):
             return x
         else:
             return resample(x, 1.0, list(range(2, x.ndim)), output_shape=out_shape)
-    
+
     def output_PR(
-        self, 
-        lambda1, 
-        lambda2, 
-        alpha, 
-        weights_pole1, 
-        weights_pole2, 
-        weights_residue
+        self, lambda1, lambda2, alpha, weights_pole1, weights_pole2, weights_residue
     ):
-        Hw=torch.zeros(weights_residue.shape[0],
-                       weights_residue.shape[0],
-                       weights_residue.shape[2],
-                       weights_residue.shape[3],
-                       lambda1.shape[0], 
-                       lambda2.shape[0], 
-                       device=alpha.device, 
-                       dtype=torch.cfloat
-                       )
-        
-        term1=torch.div(1,
-                        torch.einsum("pbix,qbik->pqbixk",
-                                     torch.sub(lambda1,weights_pole1),
-                                     torch.sub(lambda2,weights_pole2)))
-        
-        Hw=torch.einsum("bixk,pqbixk->pqbixk",
-                        weights_residue,
-                        term1)
-        
-        Pk=Hw  # for ode, Pk=-Hw; for 2d pde, Pk=Hw; for 3d pde, Pk=-Hw; 
-        output_residue1=torch.einsum("biox,oxikpq->bkox", 
-                                     alpha, 
-                                     Hw) 
-        output_residue2=torch.einsum("biox,oxikpq->bkpq",
-                                     alpha, 
-                                     Pk) 
-        return output_residue1,output_residue2
+        """Calculate output using pole-residue formulation for 2D.
 
-    def forward(
-        self, 
-        x: torch.Tensor, 
-        output_shape: Optional[Tuple[int]] = None
-    ):
-        batchsize, channels, *mode_sizes = x.shape
-        
-        modes1, modes2 = self.n_modes
-        H, W = x.shape[-2], x.shape[-1]
+        Parameters
+        ----------
+        lambda1 : torch.Tensor
+            Frequency domain grid points for first dimension
+        lambda2 : torch.Tensor
+            Frequency domain grid points for second dimension
+        alpha : torch.Tensor
+            FFT of input
+        weights_pole1 : torch.Tensor
+            Pole weights for first dimension
+        weights_pole2 : torch.Tensor
+            Pole weights for second dimension
+        weights_residue : torch.Tensor
+            Residue weights
 
-        # Ensure we do not exceed the actual resolution
-        modes1 = min(modes1, H)
-        modes2 = min(modes2, W)
-            
-        # if self.linspace_steps is None:
-        #     self.linspace_steps = x.shape[2:]
-        self.linspace_steps = x.shape[2:]
-
-        dt_list, shape = _compute_dt(
-            shape=self.linspace_steps, 
-            start_points=self.linspace_startpoints, 
-            end_points=self.linspace_endpoints
+        Returns
+        -------
+        tuple
+            Tuple of (transient part, steady-state part)
+        """
+        # Initialize output tensor for frequency response
+        Hw = torch.zeros(
+            weights_residue.shape[0],
+            weights_residue.shape[0],
+            weights_residue.shape[2],
+            weights_residue.shape[3],
+            lambda1.shape[0],
+            lambda2.shape[0],
+            device=alpha.device,
+            dtype=torch.cfloat,
         )
 
-        ty = shape[0]
-        tx = shape[1]
-        ty = ty.to(x.device)
-        tx = tx.to(x.device)
+        # Calculate pole-residue representation in the 2D Laplace domain
+        # by combining poles from both dimensions
+        term1 = torch.div(
+            1,
+            torch.einsum(
+                "pbix,qbik->pqbixk",
+                torch.sub(lambda1, weights_pole1),
+                torch.sub(lambda2, weights_pole2),
+            ),
+        )
+        Hw = torch.einsum("bixk,pqbixk->pqbixk", weights_residue, term1)
+
+        # Note: Different PDEs use different signs for the steady-state part
+        Pk = Hw  # for ode, Pk=-Hw; for 2d pde, Pk=Hw; for 3d pde, Pk=-Hw;
+
+        # Compute both transient and steady-state parts
+        output_residue1 = torch.einsum("biox,oxikpq->bkox", alpha, Hw)
+        output_residue2 = torch.einsum("biox,oxikpq->bkpq", alpha, Pk)
+        return output_residue1, output_residue2
+
+    def forward(self, x: torch.Tensor, output_shape: Optional[Tuple[int]] = None):
+        """Forward pass for 2D Laplace spectral convolution.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of shape (batch_size, channels, H, W)
+        output_shape : tuple, optional
+            Desired output spatial dimensions, by default None
+
+        Returns
+        -------
+        torch.Tensor
+            Output tensor of shape (batch_size, out_channels, H, W) or output_shape
+        """
+        batchsize, channels, *mode_sizes = x.shape
+
+        # Setup computation parameters
+        modes1, modes2 = self.n_modes
+        H, W = x.shape[-2], x.shape[-1]
+        modes1, modes2 = min(modes1, H), min(modes2, W)
+        self.linspace_steps = x.shape[2:]
+
+        # Compute the grid and spacing for the domain
+        dt_list, shape = _compute_dt(
+            shape=self.linspace_steps,
+            start_points=self.linspace_startpoints,
+            end_points=self.linspace_endpoints,
+        )
+        ty = shape[0].to(x.device)
+        tx = shape[1].to(x.device)
         dty = dt_list[0]
         dtx = dt_list[1]
-                
+
+        # Transform to frequency domain and compute frequency grids
         alpha = torch.fft.fft2(x, dim=[-2, -1])
+        omega1 = (
+            torch.fft.fftfreq(ty.shape[0], dty, device=alpha.device) * 2 * np.pi * 1j
+        )
+        omega2 = (
+            torch.fft.fftfreq(tx.shape[0], dtx, device=alpha.device) * 2 * np.pi * 1j
+        )
 
-        # Compute frequency grids
-        omega1 = torch.fft.fftfreq(ty.shape[0], dty, device=alpha.device)*2*np.pi*1j
-        omega2 = torch.fft.fftfreq(tx.shape[0], dtx, device=alpha.device)*2*np.pi*1j
-
-        # Slice frequencies to match the chosen modes
-        # omega1 = omega1[:modes1]
-        # omega2 = omega2[:modes2]
-
+        # Prepare frequency grids for computation
         omega1 = omega1.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
         omega2 = omega2.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
-        lambda1 = omega1
-        lambda2 = omega2
+        lambda1, lambda2 = omega1, omega2
 
-        # Slice alpha to only consider the selected modes
-        # alpha = alpha[:, :, :modes1, :modes2]
+        # Extract pole and residue weights from the combined weight tensor
+        weights_pole1 = self.weight[:, :, :modes1].view(
+            self.weight.size(0), self.weight.size(1), modes1
+        )
+        weights_pole2 = self.weight[:, :, modes1 : (modes1 + modes2)].view(
+            self.weight.size(0), self.weight.size(1), modes2
+        )
+        weights_residue = self.weight[
+            :, :, (modes1 + modes2) : (modes1 + modes2 + modes1 * modes2)
+        ].view(self.weight.size(0), self.weight.size(1), modes1, modes2)
 
-        # Slice weights to match the truncated modes
-        weights_pole1 = self.weight[:, :, :modes1].view(self.weight.size(0), self.weight.size(1), modes1)
-        weights_pole2 = self.weight[:, :, modes1:(modes1+modes2)].view(self.weight.size(0), self.weight.size(1), modes2)
-        weights_residue = self.weight[:, :, (modes1+modes2):(modes1+modes2+modes1*modes2)].view(self.weight.size(0), self.weight.size(1), modes1, modes2)
-        # Proceed with the existing logic
-        output_residue1, output_residue2 = self.output_PR(lambda1, 
-                                                          lambda2, 
-                                                          alpha, 
-                                                          weights_pole1, 
-                                                          weights_pole2, 
-                                                          weights_residue)
-        
+        # Calculate frequency response using pole-residue formulation
+        output_residue1, output_residue2 = self.output_PR(
+            lambda1, lambda2, alpha, weights_pole1, weights_pole2, weights_residue
+        )
+
+        # Convert transient part back to spatial domain
         x1 = torch.fft.ifft2(output_residue1, s=(x.size(-2), x.size(-1)))
-        x1 = torch.real(x1)  # shape: (b, o, H, W)
+        x1 = torch.real(x1)
 
-        # Now ty has length H and tx has length W
-        term1 = torch.einsum("iop,z->iopz", 
-                             weights_pole1, 
-                             ty.type(torch.complex64))  # (i, o, p, H)
-        term2 = torch.einsum("ioq,x->ioqx", 
-                             weights_pole2, 
-                             tx.type(torch.complex64))  # (i, o, q, W)        
+        # Calculate steady-state response in spatial domain
+        # Create exponential terms for each dimension
+        term1 = torch.einsum("iop,z->iopz", weights_pole1, ty.type(torch.complex64))
+        term2 = torch.einsum("ioq,x->ioqx", weights_pole2, tx.type(torch.complex64))
+        term1 = torch.exp(term1)
+        term2 = torch.exp(term2)
 
-        term1 = torch.exp(term1)  # (i, o, p, H)
-        term2 = torch.exp(term2)  # (i, o, q, W)
+        # Combine exponential terms across dimensions
+        term3 = torch.einsum("iopz,ioqx->iopqzx", term1, term2)
 
-        term3 = torch.einsum("iopz,ioqx->iopqzx", 
-                             term1, 
-                             term2)  # (i, o, p, q, H, W)
-
-        # output_residue2: (b, o, p, q)
-        # term3: (o, p, q, H, W)
-        x2 = torch.einsum("bopq,iopqzx->bozx", 
-                          output_residue2, 
-                          term3)  # (b, o, H, W)
-
+        # Apply steady-state response
+        x2 = torch.einsum("bopq,iopqzx->bozx", output_residue2, term3)
         x2 = torch.real(x2) / (x.size(-1) * x.size(-2))
-        
-        x = x1+x2  # Both are (b, o, H, W)
-        
+
+        # Combine transient and steady-state responses
+        x = x1 + x2
+
+        # Adjust output shape if needed
         if self.resolution_scaling_factor is not None and output_shape is None:
-            mode_sizes = tuple([round(s * r) for (s, r) in zip(mode_sizes, self.resolution_scaling_factor)])
-            
+            mode_sizes = tuple(
+                [
+                    round(s * r)
+                    for (s, r) in zip(mode_sizes, self.resolution_scaling_factor)
+                ]
+            )
         if output_shape is not None:
             mode_sizes = output_shape
-            
-        # Ensuring the ouputshape is matched with desired, if it's specified
+
+        # Ensure the output has the correct shape
         if list(x.shape[2:]) != mode_sizes:
             x = self.shape_enforcer(x, output_shape=mode_sizes)
-            
+
         return x
 
+
 class SpectralConvLaplace3D(BaseSpectralConv):
+    """Implements 3D Laplace-based Spectral Convolution.
+
+    This class implements a spectral convolution layer using pole-residue formulation
+    for 3D data. It extends the concepts of the 1D and 2D versions to handle 3D spatial domains.
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input channels
+    out_channels : int
+        Number of output channels
+    n_modes : tuple
+        Number of modes to use for pole-residue calculation (modes1, modes2, modes3)
+    complex_data : bool, optional
+        whether data takes on complex values in the spatial domain, by default False
+    max_n_modes : tuple or None, default is None
+        Maximum number of modes to keep in the Laplace layer
+    bias : bool, default is True
+        whether to include bias term
+    separable : bool, default is False
+        whether to use separable implementation
+    resolution_scaling_factor : float or float list, optional
+        Factor to scale the output resolution
+    xno_block_precision : str, default is "full"
+        Precision to use for the convolution block
+    rank : float, optional
+        Rank parameter, by default 0.5
+    factorization : str or None, optional
+        Type of factorization to use
+    implementation : str, default is "reconstructed"
+        Implementation approach for the convolution
+    fixed_rank_modes : bool, default is False
+        Whether to use fixed rank modes
+    decomposition_kwargs : dict, optional
+        Additional parameters for decomposition
+    init_std : str or float, default is "auto"
+        Standard deviation for weight initialization
+    fft_norm : str, default is "forward"
+        Normalization method for FFT
+    device : torch.device, optional
+        Device to use for computation
+    linspace_steps : list, optional
+        Number of steps for each dimension
+    linspace_startpoints : list, optional
+        Start points for each dimension
+    linspace_endpoints : list, optional
+        End points for each dimension
+    """
+
     def __init__(
-        self, 
-        in_channels, 
-        out_channels,  
+        self,
+        in_channels,
+        out_channels,
         n_modes,
         complex_data=False,
         max_n_modes=None,
@@ -500,53 +698,68 @@ class SpectralConvLaplace3D(BaseSpectralConv):
         init_std="auto",
         fft_norm="forward",
         device=None,
-        linspace_steps=None, 
-        linspace_startpoints=None, 
-        linspace_endpoints=None
-        ):
+        linspace_steps=None,
+        linspace_startpoints=None,
+        linspace_endpoints=None,
+    ):
         super(SpectralConvLaplace3D, self).__init__(device=device)
-        
+
+        # Store grid parameters for domain specification
         self.linspace_steps = linspace_steps
         self.linspace_startpoints = linspace_startpoints
         self.linspace_endpoints = linspace_endpoints
         self.n_modes = n_modes
-        
+
         self.order = len(self.n_modes)
-        self.resolution_scaling_factor: Union[
-            None, List[List[float]]
-        ] = validate_scaling_factor(resolution_scaling_factor, self.order)
-        
+        self.resolution_scaling_factor: Union[None, List[List[float]]] = (
+            validate_scaling_factor(resolution_scaling_factor, self.order)
+        )
+
+        # Set up dimensions and weight parameters
         self.modes1, self.modes2, self.modes3 = self.n_modes
-         
         max_modes1, max_modes2, max_modes3 = self.n_modes
         self.max_n_modes = self.n_modes
-         
-        # if max_n_modes is None:
-        #     max_modes1, max_modes2, max_modes3 = self.n_modes
-        # elif isinstance(max_n_modes, int):
-        #     max_modes1, max_modes2, max_modes3 = max_n_modes
-            
-        # Compute total number of modes to combine into single weight tensor
-        total_modes = max_modes1 + max_modes2 + max_modes3 + (max_modes1 * max_modes2 * max_modes3)
 
-        self.scale = (1 / (in_channels * out_channels))
-        self.weight = nn.Parameter(
-            self.scale * torch.rand(in_channels, out_channels, total_modes, dtype=torch.cfloat)
+        # Compute total number of modes to combine into single weight tensor
+        # Format: [poles for dim1] + [poles for dim2] + [poles for dim3] + [residues for all combinations]
+        total_modes = (
+            max_modes1
+            + max_modes2
+            + max_modes3
+            + (max_modes1 * max_modes2 * max_modes3)
         )
-        
+
+        self.scale = 1 / (in_channels * out_channels)
+        self.weight = nn.Parameter(
+            self.scale
+            * torch.rand(in_channels, out_channels, total_modes, dtype=torch.cfloat)
+        )
+
         self.shape_enforcer = ShapeEnforcer()
-    
-    def transform(
-        self, 
-        x, 
-        output_shape=None
-    ):
-        
+
+    def transform(self, x, output_shape=None):
+        """Transform the input tensor to match desired output shape.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor
+        output_shape : tuple, optional
+            Desired output spatial dimensions, by default None
+
+        Returns
+        -------
+        torch.Tensor
+            Transformed tensor
+        """
         in_shape = list(x.shape[2:])
 
         if self.resolution_scaling_factor is not None and output_shape is None:
             out_shape = tuple(
-                [round(s * r) for (s, r) in zip(in_shape, self.resolution_scaling_factor)]
+                [
+                    round(s * r)
+                    for (s, r) in zip(in_shape, self.resolution_scaling_factor)
+                ]
             )
         elif output_shape is not None:
             out_shape = output_shape
@@ -557,162 +770,210 @@ class SpectralConvLaplace3D(BaseSpectralConv):
             return x
         else:
             return resample(x, 1.0, list(range(2, x.ndim)), output_shape=out_shape)
-    
+
     def output_PR(
-        self, 
-        lambda1, 
-        lambda2, 
-        lambda3, 
-        alpha, 
-        weights_pole1, 
-        weights_pole2, 
-        weights_pole3, 
-        weights_residue
-        ):
-        
-        Hw=torch.zeros(
+        self,
+        lambda1,
+        lambda2,
+        lambda3,
+        alpha,
+        weights_pole1,
+        weights_pole2,
+        weights_pole3,
+        weights_residue,
+    ):
+        """Calculate output using pole-residue formulation for 3D.
+
+        Parameters
+        ----------
+        lambda1 : torch.Tensor
+            Frequency domain grid points for first dimension
+        lambda2 : torch.Tensor
+            Frequency domain grid points for second dimension
+        lambda3 : torch.Tensor
+            Frequency domain grid points for third dimension
+        alpha : torch.Tensor
+            FFT of input
+        weights_pole1 : torch.Tensor
+            Pole weights for first dimension
+        weights_pole2 : torch.Tensor
+            Pole weights for second dimension
+        weights_pole3 : torch.Tensor
+            Pole weights for third dimension
+        weights_residue : torch.Tensor
+            Residue weights
+
+        Returns
+        -------
+        tuple
+            Tuple of (transient part, steady-state part)
+        """
+        # Initialize output tensor for frequency response
+        Hw = torch.zeros(
             weights_residue.shape[0],
             weights_residue.shape[0],
             weights_residue.shape[2],
             weights_residue.shape[3],
             weights_residue.shape[4],
-            lambda1.shape[0], 
-            lambda2.shape[0], 
-            lambda2.shape[3], 
-            device=alpha.device, 
-            dtype=torch.cfloat)
-        
-        term1=torch.div(
+            lambda1.shape[0],
+            lambda2.shape[0],
+            lambda2.shape[3],
+            device=alpha.device,
+            dtype=torch.cfloat,
+        )
+
+        # Calculate pole-residue representation in the 3D Laplace domain
+        # by combining poles from all three dimensions
+        term1 = torch.div(
             1,
-            torch.einsum("pbix,qbik,rbio->pqrbixko",
-            torch.sub(lambda1,weights_pole1),
-            torch.sub(lambda2,weights_pole2),
-            torch.sub(lambda3,weights_pole3)))
-        
-        Hw=torch.einsum("bixko,pqrbixko->pqrbixko",
-                        weights_residue,
-                        term1)
+            torch.einsum(
+                "pbix,qbik,rbio->pqrbixko",
+                torch.sub(lambda1, weights_pole1),
+                torch.sub(lambda2, weights_pole2),
+                torch.sub(lambda3, weights_pole3),
+            ),
+        )
+        Hw = torch.einsum("bixko,pqrbixko->pqrbixko", weights_residue, term1)
 
-        output_residue1=torch.einsum("bioxs,oxsikpqr->bkoxs", 
-                                     alpha, 
-                                     Hw) 
-        output_residue2=torch.einsum("bioxs,oxsikpqr->bkpqr", 
-                                     alpha, 
-                                     -Hw) 
-        return output_residue1,output_residue2
-    
+        # Compute both transient and steady-state parts
+        # Note: For 3D PDEs, the steady-state part uses negative Hw
+        output_residue1 = torch.einsum("bioxs,oxsikpqr->bkoxs", alpha, Hw)
+        output_residue2 = torch.einsum("bioxs,oxsikpqr->bkpqr", alpha, -Hw)
+        return output_residue1, output_residue2
 
-    def forward(
-        self, 
-        x: torch.Tensor, 
-        output_shape: Optional[Tuple[int]] = None
-    ):
-        
+    def forward(self, x: torch.Tensor, output_shape: Optional[Tuple[int]] = None):
+        """Forward pass for 3D Laplace spectral convolution.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of shape (batch_size, channels, D, H, W)
+        output_shape : tuple, optional
+            Desired output spatial dimensions, by default None
+
+        Returns
+        -------
+        torch.Tensor
+            Output tensor of shape (batch_size, out_channels, D, H, W) or output_shape
+        """
         batchsize, channels, *mode_sizes = x.shape
 
+        # Setup computation parameters
         modes1, modes2, modes3 = self.n_modes
         D, H, W = x.shape[-3], x.shape[-2], x.shape[-1]
-        
         modes1, modes2, modes3 = min(modes1, D), min(modes2, H), min(modes3, W)
-        
-        # if self.linspace_steps is None:
-        #     self.linspace_steps = x.shape[2:]
         self.linspace_steps = x.shape[2:]
-        
-        dt_list, shape = _compute_dt(shape=self.linspace_steps, 
-                                     start_points=self.linspace_startpoints, 
-                                     end_points=self.linspace_endpoints
-                                     )
-        tz = shape[0]
-        tx = shape[1]
-        ty = shape[2]
-        tz = tz.to(x.device)
-        tx = tx.to(x.device)
-        ty = ty.to(x.device)
-        # #Compute input poles and resudes by FFT
-        dtz = dt_list[0] # this can be time dimension, instead of Z dimension
+
+        # Compute the grid and spacing for the domain
+        dt_list, shape = _compute_dt(
+            shape=self.linspace_steps,
+            start_points=self.linspace_startpoints,
+            end_points=self.linspace_endpoints,
+        )
+        tz = shape[0].to(x.device)
+        tx = shape[1].to(x.device)
+        ty = shape[2].to(x.device)
+        dtz = dt_list[0]  # this can be time dimension, instead of Z dimension
         dtx = dt_list[1]
-        dty = dt_list[2] 
-        
-        alpha = torch.fft.fftn(x, dim=[-3,-2,-1])
-        
-        # Frequency grids
-        omega1=torch.fft.fftfreq(tz.shape[0], dtz, device=alpha.device)*2*np.pi*1j   
-        omega2=torch.fft.fftfreq(tx.shape[0], dtx, device=alpha.device)*2*np.pi*1j   
-        omega3=torch.fft.fftfreq(ty.shape[0], dty, device=alpha.device)*2*np.pi*1j   
-        
+        dty = dt_list[2]
+
+        # Transform to frequency domain and compute frequency grids
+        alpha = torch.fft.fftn(x, dim=[-3, -2, -1])
+        omega1 = (
+            torch.fft.fftfreq(tz.shape[0], dtz, device=alpha.device) * 2 * np.pi * 1j
+        )
+        omega2 = (
+            torch.fft.fftfreq(tx.shape[0], dtx, device=alpha.device) * 2 * np.pi * 1j
+        )
+        omega3 = (
+            torch.fft.fftfreq(ty.shape[0], dty, device=alpha.device) * 2 * np.pi * 1j
+        )
+
         # Slice frequencies to match the chosen modes
         omega1 = omega1[:modes1]
         omega2 = omega2[:modes2]
         omega3 = omega3[:modes3]
-        
-        omega1=omega1.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
-        omega2=omega2.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
-        omega3=omega3.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
-        lambda1=omega1
-        lambda2=omega2    
-        lambda3=omega3
-        
+
+        # Prepare frequency grids for computation
+        omega1 = omega1.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
+        omega2 = omega2.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
+        omega3 = omega3.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
+        lambda1, lambda2, lambda3 = omega1, omega2, omega3
+
         # Slice alpha to only consider the selected modes
         alpha = alpha[:, :, :modes1, :modes2, :modes3]
 
-        # Slice the combined weight tensor
+        # Extract pole and residue weights from the combined weight tensor
         i, o, _ = self.weight.shape
-        
         weights_pole1 = self.weight[:, :, :modes1].view(i, o, modes1)
-        weights_pole2 = self.weight[:, :, modes1:(modes1+modes2)].view(i, o, modes2)
-        weights_pole3 = self.weight[:, :, (modes1+modes2):(modes1+modes2+modes3)].view(i, o, modes3)
-        weights_residue = self.weight[:, :, (modes1+modes2+modes3):(modes1+modes2+modes3+(modes1*modes2*modes3))].view(i, o, modes1, modes2, modes3)
+        weights_pole2 = self.weight[:, :, modes1 : (modes1 + modes2)].view(i, o, modes2)
+        weights_pole3 = self.weight[
+            :, :, (modes1 + modes2) : (modes1 + modes2 + modes3)
+        ].view(i, o, modes3)
+        weights_residue = self.weight[
+            :,
+            :,
+            (modes1 + modes2 + modes3) : (
+                modes1 + modes2 + modes3 + (modes1 * modes2 * modes3)
+            ),
+        ].view(i, o, modes1, modes2, modes3)
 
-        # Obtain output poles and residues for transient part and steady-state part
-        output_residue1,output_residue2 = self.output_PR(lambda1, 
-                                                         lambda2, 
-                                                         lambda3, 
-                                                         alpha, 
-                                                         weights_pole1, 
-                                                         weights_pole2, 
-                                                         weights_pole3, 
-                                                         weights_residue
-                                                         )
- 
-      
-        # Obtain time histories of transient response and steady-state response
-        x1 = torch.fft.ifftn(output_residue1, 
-                             s=(x.size(-3),
-                                x.size(-2),
-                                x.size(-1))
-                             )
+        # Calculate frequency response using pole-residue formulation
+        output_residue1, output_residue2 = self.output_PR(
+            lambda1,
+            lambda2,
+            lambda3,
+            alpha,
+            weights_pole1,
+            weights_pole2,
+            weights_pole3,
+            weights_residue,
+        )
+
+        # Convert transient part back to spatial domain
+        x1 = torch.fft.ifftn(output_residue1, s=(x.size(-3), x.size(-2), x.size(-1)))
         x1 = torch.real(x1)
-        
-        term1=torch.einsum("bip,kz->bipz", 
-                           weights_pole1, 
-                           tz.type(torch.complex64).reshape(1,-1))
-        term2=torch.einsum("biq,kx->biqx", 
-                           weights_pole2, 
-                           tx.type(torch.complex64).reshape(1,-1))
-        term3=torch.einsum("bim,ky->bimy", 
-                           weights_pole3, 
-                           ty.type(torch.complex64).reshape(1,-1))
-        term4=torch.einsum("bipz,biqx,bimy->bipqmzxy", 
-                           torch.exp(term1),
-                           torch.exp(term2),
-                           torch.exp(term3))
-        x2=torch.einsum("kbpqm,bipqmzxy->kizxy", 
-                        output_residue2,
-                        term4)
-        x2=torch.real(x2)
-        x2=x2/x.size(-1)/x.size(-2)/x.size(-3)
-        
-        x = x1+x2  
-        
+
+        # Calculate steady-state response in spatial domain
+        # Create exponential terms for each dimension
+        term1 = torch.einsum(
+            "bip,kz->bipz", weights_pole1, tz.type(torch.complex64).reshape(1, -1)
+        )
+        term2 = torch.einsum(
+            "biq,kx->biqx", weights_pole2, tx.type(torch.complex64).reshape(1, -1)
+        )
+        term3 = torch.einsum(
+            "bim,ky->bimy", weights_pole3, ty.type(torch.complex64).reshape(1, -1)
+        )
+
+        # Combine exponential terms across all three dimensions
+        term4 = torch.einsum(
+            "bipz,biqx,bimy->bipqmzxy",
+            torch.exp(term1),
+            torch.exp(term2),
+            torch.exp(term3),
+        )
+
+        # Apply steady-state response
+        x2 = torch.einsum("kbpqm,bipqmzxy->kizxy", output_residue2, term4)
+        x2 = torch.real(x2) / x.size(-1) / x.size(-2) / x.size(-3)
+
+        # Combine transient and steady-state responses
+        x = x1 + x2
+
+        # Adjust output shape if needed
         if self.resolution_scaling_factor is not None and output_shape is None:
-            mode_sizes = tuple([round(s * r) for (s, r) in zip(mode_sizes, self.resolution_scaling_factor)])
-            
+            mode_sizes = tuple(
+                [
+                    round(s * r)
+                    for (s, r) in zip(mode_sizes, self.resolution_scaling_factor)
+                ]
+            )
         if output_shape is not None:
             mode_sizes = output_shape
-            
-        # Ensuring the ouputshape is matched with desired, if it's specified
+
+        # Ensure the output has the correct shape
         if list(x.shape[2:]) != mode_sizes:
             x = self.shape_enforcer(x, output_shape=mode_sizes)
-            
+
         return x

--- a/neuralop/layers/spectral_convolution_laplace.py
+++ b/neuralop/layers/spectral_convolution_laplace.py
@@ -1,0 +1,718 @@
+
+import torch
+import torch.nn as nn
+import numpy as np
+from typing import Optional, Union, Sequence
+from typing import List, Optional, Tuple, Union
+from .resample import resample
+from ..utils import validate_scaling_factor
+from .shape_enforcer import ShapeEnforcer
+from .base_spectral_conv import BaseSpectralConv
+
+Number = Union[int, float]
+
+
+def _compute_dt(
+    shape, 
+    start_points: List=None, 
+    end_points: List=None
+    ):
+    """
+    Compute uniform spacing (dt) for each dimension based on domain lengths, step sizes,
+    start points, and end points. Defaults to a unit domain if not specified.
+
+    Parameters:
+    shape (Sequence[int]): The shape of the input excluding batch and channel, i.e. (d_1, d_2, ..., d_n).
+    step_sizes (Sequence[float], optional): Step sizes for each dimension. Defaults to shape-based uniform spacing.
+    start_points (Sequence[float], optional): Start points for each dimension. Defaults to 0.0 for all dimensions.
+    end_points (Sequence[float], optional): End points for each dimension. Defaults to 1.0 for all dimensions.
+
+    Returns:
+    dt_list (Sequence[float]): A list of spacings, one per dimension.
+    grid (List[torch.Tensor]): A list of grid points for each dimension based on the spacing and domain.
+    """
+    dim = len(shape)
+    # Set default start and end points if not provided
+    if start_points is None:
+        start_points = torch.zeros(dim).tolist()
+    if end_points is None:
+        end_points = torch.ones(dim).tolist()
+
+    # Validate that start_points and end_points match the number of dimensions
+    if len(start_points) != dim or len(end_points) != dim:
+        raise ValueError("Start points and end points must match the number of input dimensions ({dim}).")
+
+    # Compute domain lengths from start and end points
+    domain_lengths = [end_points[i] - start_points[i] for i in range(dim)]
+
+    # Generate grid points for each dimension using torch.linspace
+    grid = [torch.linspace(start_points[i], end_points[i], steps=shape[i]) for i in range(dim)]
+
+    # Compute dt directly from the grid
+    dt_list = [(grid[i][1] - grid[i][0]).item() for i in range(dim)]
+
+    return dt_list, grid
+
+
+
+# ====================================
+#  Laplace layer: pole-residue operation is used to calculate the poles and residues of the output
+# ====================================
+class SpectralConvLaplace1D(BaseSpectralConv):
+    def __init__(
+        self, 
+        in_channels, 
+        out_channels, 
+        n_modes,
+        complex_data=False,
+        max_n_modes=None,
+        bias=True,
+        separable=False,
+        resolution_scaling_factor: Optional[Union[Number, List[Number]]] = None,
+        xno_block_precision="full",
+        rank=0.5,
+        factorization=None,
+        implementation="reconstructed",
+        fixed_rank_modes=False,
+        decomposition_kwargs: Optional[dict] = None,
+        init_std="auto",
+        fft_norm="forward",
+        device=None, 
+        linspace_steps=None, 
+        linspace_startpoints=None, 
+        linspace_endpoints=None, 
+        
+        ):
+        super(SpectralConvLaplace1D, self).__init__(device=device)
+        
+        
+        self.linspace_steps = linspace_steps
+        self.linspace_startpoints = linspace_startpoints
+        self.linspace_endpoints = linspace_endpoints
+        self.n_modes = n_modes
+        
+        self.order = len(self.n_modes)
+        self.resolution_scaling_factor: Union[
+            None, List[List[float]]
+        ] = validate_scaling_factor(resolution_scaling_factor, self.order)
+        
+        max_n_modes, = self.n_modes
+        self.max_n_modes = self.n_modes
+        
+        self.scale = 1 / (in_channels * out_channels)
+        
+        # Initialize single weight tensor combining poles and residues
+        
+        total_modes = max_n_modes + 1 * max_n_modes
+        self.weight = nn.Parameter(
+            self.scale * torch.rand(
+                in_channels, 
+                out_channels, 
+                total_modes, 
+                dtype=torch.cfloat, 
+                )
+        )
+        
+        self.shape_enforcer = ShapeEnforcer()
+       
+    
+    def transform(
+        self, 
+        x, 
+        output_shape=None
+        ):
+        
+        in_shape = list(x.shape[2:])
+
+        if self.resolution_scaling_factor is not None and output_shape is None:
+            out_shape = tuple(
+                [round(s * r) for (s, r) in zip(in_shape, self.resolution_scaling_factor)]
+            )
+        elif output_shape is not None:
+            out_shape = output_shape
+        else:
+            out_shape = in_shape
+
+        if in_shape == out_shape:
+            return x
+        else:
+            return resample(x, 1.0, list(range(2, x.ndim)), output_shape=out_shape)
+    
+    def output_PR(
+        self, 
+        lambda1,
+        alpha, 
+        weights_pole, 
+        weights_residue
+        ):   
+        
+        Hw=torch.zeros(
+            weights_residue.shape[0],
+            weights_residue.shape[0],
+            weights_residue.shape[2],
+            lambda1.shape[0], 
+            device=alpha.device, 
+            dtype=torch.cfloat
+        )
+        
+        term1=torch.div(1,
+                        torch.sub(lambda1,
+                                  weights_pole
+                        )
+                        )
+
+        Hw=weights_residue*term1
+
+        output_residue1=torch.einsum("bix,xiok->box", 
+                                     alpha, 
+                                     Hw
+                                     ) 
+        output_residue2=torch.einsum("bix,xiok->bok", 
+                                     alpha, 
+                                     -Hw
+                                     ) 
+        
+        return output_residue1,output_residue2    
+
+    def forward(
+        self, 
+        x: torch.Tensor, 
+        output_shape: Optional[Tuple[int]] = None
+    ):
+        
+        batchsize, channels, *mode_sizes = x.shape
+                
+        modes1, = self.n_modes
+        L = x.shape[-1]
+        
+        # Ensure we do not exceed the actual resolution
+        modes1 = min(modes1, L)
+        
+        # if self.linspace_steps is None:
+        #     self.linspace_steps = x.shape[2:]
+        self.linspace_steps = x.shape[2:]
+            
+        dt_list, shape = _compute_dt(
+            shape=self.linspace_steps, 
+            start_points=self.linspace_startpoints, end_points=self.linspace_endpoints
+        )
+        
+        t = shape[0]
+        t = t.to(x.device)
+        dt = dt_list[0]        
+        
+        alpha = torch.fft.fft(x, dim=-1)
+        lambda0=torch.fft.fftfreq(t.shape[0], dt, device=alpha.device)*2*np.pi*1j
+        # lambda1=lambda0[:modes1].unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
+        lambda1=lambda0.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
+        
+        # Slice alpha and weights to match the truncated modes
+        # alpha = alpha[:, :, :modes1]
+        
+        
+        weights_pole = self.weight[:, :, :modes1].view(self.weight.size(0), self.weight.size(1), modes1)
+        weights_residue = self.weight[:, :, modes1:(modes1 * 2)].view(self.weight.size(0), self.weight.size(1), modes1)
+    
+        # Obtain output poles and residues for transient part and steady-state part
+        output_residue1,output_residue2= self.output_PR(lambda1, 
+                                                        alpha, 
+                                                        weights_pole, 
+                                                        weights_residue
+                                                        )
+    
+        # Obtain time histories of transient response and steady-state response
+        x1 = torch.fft.ifft(output_residue1, n=x.size(-1))
+        x1 = torch.real(x1)
+        
+        x2=torch.zeros(output_residue2.shape[0],
+                       output_residue2.shape[1],
+                       t.shape[0],
+                       device=alpha.device,
+                       dtype=torch.cfloat)    
+        
+        term1=torch.einsum("iok,az->iokz", 
+                           weights_pole, 
+                           t.type(torch.complex64).reshape(1,-1))
+        term2=torch.exp(term1) 
+        
+        x2=torch.einsum("bok,iokz->boz",
+                        output_residue2,
+                        term2)
+        x2=torch.real(x2)
+        x2=x2/x.size(-1)
+        
+        x = x1+x2
+        
+        if self.resolution_scaling_factor is not None and output_shape is None:
+            mode_sizes = tuple([round(s * r) for (s, r) in zip(mode_sizes, self.resolution_scaling_factor)])
+            
+        if output_shape is not None:
+            mode_sizes = output_shape
+            
+        # Ensuring the ouputshape is matched with desired, if it's specified
+        if list(x.shape[2:]) != mode_sizes:
+            x = self.shape_enforcer(x, output_shape=mode_sizes)
+            
+        return x
+
+
+class SpectralConvLaplace2D(BaseSpectralConv):
+    def __init__(
+        self, 
+        in_channels, 
+        out_channels, 
+        n_modes,
+        complex_data=False,
+        max_n_modes=None,
+        bias=True,
+        separable=False,
+        resolution_scaling_factor: Optional[Union[Number, List[Number]]] = None,
+        xno_block_precision="full",
+        rank=0.5,
+        factorization=None,
+        implementation="reconstructed",
+        fixed_rank_modes=False,
+        decomposition_kwargs: Optional[dict] = None,
+        init_std="auto",
+        fft_norm="forward",
+        device=None,
+        linspace_steps=None, 
+        linspace_startpoints=None, 
+        linspace_endpoints=None
+        ):
+        
+        super(SpectralConvLaplace2D, self).__init__(device=device)
+        
+        self.linspace_steps = linspace_steps
+        self.linspace_startpoints = linspace_startpoints
+        self.linspace_endpoints = linspace_endpoints
+        
+        self.n_modes = n_modes
+
+        self.order = len(self.n_modes)
+        self.resolution_scaling_factor: Union[
+            None, List[List[float]]
+        ] = validate_scaling_factor(resolution_scaling_factor, self.order)
+        
+        """
+            Commulating all weights into a single weight attribute on the class, and break it down for different applications like weights_pole1, etc. in convolution process. 
+        """
+        max_modes1, max_modes2 = self.n_modes
+        self.max_n_modes = self.n_modes
+        
+        # if max_n_modes is None:
+        #     max_modes1, max_modes2 = self.n_modes
+        # elif isinstance(max_n_modes, int):
+        #     max_modes1, max_modes2 = max_n_modes
+
+        self.scale = 1 / (in_channels * out_channels)
+        
+        # Initialize single weight tensor combining poles and residues
+        # Shape: (in_channels, out_channels, modes1 + modes2 + modes1 * modes2)
+        total_modes = max_modes1 + max_modes2 + (max_modes1 * max_modes2)
+        self.weight = nn.Parameter(
+            self.scale * torch.rand(
+                in_channels, 
+                out_channels, 
+                total_modes, 
+                dtype=torch.cfloat
+            )
+        )
+        
+        self.shape_enforcer = ShapeEnforcer()
+        
+    def transform(
+        self, 
+        x, 
+        output_shape=None
+    ):
+        in_shape = list(x.shape[2:])
+
+        if self.resolution_scaling_factor is not None and output_shape is None:
+            out_shape = tuple(
+                [round(s * r) for (s, r) in zip(in_shape, self.resolution_scaling_factor)]
+            )
+        elif output_shape is not None:
+            out_shape = output_shape
+        else:
+            out_shape = in_shape
+
+        if in_shape == out_shape:
+            return x
+        else:
+            return resample(x, 1.0, list(range(2, x.ndim)), output_shape=out_shape)
+    
+    def output_PR(
+        self, 
+        lambda1, 
+        lambda2, 
+        alpha, 
+        weights_pole1, 
+        weights_pole2, 
+        weights_residue
+    ):
+        Hw=torch.zeros(weights_residue.shape[0],
+                       weights_residue.shape[0],
+                       weights_residue.shape[2],
+                       weights_residue.shape[3],
+                       lambda1.shape[0], 
+                       lambda2.shape[0], 
+                       device=alpha.device, 
+                       dtype=torch.cfloat
+                       )
+        
+        term1=torch.div(1,
+                        torch.einsum("pbix,qbik->pqbixk",
+                                     torch.sub(lambda1,weights_pole1),
+                                     torch.sub(lambda2,weights_pole2)))
+        
+        Hw=torch.einsum("bixk,pqbixk->pqbixk",
+                        weights_residue,
+                        term1)
+        
+        Pk=Hw  # for ode, Pk=-Hw; for 2d pde, Pk=Hw; for 3d pde, Pk=-Hw; 
+        output_residue1=torch.einsum("biox,oxikpq->bkox", 
+                                     alpha, 
+                                     Hw) 
+        output_residue2=torch.einsum("biox,oxikpq->bkpq",
+                                     alpha, 
+                                     Pk) 
+        return output_residue1,output_residue2
+
+    def forward(
+        self, 
+        x: torch.Tensor, 
+        output_shape: Optional[Tuple[int]] = None
+    ):
+        batchsize, channels, *mode_sizes = x.shape
+        
+        modes1, modes2 = self.n_modes
+        H, W = x.shape[-2], x.shape[-1]
+
+        # Ensure we do not exceed the actual resolution
+        modes1 = min(modes1, H)
+        modes2 = min(modes2, W)
+            
+        # if self.linspace_steps is None:
+        #     self.linspace_steps = x.shape[2:]
+        self.linspace_steps = x.shape[2:]
+
+        dt_list, shape = _compute_dt(
+            shape=self.linspace_steps, 
+            start_points=self.linspace_startpoints, 
+            end_points=self.linspace_endpoints
+        )
+
+        ty = shape[0]
+        tx = shape[1]
+        ty = ty.to(x.device)
+        tx = tx.to(x.device)
+        dty = dt_list[0]
+        dtx = dt_list[1]
+                
+        alpha = torch.fft.fft2(x, dim=[-2, -1])
+
+        # Compute frequency grids
+        omega1 = torch.fft.fftfreq(ty.shape[0], dty, device=alpha.device)*2*np.pi*1j
+        omega2 = torch.fft.fftfreq(tx.shape[0], dtx, device=alpha.device)*2*np.pi*1j
+
+        # Slice frequencies to match the chosen modes
+        # omega1 = omega1[:modes1]
+        # omega2 = omega2[:modes2]
+
+        omega1 = omega1.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
+        omega2 = omega2.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
+        lambda1 = omega1
+        lambda2 = omega2
+
+        # Slice alpha to only consider the selected modes
+        # alpha = alpha[:, :, :modes1, :modes2]
+
+        # Slice weights to match the truncated modes
+        weights_pole1 = self.weight[:, :, :modes1].view(self.weight.size(0), self.weight.size(1), modes1)
+        weights_pole2 = self.weight[:, :, modes1:(modes1+modes2)].view(self.weight.size(0), self.weight.size(1), modes2)
+        weights_residue = self.weight[:, :, (modes1+modes2):(modes1+modes2+modes1*modes2)].view(self.weight.size(0), self.weight.size(1), modes1, modes2)
+        # Proceed with the existing logic
+        output_residue1, output_residue2 = self.output_PR(lambda1, 
+                                                          lambda2, 
+                                                          alpha, 
+                                                          weights_pole1, 
+                                                          weights_pole2, 
+                                                          weights_residue)
+        
+        x1 = torch.fft.ifft2(output_residue1, s=(x.size(-2), x.size(-1)))
+        x1 = torch.real(x1)  # shape: (b, o, H, W)
+
+        # Now ty has length H and tx has length W
+        term1 = torch.einsum("iop,z->iopz", 
+                             weights_pole1, 
+                             ty.type(torch.complex64))  # (i, o, p, H)
+        term2 = torch.einsum("ioq,x->ioqx", 
+                             weights_pole2, 
+                             tx.type(torch.complex64))  # (i, o, q, W)        
+
+        term1 = torch.exp(term1)  # (i, o, p, H)
+        term2 = torch.exp(term2)  # (i, o, q, W)
+
+        term3 = torch.einsum("iopz,ioqx->iopqzx", 
+                             term1, 
+                             term2)  # (i, o, p, q, H, W)
+
+        # output_residue2: (b, o, p, q)
+        # term3: (o, p, q, H, W)
+        x2 = torch.einsum("bopq,iopqzx->bozx", 
+                          output_residue2, 
+                          term3)  # (b, o, H, W)
+
+        x2 = torch.real(x2) / (x.size(-1) * x.size(-2))
+        
+        x = x1+x2  # Both are (b, o, H, W)
+        
+        if self.resolution_scaling_factor is not None and output_shape is None:
+            mode_sizes = tuple([round(s * r) for (s, r) in zip(mode_sizes, self.resolution_scaling_factor)])
+            
+        if output_shape is not None:
+            mode_sizes = output_shape
+            
+        # Ensuring the ouputshape is matched with desired, if it's specified
+        if list(x.shape[2:]) != mode_sizes:
+            x = self.shape_enforcer(x, output_shape=mode_sizes)
+            
+        return x
+
+class SpectralConvLaplace3D(BaseSpectralConv):
+    def __init__(
+        self, 
+        in_channels, 
+        out_channels,  
+        n_modes,
+        complex_data=False,
+        max_n_modes=None,
+        bias=True,
+        separable=False,
+        resolution_scaling_factor: Optional[Union[Number, List[Number]]] = None,
+        xno_block_precision="full",
+        rank=0.5,
+        factorization=None,
+        implementation="reconstructed",
+        fixed_rank_modes=False,
+        decomposition_kwargs: Optional[dict] = None,
+        init_std="auto",
+        fft_norm="forward",
+        device=None,
+        linspace_steps=None, 
+        linspace_startpoints=None, 
+        linspace_endpoints=None
+        ):
+        super(SpectralConvLaplace3D, self).__init__(device=device)
+        
+        self.linspace_steps = linspace_steps
+        self.linspace_startpoints = linspace_startpoints
+        self.linspace_endpoints = linspace_endpoints
+        self.n_modes = n_modes
+        
+        self.order = len(self.n_modes)
+        self.resolution_scaling_factor: Union[
+            None, List[List[float]]
+        ] = validate_scaling_factor(resolution_scaling_factor, self.order)
+        
+        self.modes1, self.modes2, self.modes3 = self.n_modes
+         
+        max_modes1, max_modes2, max_modes3 = self.n_modes
+        self.max_n_modes = self.n_modes
+         
+        # if max_n_modes is None:
+        #     max_modes1, max_modes2, max_modes3 = self.n_modes
+        # elif isinstance(max_n_modes, int):
+        #     max_modes1, max_modes2, max_modes3 = max_n_modes
+            
+        # Compute total number of modes to combine into single weight tensor
+        total_modes = max_modes1 + max_modes2 + max_modes3 + (max_modes1 * max_modes2 * max_modes3)
+
+        self.scale = (1 / (in_channels * out_channels))
+        self.weight = nn.Parameter(
+            self.scale * torch.rand(in_channels, out_channels, total_modes, dtype=torch.cfloat)
+        )
+        
+        self.shape_enforcer = ShapeEnforcer()
+    
+    def transform(
+        self, 
+        x, 
+        output_shape=None
+    ):
+        
+        in_shape = list(x.shape[2:])
+
+        if self.resolution_scaling_factor is not None and output_shape is None:
+            out_shape = tuple(
+                [round(s * r) for (s, r) in zip(in_shape, self.resolution_scaling_factor)]
+            )
+        elif output_shape is not None:
+            out_shape = output_shape
+        else:
+            out_shape = in_shape
+
+        if in_shape == out_shape:
+            return x
+        else:
+            return resample(x, 1.0, list(range(2, x.ndim)), output_shape=out_shape)
+    
+    def output_PR(
+        self, 
+        lambda1, 
+        lambda2, 
+        lambda3, 
+        alpha, 
+        weights_pole1, 
+        weights_pole2, 
+        weights_pole3, 
+        weights_residue
+        ):
+        
+        Hw=torch.zeros(
+            weights_residue.shape[0],
+            weights_residue.shape[0],
+            weights_residue.shape[2],
+            weights_residue.shape[3],
+            weights_residue.shape[4],
+            lambda1.shape[0], 
+            lambda2.shape[0], 
+            lambda2.shape[3], 
+            device=alpha.device, 
+            dtype=torch.cfloat)
+        
+        term1=torch.div(
+            1,
+            torch.einsum("pbix,qbik,rbio->pqrbixko",
+            torch.sub(lambda1,weights_pole1),
+            torch.sub(lambda2,weights_pole2),
+            torch.sub(lambda3,weights_pole3)))
+        
+        Hw=torch.einsum("bixko,pqrbixko->pqrbixko",
+                        weights_residue,
+                        term1)
+
+        output_residue1=torch.einsum("bioxs,oxsikpqr->bkoxs", 
+                                     alpha, 
+                                     Hw) 
+        output_residue2=torch.einsum("bioxs,oxsikpqr->bkpqr", 
+                                     alpha, 
+                                     -Hw) 
+        return output_residue1,output_residue2
+    
+
+    def forward(
+        self, 
+        x: torch.Tensor, 
+        output_shape: Optional[Tuple[int]] = None
+    ):
+        
+        batchsize, channels, *mode_sizes = x.shape
+
+        modes1, modes2, modes3 = self.n_modes
+        D, H, W = x.shape[-3], x.shape[-2], x.shape[-1]
+        
+        modes1, modes2, modes3 = min(modes1, D), min(modes2, H), min(modes3, W)
+        
+        # if self.linspace_steps is None:
+        #     self.linspace_steps = x.shape[2:]
+        self.linspace_steps = x.shape[2:]
+        
+        dt_list, shape = _compute_dt(shape=self.linspace_steps, 
+                                     start_points=self.linspace_startpoints, 
+                                     end_points=self.linspace_endpoints
+                                     )
+        tz = shape[0]
+        tx = shape[1]
+        ty = shape[2]
+        tz = tz.to(x.device)
+        tx = tx.to(x.device)
+        ty = ty.to(x.device)
+        # #Compute input poles and resudes by FFT
+        dtz = dt_list[0] # this can be time dimension, instead of Z dimension
+        dtx = dt_list[1]
+        dty = dt_list[2] 
+        
+        alpha = torch.fft.fftn(x, dim=[-3,-2,-1])
+        
+        # Frequency grids
+        omega1=torch.fft.fftfreq(tz.shape[0], dtz, device=alpha.device)*2*np.pi*1j   
+        omega2=torch.fft.fftfreq(tx.shape[0], dtx, device=alpha.device)*2*np.pi*1j   
+        omega3=torch.fft.fftfreq(ty.shape[0], dty, device=alpha.device)*2*np.pi*1j   
+        
+        # Slice frequencies to match the chosen modes
+        omega1 = omega1[:modes1]
+        omega2 = omega2[:modes2]
+        omega3 = omega3[:modes3]
+        
+        omega1=omega1.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
+        omega2=omega2.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
+        omega3=omega3.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
+        lambda1=omega1
+        lambda2=omega2    
+        lambda3=omega3
+        
+        # Slice alpha to only consider the selected modes
+        alpha = alpha[:, :, :modes1, :modes2, :modes3]
+
+        # Slice the combined weight tensor
+        i, o, _ = self.weight.shape
+        
+        weights_pole1 = self.weight[:, :, :modes1].view(i, o, modes1)
+        weights_pole2 = self.weight[:, :, modes1:(modes1+modes2)].view(i, o, modes2)
+        weights_pole3 = self.weight[:, :, (modes1+modes2):(modes1+modes2+modes3)].view(i, o, modes3)
+        weights_residue = self.weight[:, :, (modes1+modes2+modes3):(modes1+modes2+modes3+(modes1*modes2*modes3))].view(i, o, modes1, modes2, modes3)
+
+        # Obtain output poles and residues for transient part and steady-state part
+        output_residue1,output_residue2 = self.output_PR(lambda1, 
+                                                         lambda2, 
+                                                         lambda3, 
+                                                         alpha, 
+                                                         weights_pole1, 
+                                                         weights_pole2, 
+                                                         weights_pole3, 
+                                                         weights_residue
+                                                         )
+ 
+      
+        # Obtain time histories of transient response and steady-state response
+        x1 = torch.fft.ifftn(output_residue1, 
+                             s=(x.size(-3),
+                                x.size(-2),
+                                x.size(-1))
+                             )
+        x1 = torch.real(x1)
+        
+        term1=torch.einsum("bip,kz->bipz", 
+                           weights_pole1, 
+                           tz.type(torch.complex64).reshape(1,-1))
+        term2=torch.einsum("biq,kx->biqx", 
+                           weights_pole2, 
+                           tx.type(torch.complex64).reshape(1,-1))
+        term3=torch.einsum("bim,ky->bimy", 
+                           weights_pole3, 
+                           ty.type(torch.complex64).reshape(1,-1))
+        term4=torch.einsum("bipz,biqx,bimy->bipqmzxy", 
+                           torch.exp(term1),
+                           torch.exp(term2),
+                           torch.exp(term3))
+        x2=torch.einsum("kbpqm,bipqmzxy->kizxy", 
+                        output_residue2,
+                        term4)
+        x2=torch.real(x2)
+        x2=x2/x.size(-1)/x.size(-2)/x.size(-3)
+        
+        x = x1+x2  
+        
+        if self.resolution_scaling_factor is not None and output_shape is None:
+            mode_sizes = tuple([round(s * r) for (s, r) in zip(mode_sizes, self.resolution_scaling_factor)])
+            
+        if output_shape is not None:
+            mode_sizes = output_shape
+            
+        # Ensuring the ouputshape is matched with desired, if it's specified
+        if list(x.shape[2:]) != mode_sizes:
+            x = self.shape_enforcer(x, output_shape=mode_sizes)
+            
+        return x

--- a/neuralop/layers/tests/test_shape_enforcer.py
+++ b/neuralop/layers/tests/test_shape_enforcer.py
@@ -1,0 +1,110 @@
+# MIT License
+# Copyright (c) 2024 Saman Pordanesh
+
+import pytest
+import torch
+import numpy as np
+from neuralop.layers.shape_enforcer import ShapeEnforcer
+
+
+@pytest.mark.parametrize(
+    "test_id, start_dim, input_shape, output_shape, description",
+    [
+        # Basic functionality
+        (1, 2, (2, 3, 10, 8), [6, 12], "Basic usage with 2D data - mixed resize"),
+        (2, 1, (2, 3, 8, 10), [5, 8, 10], "Start dim = 1 (channel dimension)"),
+        (3, 3, (2, 3, 10, 8, 6), [4, 3], "Start dim = 3 (last two dimensions)"),
+        # Cropping and padding scenarios
+        (4, 2, (2, 3, 20, 30), [10, 15], "Pure cropping - all dimensions smaller"),
+        (5, 2, (2, 3, 10, 15), [20, 25], "Pure padding - all dimensions larger"),
+        (6, 2, (2, 3, 20, 10), [10, 15], "Mixed - first dim cropped, second padded"),
+        # Edge cases
+        (7, 2, (2, 3, 10, 15), [10, 15], "Same shape - no changes needed"),
+        (8, 2, (2, 3, 10, 15), None, "None output shape - return input unchanged"),
+        (9, 2, (2, 0, 10, 15), [8, 20], "Empty tensor - preserve empty dimension"),
+        (
+            10,
+            2,
+            (2, 3, 100, 100),
+            [1, 1],
+            "Extreme downsizing - very large to very small",
+        ),
+    ],
+)
+def test_shape_enforcer(test_id, start_dim, input_shape, output_shape, description):
+    """
+    Comprehensive test for ShapeEnforcer with various scenarios.
+
+    Tests different combinations of:
+    - input shapes and dimensions
+    - output shapes
+    - start_dim values
+    - cropping, padding, and mixed operations
+    - edge cases
+    """
+    # Create enforcer with the specified start_dim
+    enforcer = ShapeEnforcer(start_dim=start_dim)
+
+    # Create input tensor with the specified shape
+    x = torch.randn(*input_shape)
+
+    # Apply the shape enforcer
+    y = enforcer(x, output_shape=output_shape)
+
+    # Test case specific assertions
+    if output_shape is None:
+        # If output_shape is None, input should be returned unchanged
+        assert y.shape == x.shape
+        assert torch.all(y == x)
+    else:
+        # Check dimensions before start_dim are preserved
+        assert y.shape[:start_dim] == x.shape[:start_dim]
+
+        # Check dimensions after start_dim match output_shape
+        assert y.shape[start_dim:] == tuple(output_shape)
+
+        # Additional assertions for specific test cases
+        if test_id == 4:  # Pure cropping
+            # For cropping, check that the preserved values are unchanged
+            slices = [slice(None)] * start_dim
+            for i, size in enumerate(output_shape):
+                slices.append(slice(0, size))
+            assert torch.all(y == x[tuple(slices)])
+
+        elif test_id == 5:  # Pure padding
+            # For padding, check original values are preserved and new values are zero
+            # Check original values preserved
+
+            # Create slices to get the part of y that corresponds to the original x
+            orig_slices = [slice(None)] * len(y.shape)
+            for i in range(start_dim, len(x.shape)):
+                orig_slices[i] = slice(0, x.shape[i])
+
+            # Check that original values are preserved
+            assert torch.all(y[tuple(orig_slices)] == x)
+
+            # Check padded areas are zero
+            for i, (orig_size, new_size) in enumerate(
+                zip(x.shape[start_dim:], output_shape)
+            ):
+                if orig_size < new_size:
+                    pad_slices = [slice(None)] * len(y.shape)
+                    pad_slices[start_dim + i] = slice(orig_size, None)
+                    assert torch.all(y[tuple(pad_slices)] == 0)
+
+        elif test_id == 6:  # Mixed crop/pad
+            # First dimension should be cropped
+            assert y.shape[start_dim] == output_shape[0]
+            # Check cropped part
+            assert torch.all(y[:, :, :, : x.shape[3]] == x[:, :, : output_shape[0], :])
+            # Check padded part
+            if x.shape[3] < output_shape[1]:
+                assert torch.all(y[:, :, :, x.shape[3] :] == 0)
+
+        elif test_id == 9:  # Empty tensor
+            # Check that empty dimension is preserved
+            assert y.shape[1] == 0
+
+        elif test_id == 10:  # Extreme downsizing
+            # Check that only the top-left corner is preserved
+            assert torch.all(y[:, :, 0, 0] == x[:, :, 0, 0])

--- a/neuralop/layers/tests/test_spectral_convolution_laplace.py
+++ b/neuralop/layers/tests/test_spectral_convolution_laplace.py
@@ -1,0 +1,317 @@
+# MIT License
+# Copyright (c) 2024 Saman Pordanesh
+
+import pytest
+import torch
+import numpy as np
+from neuralop.layers.spectral_convolution_laplace import (
+    SpectralConvLaplace1D,
+    SpectralConvLaplace2D,
+    SpectralConvLaplace3D,
+)
+
+# ------------------------------------------------------------------
+# 1D Laplace Convolution Tests
+# ------------------------------------------------------------------
+
+
+def test_laplace1d_forward_basic():
+    """
+    Basic forward test for SpectralConvLaplace1D:
+      - Checks the output has correct shape
+      - Verifies it returns a real tensor if input is real
+      - Ensures no runtime error for standard usage
+    """
+    batch_size, in_channels, out_channels = 2, 3, 2
+    length = 16
+    n_modes = (8,)
+
+    conv = SpectralConvLaplace1D(
+        in_channels=in_channels, out_channels=out_channels, n_modes=n_modes
+    )
+
+    x = torch.randn(batch_size, in_channels, length, dtype=torch.float32)
+    y = conv(x)
+    assert y.shape == (batch_size, out_channels, length)
+    # The module internally does ifft, and we expect real output from real input
+    assert torch.is_floating_point(y)
+
+
+def test_laplace1d_transform_scaling_up_down():
+    """
+    Test the transform() method in SpectralConvLaplace1D:
+      - Verifies upsampling and downsampling
+      - Ensures shape changes are correct
+    """
+    conv_down = SpectralConvLaplace1D(
+        in_channels=1, out_channels=1, n_modes=(4,), resolution_scaling_factor=0.5
+    )
+    conv_up = SpectralConvLaplace1D(
+        in_channels=1, out_channels=1, n_modes=(4,), resolution_scaling_factor=2.0
+    )
+
+    x = torch.randn(1, 1, 12)  # (B, C, L)
+
+    x_down = conv_down.transform(x)
+    x_up = conv_up.transform(x)
+
+    # 12 -> 6
+    assert x_down.shape == (1, 1, 6)
+    # 12 -> 24
+    assert x_up.shape == (1, 1, 24)
+
+
+def test_laplace1d_custom_domain():
+    """
+    Checks that user-specified domain (start_points, end_points, linspace_steps)
+    runs correctly. dt should be computed from the shape and domain.
+    We only check that it runs without error and the shape is retained.
+    """
+    conv = SpectralConvLaplace1D(
+        in_channels=1,
+        out_channels=1,
+        n_modes=(5,),
+        linspace_steps=[20],
+        linspace_startpoints=[-2.0],
+        linspace_endpoints=[2.0],
+    )
+    x = torch.randn(1, 1, 20)
+    y = conv(x)
+    # shape must remain the same if transform() is not triggered:
+    assert y.shape == (1, 1, 20)
+
+
+def test_laplace1d_invalid_linspace():
+    """
+    Ensures a ValueError is raised if user-specified domain arguments
+    don't match the dimension.
+    For 1D, we need exactly 1 start point and 1 end point.
+    """
+    x = torch.rand(1, 2, 3)
+    conv = SpectralConvLaplace1D(
+        in_channels=2,
+        out_channels=2,
+        n_modes=(4,),
+        linspace_steps=[16],
+        linspace_startpoints=[0.0, 1.0],  # Mismatch: we have 2
+        linspace_endpoints=[2.0],
+    )
+    with pytest.raises(ValueError):
+        y = conv(x)
+
+
+def test_laplace1d_pole_residue_manual_weight():
+    """
+    Test the core 'pole-residue' logic in 1D by setting the conv.weight
+    to a known pattern and verifying partial outputs:
+      - Check that transient (x1) and steady-state-like (x2) parts
+        contribute differently.
+      - This is a *sanity* check that output_PR is invoked as expected.
+    """
+    in_channels, out_channels = 1, 1
+    conv = SpectralConvLaplace1D(
+        in_channels=in_channels, out_channels=out_channels, n_modes=(4,)
+    )
+    # Overwrite the initial random weights with a small, known, complex pattern
+    # conv.weight shape => (in_channels, out_channels, total_modes)
+    # total_modes = max_n_modes + max_n_modes for 1D
+    w_shape = conv.weight.shape
+    # Example pattern: real part = 0, imag part = index
+    # so conv.weight[i] = i * 1j, purely imaginary
+    w_data = torch.zeros_like(conv.weight)
+    for idx in range(w_shape[-1]):
+        w_data[..., idx] = 1j * (idx + 1)
+    conv.weight.data = w_data
+
+    x = torch.rand(2, in_channels, 8)
+    y = conv(x)
+
+    # We can't know the exact numeric answer without writing an entire symbolic solution,
+    # but we can at least confirm the shape and that the output is real.
+    assert y.shape == (2, out_channels, 8)
+    assert torch.is_floating_point(y)
+
+
+# ------------------------------------------------------------------
+# 2D Laplace Convolution Tests
+# ------------------------------------------------------------------
+
+
+def test_laplace2d_forward_basic():
+    """
+    Basic forward test for SpectralConvLaplace2D.
+    We verify that the output shape matches the input shape in H/W
+    and that no runtime error occurs.
+    """
+    batch_size, in_channels, out_channels = 2, 2, 3
+    height, width = 16, 12
+    conv = SpectralConvLaplace2D(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        n_modes=(6, 6),
+    )
+
+    x = torch.randn(batch_size, in_channels, height, width)
+    y = conv(x)
+    assert y.shape == (batch_size, out_channels, height, width)
+    assert torch.is_floating_point(y)
+
+
+@pytest.mark.parametrize(
+    "n_modes,max_n_modes",
+    [
+        ((10, 8), None),
+        ((10, 8), (6, 4)),  # forced truncation
+    ],
+)
+def test_laplace2d_mode_truncation(n_modes, max_n_modes):
+    """
+    Validate that 2D Laplace conv properly truncates modes if
+    max_n_modes < n_modes or input dimension < n_modes.
+    """
+    conv = SpectralConvLaplace2D(
+        in_channels=1, out_channels=1, n_modes=n_modes, max_n_modes=max_n_modes
+    )
+    # shape is 8x6, smaller than some of the modes
+    x = torch.randn(1, 1, 8, 6)
+    y = conv(x)
+    assert y.shape == (1, 1, 8, 6)
+
+
+def test_laplace2d_transform_up_down():
+    """
+    Test transform() in 2D with different resolution_scaling_factors.
+    Ensures that shape changes are correct.
+    """
+    conv_down = SpectralConvLaplace2D(
+        in_channels=1, out_channels=1, n_modes=(4, 4), resolution_scaling_factor=0.5
+    )
+    conv_up = SpectralConvLaplace2D(
+        in_channels=1, out_channels=1, n_modes=(4, 4), resolution_scaling_factor=2.0
+    )
+    x = torch.randn(1, 1, 10, 12)
+
+    x_down = conv_down.transform(x)
+    x_up = conv_up.transform(x)
+
+    # 10 -> 5, 12 -> 6
+    assert x_down.shape == (1, 1, 5, 6)
+    # 10 -> 20, 12 -> 24
+    assert x_up.shape == (1, 1, 20, 24)
+
+
+def test_laplace2d_pole_residue_sanity():
+    """
+    Test partial sanity on the 'pole-residue' approach for 2D:
+    - Overwrite conv.weight to a small, controlled pattern
+    - Ensure the forward pass completes and yields real output
+    """
+    conv = SpectralConvLaplace2D(in_channels=1, out_channels=1, n_modes=(3, 3))
+    # total_modes = n_modes1 + n_modes2 + (n_modes1 * n_modes2)
+    # e.g. = 3 + 3 + 3*3 = 3 + 3 + 9 = 15
+    w_shape = conv.weight.shape
+    assert w_shape[-1] == 15
+
+    w_data = torch.zeros_like(conv.weight)
+    # Fill with a small imaginary pattern again
+    for idx in range(w_data.shape[-1]):
+        w_data[..., idx] = 0.01j * (idx + 1)
+    conv.weight.data = w_data
+
+    x = torch.rand(1, 1, 8, 8)
+    y = conv(x)
+    assert y.shape == (1, 1, 8, 8)
+    assert torch.is_floating_point(y)
+
+
+# ------------------------------------------------------------------
+# 3D Laplace Convolution Tests
+# ------------------------------------------------------------------
+
+
+def test_laplace3d_forward_basic():
+    """
+    Basic forward test for SpectralConvLaplace3D:
+      - Checks shape consistency
+      - Ensures real output for real input
+    """
+    batch_size, in_channels, out_channels = 1, 2, 2
+    depth, height, width = 4, 5, 6
+    conv = SpectralConvLaplace3D(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        n_modes=(4, 3, 2),
+    )
+
+    x = torch.randn(batch_size, in_channels, depth, height, width)
+    y = conv(x)
+    assert y.shape == (batch_size, out_channels, depth, height, width)
+    assert torch.is_floating_point(y)
+
+
+def test_laplace3d_transform_scaling():
+    """
+    Check transform() in 3D: up/down-sampling.
+    """
+    conv = SpectralConvLaplace3D(
+        in_channels=1,
+        out_channels=1,
+        n_modes=(2, 2, 2),
+        resolution_scaling_factor=[2.0, 0.5, 1.5],
+    )
+    x = torch.randn(1, 1, 6, 6, 6)
+    # 6 -> 12, 6 -> 3, 6 -> 9
+    x_t = conv.transform(x)
+    assert x_t.shape == (1, 1, 12, 3, 9)
+
+
+@pytest.mark.parametrize(
+    "n_modes,max_n_modes",
+    [
+        ((4, 4, 4), None),
+        ((5, 5, 5), (3, 6, 5)),  # partial truncation
+    ],
+)
+def test_laplace3d_mode_truncation(n_modes, max_n_modes):
+    """
+    3D mode truncation check:
+      - ensures we never exceed input dims (or max_n_modes) in each dimension
+    """
+    conv = SpectralConvLaplace3D(
+        in_channels=2, out_channels=2, n_modes=n_modes, max_n_modes=max_n_modes
+    )
+    x = torch.randn(2, 2, 4, 5, 6)
+    y = conv(x)
+    assert y.shape == (2, 2, 4, 5, 6)
+
+
+def test_laplace3d_pole_residue_sanity():
+    """
+    Minimal sanity test for the pole-residue approach in 3D:
+    - Manually set the combined weight array to a small imaginary pattern
+    - Forward pass should still produce real output with correct shape
+    """
+    conv = SpectralConvLaplace3D(
+        in_channels=1,
+        out_channels=1,
+        n_modes=(2, 2, 2),
+    )
+    w_shape = conv.weight.shape
+    # total_modes = modes1 + modes2 + modes3 + (modes1*modes2*modes3)
+    # e.g. = 2+2+2 + (2*2*2)=6 + 8=14
+    assert w_shape[-1] == 14
+
+    w_data = torch.zeros_like(conv.weight)
+    for idx in range(w_data.shape[-1]):
+        w_data[..., idx] = 0.001j * (idx + 1)
+    conv.weight.data = w_data
+
+    x = torch.rand(2, 1, 4, 4, 4)
+    y = conv(x)
+    assert y.shape == (2, 1, 4, 4, 4)
+    assert torch.is_floating_point(y)
+
+
+# ------------------------------------------------------------------
+# Shared Edge Cases Across All Dimensions
+# ------------------------------------------------------------------


### PR DESCRIPTION
# ✨ Laplace Neural Operator (LNO) ✨
This PR introduces **Laplace‑based Spectral Convolutions** in 1‑D, 2‑D, and 3‑D, along with unit tests and a small utility for shape enforcement.

**Primary references**

| Resource | Link |
|----------|------|
| Paper | <https://arxiv.org/pdf/2303.10528> |
| Original implementation | <https://github.com/qianyingcao/Laplace-Neural-Operator> |

---

## 1  |  Why a series of small PRs?
Implementing Laplace and Wavelet kernels touches multiple layers of the library (kernels → blocks → models).  
To keep each review focused and mergeable, I’m submitting a **bottom‑up sequence** of PRs:

1. **Spectral kernels** (Laplace ✓, Wavelet → upcoming)  
2. **Block‑level integration** (FNOBlocks / XNOBlocks)  
3. **Model‑level wiring** (FNO, TFNO, etc.)  
4. **Docs & gallery example refresh**

Each PR contains **fully‑documented code, helper utilities, unit tests, and inline typing**.  
I don’t expect immediate approval; instead, I’m committed to an iterative review process and will revise as many times as needed to meet project standards.

---

## 2  |  What’s in this PR

| File | Purpose |
|------|---------|
| `neuralop/layers/spectral_convolution_laplace.py` | New `SpectralConvLaplace{1,2,3}D` layers following core API conventions (FFT shape‑handling, `modes`, bias, complex weights). |
| `neuralop/layers/shape_enforcer.py` | Utility to ensure inverse FFT outputs match expected spatial dims (PyTorch handles this for FFT; Laplace kernels need an explicit helper). |
| `neuralop/layers/tests/test_spectral_convolution_laplace.py` | Unit tests for forward pass, mode truncation, etc. |
| `neuralop/layers/tests/test_shape_enforcer.py` | Edge‑case tests for cropping/padding logic. |

---

## 3  |  Review notes & open questions

* **API surface** – I tried to mirror `SpectralConv` naming (`in_channels`, `out_channels`, etc.), and consider all those arguemtns in each new spectral convolution classes, although not all of them being used. Just keep them for future developement. 
* **ShapeEnforcer location** – currently in `neuralop.layers`; relocate if there’s a utilities sub‑package you’d rather use.

---

## 4  |  Additional references
For a detailed comparison between the Laplace kernels introduced in this PR and the original paper’s implementation, see **LNO.md**:

[LNO.md](https://github.com/user-attachments/files/19823392/LNO.md)

The note documents each kernel, explains the adaptations made for `neuralop`, and provides accuracy checks confirming numerical parity with the reference code.


---

*Thank you for your time and feedback. I’m available to iterate until the code fits seamlessly into* **neuraloperator** *and its CI.* 
