### PR TITLE
Escape characters compatible with python >= 3.12

### DIFF
--- a/neuralop/layers/attention_kernel_integral.py
+++ b/neuralop/layers/attention_kernel_integral.py
@@ -7,9 +7,9 @@ from torch.nn.init import xavier_uniform_, zeros_
 class AttentionKernelIntegral(torch.nn.Module):
     """
     Kernel integral transform with attention
-    Computes \int_{Omega} k(x, y) * f(y) dy,
+    Computes \\int_{Omega} k(x, y) * f(y) dy,
     where:
-          K(x, y) = \sum_{c=1}^d q_c(x) * k_c(y), q(x) = [q_1(x); ...; q_d(x)], k(y) = [k_1(y); ...; k_d(y)]
+          K(x, y) = \\sum_{c=1}^d q_c(x) * k_c(y), q(x) = [q_1(x); ...; q_d(x)], k(y) = [k_1(y); ...; k_d(y)]
           f(y) = v(y)
     More specifically, this module supports using just one input function (self-attention) or
     two input functions (cross-attention) to compute the kernel integral transform.
@@ -30,7 +30,7 @@ class AttentionKernelIntegral(torch.nn.Module):
     Self-attention can be considered as a special case of cross-attention, where u = u_qry = u_src and D_x = D_y.
 
     The kernel integral transform will be numerically computed as:
-        \int_{Omega} k(x, y) * f(y) dy \appox \sum_{j=1}^M * k(x, y_j) * f(y_j) * w(y_j)
+        \\int_{Omega} k(x, y) * f(y) dy \\appox \\sum_{j=1}^M * k(x, y_j) * f(y_j) * w(y_j)
     For uniform quadrature, the weights w(y_j) = 1/M.
     For non-uniform quadrature, the weights w(y_j) is specified as an input to the forward function.
 
@@ -40,7 +40,7 @@ class AttentionKernelIntegral(torch.nn.Module):
     out_channels : int, output channels
     n_heads : int, number of attention heads in multi-head attention
     head_n_channels : int, dimension of each attention head, determines how many function bases to use for the kernel
-                      k(x, y) = \sum_{c=1}^d \q_c(x) * \k_c(y), head_n_channels controls the d
+                      k(x, y) = \\sum_{c=1}^d \\q_c(x) * \\k_c(y), head_n_channels controls the d
     pos_dim : int, dimension of the domain, determines the dimension of coordinates
     project_query : bool, whether to project the query function with pointwise linear layer
                    (this is sometimes not needed when using cross-attention)

--- a/neuralop/layers/gno_block.py
+++ b/neuralop/layers/gno_block.py
@@ -23,10 +23,10 @@ class GNOBlock(nn.Module):
 
     The kernel integral computed in IntegralTransform 
     computes one of the following:
-        (a) \int_{A(x)} k(x, y) dy
-        (b) \int_{A(x)} k(x, y) * f(y) dy
-        (c) \int_{A(x)} k(x, y, f(y)) dy
-        (d) \int_{A(x)} k(x, y, f(y)) * f(y) dy
+        (a) \\int_{A(x)} k(x, y) dy
+        (b) \\int_{A(x)} k(x, y) * f(y) dy
+        (c) \\int_{A(x)} k(x, y, f(y)) dy
+        (d) \\int_{A(x)} k(x, y, f(y)) * f(y) dy
     
     Parameters
     ----------

--- a/neuralop/layers/integral_transform.py
+++ b/neuralop/layers/integral_transform.py
@@ -9,10 +9,10 @@ from .segment_csr import segment_csr
 class IntegralTransform(nn.Module):
     """Integral Kernel Transform (GNO)
     Computes one of the following:
-        (a) \int_{A(x)} k(x, y) dy
-        (b) \int_{A(x)} k(x, y) * f(y) dy
-        (c) \int_{A(x)} k(x, y, f(y)) dy
-        (d) \int_{A(x)} k(x, y, f(y)) * f(y) dy
+        (a) \\int_{A(x)} k(x, y) dy
+        (b) \\int_{A(x)} k(x, y) * f(y) dy
+        (c) \\int_{A(x)} k(x, y, f(y)) dy
+        (d) \\int_{A(x)} k(x, y, f(y)) * f(y) dy
 
     x : Points for which the output is defined
 

--- a/neuralop/losses/data_losses.py
+++ b/neuralop/losses/data_losses.py
@@ -33,7 +33,7 @@ class LpLoss(object):
         dimension of data on which to compute, by default 1
     p : int, optional
         order of L-norm, by default 2
-        L-p norm: [\sum_{i=0}^n (x_i - y_i)**p] ** (1/p)
+        L-p norm: [\\sum_{i=0}^n (x_i - y_i)**p] ** (1/p)
     measure : float or list, optional
         measure of the domain, by default 1.0
         either single scalar for each dim, or one per dim


### PR DESCRIPTION
Minor correction in docstrings: changed escape characters to prevent 'SyntaxError' in python versions >= 3.12