### PR TITLE
(fix) ensure imaginary components of zero and nyquist frequencies are 0 before IFFT

### DIFF
--- a/neuralop/layers/irfft.py
+++ b/neuralop/layers/irfft.py
@@ -1,0 +1,90 @@
+from typing import Iterable, Literal
+
+import torch
+from torch.fft import irfftn
+from torch.testing import assert_close
+
+class irfftn_handle(object):
+    """ 
+    Wrapper around torch.fft.irfftn() to manually correct cufft. 
+    """
+    def __init__(self, device):
+        # set up cuda to use CUFFT backend if possible
+
+        x = torch.randn(32,dtype=torch.cfloat).to(device)
+        x_no_imag = torch.clone(x)
+
+        # manually set zero and nyquist imaginary components to zero 
+        # this should happen in the inverse RFFT but some CUFFT backends
+        # do not verify this. 
+        x_no_imag[0].imag = 0. 
+        x_no_imag[16].imag = 0. 
+
+        x_irfft = irfftn(x)
+        x_irfft_no_imag = irfftn(x_no_imag)
+
+        try:
+            assert_close(x_irfft, x_irfft_no_imag)
+            self.needs_manual_correction = False
+        except AssertionError:
+            self.needs_manual_correction = True
+    
+    def __call__(self, x: torch.Tensor, 
+                 fft_dims: Iterable=None, 
+                 mode_sizes: Iterable=None, 
+                 norm: Literal['ortho', 'forward', 'backward']=None):
+        """
+        Compute the inverse Real N-dimensional Fast Fourier Transform
+        
+        Parameters
+        ----------
+        x : ``torch.Tensor``
+            input tensor of basis coefficients to be inverse transformed
+        fft_dims : ``Iterable``, optional
+            dimensions of x along which to perform the IRFFT,
+            by default None. 
+            If None, performs IRFFT along each dimension. 
+        mode_sizes : ``Iterable``, optional
+            Size of the output of IRFFT along each dimension,
+            corresponding to the dimensions listed in fft_dims,
+            by default None.
+            If None, uses default output size computed by IRFFT.
+        norm : ``Literal['ortho', 'forward', 'backward']``, optional
+            Whether to normalize the outputs of the IRFFT, by default None
+            * If ``'ortho'``, scales outputs by ``1/sqrt(n)`` 
+            along each dim of size ``n`` 
+            * If ``'forward'``, does nothing in the reverse direction,
+            as input is assumed to be scaled by ``1/n`` by the FFT.
+            * If ``'backward'``, scales outputs by ``1/n`` 
+            along each dim of size ``n``. 
+        """
+        
+        if self.needs_manual_correction:
+            zero_frequency_inds = [] 
+            nyquist_frequency_inds = []
+            fft_size = x.shape[fft_dims]
+            
+            # correct zero and optionally nyquist frequency imaginary components
+            # along each transformed mode of the FFT tensor
+            for mode_size, dim in zip(fft_size, fft_dims):
+                zero_ind = [slice(None)] * input.ndim
+                zero_ind[dim] = slice(0,1)
+
+                x[zero_ind].imag = 0.
+
+                # only correct the nyquist frequency here if the signal length along 
+                # this dimension is a multiple of two. 
+                if mode_size % 2 == 0:
+                    nyquist_ind = [None] * input.ndim
+                    nyquist_ind[dim] = slice(mode_size // 2, mode_size // 2 + 1)
+                    x[nyquist_ind].imag = 0.
+                
+            # Manually set the imaginary component of the nyquist frequency 
+            # of the last dim, which we truncate to remove redundant coefficients, to zero
+            last_nyquist_ind = [slice(None)] * (x.ndim-1) + [slice(-1, 0)]
+            x[last_nyquist_ind].imag = 0.
+        else:
+            return irfftn(x, s=mode_sizes, dim=dim, norm=norm)
+
+
+

--- a/neuralop/layers/irfft.py
+++ b/neuralop/layers/irfft.py
@@ -62,12 +62,12 @@ class irfftn_handle(object):
         if self.needs_manual_correction:
             zero_frequency_inds = [] 
             nyquist_frequency_inds = []
-            fft_size = x.shape[fft_dims]
+            fft_size = [x.shape[k] for k in fft_dims]
             
             # correct zero and optionally nyquist frequency imaginary components
             # along each transformed mode of the FFT tensor
             for mode_size, dim in zip(fft_size, fft_dims):
-                zero_ind = [slice(None)] * input.ndim
+                zero_ind = [slice(None)] * x.ndim
                 zero_ind[dim] = slice(0,1)
 
                 x[zero_ind].imag = 0.
@@ -75,7 +75,7 @@ class irfftn_handle(object):
                 # only correct the nyquist frequency here if the signal length along 
                 # this dimension is a multiple of two. 
                 if mode_size % 2 == 0:
-                    nyquist_ind = [None] * input.ndim
+                    nyquist_ind = [slice(None)] * x.ndim
                     nyquist_ind[dim] = slice(mode_size // 2, mode_size // 2 + 1)
                     x[nyquist_ind].imag = 0.
                 
@@ -83,8 +83,8 @@ class irfftn_handle(object):
             # of the last dim, which we truncate to remove redundant coefficients, to zero
             last_nyquist_ind = [slice(None)] * (x.ndim-1) + [slice(-1, 0)]
             x[last_nyquist_ind].imag = 0.
-        else:
-            return irfftn(x, s=mode_sizes, dim=dim, norm=norm)
+        
+        return irfftn(x, s=mode_sizes, dim=fft_dims, norm=norm)
 
 
 

--- a/neuralop/layers/spectral_convolution.py
+++ b/neuralop/layers/spectral_convolution.py
@@ -503,14 +503,14 @@ class SpectralConv(BaseSpectralConv):
             # b, c, *spatial_dims
 
             # after reversing fft shift, zero is at 0 
-            zero_indices.append([[slice(None), slice(None)] + [slice(None)] * i +\
-                                        [slice(0, 1)] + [slice(None)] * (len(fft_size) - i - 1)])
+            zero_indices.append([slice(None), slice(None)] + [slice(None)] * i +\
+                                        [slice(0, 1)] + [slice(None)] * (len(fft_size) - i - 1))
             
         # after reversing fft shift, nyquist is at n//2 
         for i, mode_sz in enumerate(fft_size[:-1]):
             if mode_sz % 2 == 0:
-                nyquist_indices.append([[slice(None), slice(None)] + [slice(None)] * i +\
-                                        [slice(mode_sz//2, mode_sz//2 + 1)] + [slice(None)] * (len(fft_size) - i - 1)])
+                nyquist_indices.append([slice(None), slice(None)] + [slice(None)] * i +\
+                                        [slice(mode_sz//2, mode_sz//2 + 1)] + [slice(None)] * (len(fft_size) - i - 1))
         # except for the last mode, where it is at 
         nyquist_indices.append((slice(None), slice(None), *[slice(None)]*(len(fft_size)-1), slice(-1)))
             

--- a/neuralop/layers/spectral_convolution.py
+++ b/neuralop/layers/spectral_convolution.py
@@ -503,7 +503,7 @@ class SpectralConv(BaseSpectralConv):
         if self.order > 1:
             out_fft = torch.fft.fftshift(out_fft, dim=fft_dims[:-1])
 
-        # not all CUFFT backend algorithms ensure that the imaginary components 
+        '''# not all CUFFT backend algorithms ensure that the imaginary components 
         # of zero and nyquist (n//2) frequencies are set to 0, so we do this manually
 
         zero_indices = []
@@ -527,7 +527,7 @@ class SpectralConv(BaseSpectralConv):
             out_fft[idx].imag = 0.0
         
         for idx in nyquist_indices:
-            out_fft[idx].imag = 0.0
+            out_fft[idx].imag = 0.0'''
 
 
         if self.complex_data:

--- a/neuralop/layers/spectral_convolution.py
+++ b/neuralop/layers/spectral_convolution.py
@@ -533,7 +533,7 @@ class SpectralConv(BaseSpectralConv):
         if self.complex_data:
             x = torch.fft.ifftn(out_fft, s=mode_sizes, dim=fft_dims, norm=self.fft_norm)
         else:
-            x = self._irfftn_handle(out_fft, s=mode_sizes, dim=fft_dims, norm=self.fft_norm)
+            x = self._irfftn_handle(out_fft, mode_sizes=mode_sizes, fft_dims=fft_dims, norm=self.fft_norm)
 
         if self.bias is not None:
             x = x + self.bias


### PR DESCRIPTION
Relates to [this fix](https://github.com/NVIDIA/torch-harmonics/pull/70) in `torch-harmonics` related to a bug in some CUFFT backends. The nyquist frequency and zero frequency sometimes have erroneous imaginary components which need to be manually removed. 

# Fix
In `neuralop/layers/spectral_convolution.py`, explicitly sets the imaginary component of the zero frequency and nyquist frequency along each mode to zero. 