### PR TITLE
(doc) Add helpful error messages to all asserts

### DIFF
--- a/neuralop/data/datasets/mesh_datamodule.py
+++ b/neuralop/data/datasets/mesh_datamodule.py
@@ -55,7 +55,7 @@ class MeshDataModule:
 
         if o3d_warn:
             print("Warning: you are attempting to run MeshDataModule without the required dependency open3d.")
-
+            raise ModuleNotFoundError()
         if isinstance(root_dir, str):
             root_dir = Path(root_dir)
 

--- a/neuralop/data/datasets/pt_dataset.py
+++ b/neuralop/data/datasets/pt_dataset.py
@@ -114,9 +114,13 @@ class PTDataset:
             # expand subsampling rate along dims if one per dim is not provided
             input_subsampling_rate = [input_subsampling_rate] * input_data_dims
         # make sure there is one subsampling rate per data dim
-        assert len(input_subsampling_rate) == input_data_dims
+        assert len(input_subsampling_rate) == input_data_dims, \
+            f"Error: length mismatch between input_subsampling_rate and dimensions of data.\
+                input_subsampling_rate must be one int shared across all dims, or an iterable of\
+                    length {len(input_data_dims)}, got {input_subsampling_rate}"
         # Construct full indices along which to grab X
-        train_input_indices = [slice(0, n_train, None)] + [slice(None, None, rate) for rate in input_subsampling_rate]
+        train_input_indices = [slice(0, n_train, None)] + [slice(None, None, rate)\
+                                                           for rate in input_subsampling_rate]
         train_input_indices.insert(channel_dim, slice(None))
         x_train = x_train[train_input_indices]
         
@@ -133,7 +137,10 @@ class PTDataset:
             # expand subsampling rate along dims if one per dim is not provided
             output_subsampling_rate = [output_subsampling_rate] * output_data_dims
         # make sure there is one subsampling rate per data dim
-        assert len(output_subsampling_rate) == output_data_dims
+        assert len(output_subsampling_rate) == output_data_dims, \
+            f"Error: length mismatch between output_subsampling_rate and dimensions of data.\
+                input_subsampling_rate must be one int shared across all dims, or an iterable of\
+                    length {len(output_data_dims)}, got {output_subsampling_rate}"
 
         # Construct full indices along which to grab Y
         train_output_indices = [slice(0, n_train, None)] + [slice(None, None, rate) for rate in output_subsampling_rate]

--- a/neuralop/data/datasets/web_utils.py
+++ b/neuralop/data/datasets/web_utils.py
@@ -106,7 +106,9 @@ def download_from_url(
                     prog = curr_size / size
                     print(f"Download in progress: {prog:.2%}", end='\r')
 
-            assert fpath.stat().st_size == size
+            assert fpath.stat().st_size == size, f"Error: mismatch between expected\
+                 and true size of downloaded file {fpath}. Delete the file\
+                    and try again. "
 
     # check integrity of downloaded file
     if not check_integrity(fpath, md5):


### PR DESCRIPTION
Adds errors to asserts in `neuralop.data.datasets` that describe failures more informatively. 