### PR TITLE
add explicit indexing type in torch.meshgrid(...) for posterity

### DIFF
--- a/examples/layers/plot_DISCO_convolutions.py
+++ b/examples/layers/plot_DISCO_convolutions.py
@@ -46,7 +46,7 @@ plt.show()
 x_in = torch.linspace(0, 2, nx)
 y_in = torch.linspace(0, 3, ny)
 
-x_in, y_in = torch.meshgrid(x_in, y_in)
+x_in, y_in = torch.meshgrid(x_in, y_in, indexing='ij')
 grid_in = torch.stack([x_in.reshape(-1), y_in.reshape(-1)])
 
 # compute the correct quadrature weights
@@ -85,7 +85,7 @@ nyo = 120
 x_out = torch.linspace(0, 2, nxo)
 y_out = torch.linspace(0, 3, nyo)
 
-x_out, y_out = torch.meshgrid(x_out, y_out)
+x_out, y_out = torch.meshgrid(x_out, y_out, indexing='ij')
 grid_out = torch.stack([x_out.reshape(-1), y_out.reshape(-1)])
 
 # compute the correct quadrature weights

--- a/neuralop/layers/discrete_continuous_convolution.py
+++ b/neuralop/layers/discrete_continuous_convolution.py
@@ -346,8 +346,8 @@ class DiscreteContinuousConv2d(DiscreteContinuousConv):
             assert len(n_in) == 2
             x, wx = _precompute_grid(n_in[0], grid=grid_in, periodic=periodic)
             y, wy = _precompute_grid(n_in[1], grid=grid_in, periodic=periodic)
-            x, y = torch.meshgrid(torch.from_numpy(x), torch.from_numpy(y))
-            wx, wy = torch.meshgrid(torch.from_numpy(wx), torch.from_numpy(wy))
+            x, y = torch.meshgrid(torch.from_numpy(x), torch.from_numpy(y), indexing='ij')
+            wx, wy = torch.meshgrid(torch.from_numpy(wx), torch.from_numpy(wy), indexing='ij')
             grid_in = torch.stack([x.reshape(-1), y.reshape(-1)])
             quadrature_weights = (wx * wy).reshape(-1)
         else:
@@ -360,7 +360,7 @@ class DiscreteContinuousConv2d(DiscreteContinuousConv):
             assert len(n_out) == 2
             x, wx = _precompute_grid(n_out[0], grid=grid_out, periodic=periodic)
             y, wy = _precompute_grid(n_out[1], grid=grid_out, periodic=periodic)
-            x, y = torch.meshgrid(torch.from_numpy(x), torch.from_numpy(y))
+            x, y = torch.meshgrid(torch.from_numpy(x), torch.from_numpy(y), indexing='ij')
             grid_out = torch.stack([x.reshape(-1), y.reshape(-1)])
         else:
             raise ValueError(f"Unknown grid output type of type {type(grid_out)}")
@@ -528,8 +528,8 @@ class DiscreteContinuousConvTranspose2d(DiscreteContinuousConv):
             assert len(n_in) == 2
             x, wx = _precompute_grid(n_in[0], grid=grid_in, periodic=periodic)
             y, wy = _precompute_grid(n_in[1], grid=grid_in, periodic=periodic)
-            x, y = torch.meshgrid(torch.from_numpy(x), torch.from_numpy(y))
-            wx, wy = torch.meshgrid(torch.from_numpy(wx), torch.from_numpy(wy))
+            x, y = torch.meshgrid(torch.from_numpy(x), torch.from_numpy(y), indexing='ij')
+            wx, wy = torch.meshgrid(torch.from_numpy(wx), torch.from_numpy(wy), indexing='ij')
             grid_in = torch.stack([x.reshape(-1), y.reshape(-1)])
             quadrature_weights = (wx * wy).reshape(-1)
         else:
@@ -542,7 +542,7 @@ class DiscreteContinuousConvTranspose2d(DiscreteContinuousConv):
             assert len(n_out) == 2
             x, wx = _precompute_grid(n_out[0], grid=grid_out, periodic=periodic)
             y, wy = _precompute_grid(n_out[1], grid=grid_out, periodic=periodic)
-            x, y = torch.meshgrid(torch.from_numpy(x), torch.from_numpy(y))
+            x, y = torch.meshgrid(torch.from_numpy(x), torch.from_numpy(y), indexing='ij')
             grid_out = torch.stack([x.reshape(-1), y.reshape(-1)])
         else:
             raise ValueError(f"Unknown grid output type of type {type(grid_out)}")
@@ -726,7 +726,7 @@ class EquidistantDiscreteContinuousConv2d(DiscreteContinuousConv):
         # psi_local is essentially the support of the hat functions evaluated locally
         x = torch.linspace(-radius_cutoff, radius_cutoff, self.psi_local_h)
         y = torch.linspace(-radius_cutoff, radius_cutoff, self.psi_local_w)
-        x, y = torch.meshgrid(x, y)
+        x, y = torch.meshgrid(x, y, indexing='ij')
         grid_in = torch.stack([x.reshape(-1), y.reshape(-1)])
 
         # compute quadrature weights on the incoming grid
@@ -889,7 +889,7 @@ class EquidistantDiscreteContinuousConvTranspose2d(DiscreteContinuousConv):
         # psi_local is essentially the support of the hat functions evaluated locally
         x = torch.linspace(-radius_cutoff, radius_cutoff, self.psi_local_h)
         y = torch.linspace(-radius_cutoff, radius_cutoff, self.psi_local_w)
-        x, y = torch.meshgrid(x, y)
+        x, y = torch.meshgrid(x, y, indexing='ij')
         grid_in = torch.stack([x.reshape(-1), y.reshape(-1)])
         grid_out = torch.Tensor([[0.0], [0.0]])
 


### PR DESCRIPTION
Hi @dhpitt, as discussed in #550, this PR adds explicit indexing support when constructing the meshgrids. This is needed since `torch.meshgrid(...)` would transition to indexing type `xy` in the future from the current default of `ij`.