### PR TITLE
Fix the small bug for PINO loss

### DIFF
--- a/neuralop/losses/equation_losses.py
+++ b/neuralop/losses/equation_losses.py
@@ -219,6 +219,6 @@ class PoissonEqnLoss(object):
             interior_loss = self.interior_weight * self.interior_loss(out['domain'], **kwargs)
             bc_loss = self.boundary_weight * self.boundary_loss(out['boundary'], y=y['boundary'],  **kwargs)
         else:
-            interior_loss = self.interior_weight + self.interior_loss(out, **kwargs)
+            interior_loss = self.interior_weight * self.interior_loss(out, **kwargs)
             bc_loss = self.boundary_weight * self.boundary_loss(out, y=y, **kwargs)
         return interior_loss + bc_loss


### PR DESCRIPTION
The original PINO code has a bug where the Poisson equation loss adds interior weights with interior loss instead of multiplication. It is fixed to be multiplicatio now.