### PR TITLE
[BUGFIX] Fix TypeError caused by len() on None in CODANO

### DIFF
--- a/neuralop/models/codano.py
+++ b/neuralop/models/codano.py
@@ -195,15 +195,15 @@ class CODANO(nn.Module):
         self.n_layers = n_layers
         assert len(n_modes) == n_layers, "number of modes for all layers are not given"
         assert (
-            len(n_heads) == n_layers or n_heads is None
+             n_heads is None or len(n_heads) == n_layers
         ), "number of Attention head for all layers are not given"
         assert (
+            per_layer_scaling_factors is None or
             len(per_layer_scaling_factors) == n_layers
-            or per_layer_scaling_factors is None
         ), "scaling for all layers are not given"
         assert (
+            attention_scaling_factors is None or
             len(attention_scaling_factors) == n_layers
-            or attention_scaling_factors is None
         ), "attention scaling for all layers are not given"
         if use_positional_encoding:
             assert positional_encoding_dim > 0, "positional encoding dim is not given"

--- a/test.ipynb
+++ b/test.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7a02f9c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "print token code dimension 1 1\n",
+      "print token code dimension 1 1\n",
+      "print token code dimension 1 1\n",
+      "print token code dimension 1 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "from neuralop.models.codano import CODANO\n",
+    "import torch\n",
+    "\n",
+    "model = CODANO(\n",
+    "    output_variable_codimension=1,\n",
+    "    lifting_channels=64,\n",
+    "    hidden_variable_codimension=32,\n",
+    "    projection_channels=64,\n",
+    "    n_layers=4,\n",
+    "    n_modes=[[16, 16]] * 4,\n",
+    "    variable_ids=['u_x', 'u_y', 'p'],\n",
+    "    use_positional_encoding=True,\n",
+    "    positional_encoding_dim=8,\n",
+    "    positional_encoding_modes=[16, 16],\n",
+    "    static_channel_dim=1,\n",
+    "    enable_cls_token=True,\n",
+    ").to(\"cuda\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "896238b6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([32, 3, 16, 18])\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = torch.randn(32, 3, 16, 18).to(\"cuda\")\n",
+    "static_channel = torch.randn(32, 1, 16, 18).to(\"cuda\")\n",
+    "input_variable_ids = ['u_x', 'u_y', 'p']\n",
+    "output = model(data, static_channel, input_variable_ids)\n",
+    "\n",
+    "print(output.shape)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### 🐛 Bug Description

In the `CODANO` class constructor, the following assertion is currently written as:

```python
assert (
    len(n_heads) == n_layers or n_heads is None
), "number of Attention head for all layers are not given"
assert (
    len(per_layer_scaling_factors) == n_layers
    or per_layer_scaling_factors is None
), "scaling for all layers are not given"
assert (
    len(attention_scaling_factors) == n_layers
    or attention_scaling_factors is None
), "attention scaling for all layers are not given"
```

However, if `n_heads`, `per_layer_scaling_factors`, or `attention_scaling_factors`  are None, this leads to a TypeError:
```python
TypeError: object of type 'NoneType' has no len()
```

✅ Fix Summary
This PR fixes the bug by changing the order of conditions in the assertion statements to check for None first. This avoids evaluating len() on a NoneType object.

Updated code:
```python
assert (
     n_heads is None or len(n_heads) == n_layers
), "number of Attention head for all layers are not given"
assert (
    per_layer_scaling_factors is None or
    len(per_layer_scaling_factors) == n_layers
), "scaling for all layers are not given"
assert (
    attention_scaling_factors is None or
    len(attention_scaling_factors) == n_layers
), "attention scaling for all layers are not given"
```

This change aligns with the later logic in the code, where default values are set when these arguments are None.

🧪 Added Test File
To verify the fix and provide a simple example usage of CODANO, I added a new notebook:
`test.ipynb`

This notebook includes minimal code to instantiate the model with default parameters and ensures that the bug no longer occurs.

Thanks for reviewing this PR!