### PR TITLE
Add wavelet convolution layer

### DIFF
--- a/neuralop/layers/spectral_convolution_wavelet.py
+++ b/neuralop/layers/spectral_convolution_wavelet.py
@@ -159,7 +159,6 @@ class SpectralConvWavelet(nn.Module):
         
     # ------------------------------- forward -------------------------------
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        
         # Dimension check for incoming tensor (Assuming B,C,S... format)
         assert x.ndim == 2 + self.n_dim, f"Expected (B,C,{self.n_dim}D), got {x.shape}"
         B, Cin = x.shape[:2]
@@ -234,6 +233,6 @@ class SpectralConvWavelet(nn.Module):
                 zero_dict = {k: torch.zeros_like(next(iter(D_out.values()))) for k in D_out.keys()}
                 coeffs_out.append(zero_dict)
 
-            yb = ptwt_waverec3(tuple(coeffs_out), wav, mode=self.mode)
+            yb = ptwt_waverec3(tuple(coeffs_out), wav)
             out[b] = yb
         return out

--- a/neuralop/layers/spectral_convolution_wavelet.py
+++ b/neuralop/layers/spectral_convolution_wavelet.py
@@ -1,0 +1,62 @@
+from __features__ import Feature
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+import numpy as np
+import torch
+import torch.nn as nn
+
+try: 
+    from pytorch_wavelets import DWT1D, IDWT1D
+    from pytorch_waqvelets import DWT, IDWT
+    _HAS_PTW = True
+except Exception: 
+    _HAS_PTW = False
+    
+try:
+    import pywt
+    from ptwt.conv_transform_3 import wavedec3 as ptwt_wavedec3
+    from ptwt.conv_transform_3 import waverec3 as ptwt_waverec3
+    _HAS_PYWT_PTWT = True
+except Exception:
+    _HAS_PYWT_PTWT = False
+
+
+class SpectralConvWavelet(nn.Module):
+    """Implements Unified Wavelet-based Spectral Convolution for n_dim ∈ {1,2,3}.
+    described in [1]_
+
+    Parameters
+    ----------
+    in_channels, out_channels : int
+    level : int
+        Decomposition levels (we act on the last level only).
+    size : int | Tuple[int, ...]
+        Nominal spatial size. For n_dim=1 provide an int; for 2D/3D a tuple/list.
+    n_dim : {1,2,3}
+        Dimensionality selector.
+    wavelet : str
+        Wavelet name (e.g., 'db4'). For 3D we pass pywt.Wavelet(wavelet) to ptwt.
+    mode : str
+        Boundary mode (e.g., 'symmetric' for 1D/2D; 'periodization' or 'symmetric' for 3D).
+
+    .. [1] : Tripura, T., and Chakraborty, S. “Wavelet neural operator: a neural operator for parametric partial differential equations” (2022). arXiv preprint arXiv:2205.02191, https://arxiv.org/pdf/2205.02191.
+
+    """
+    
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        level: int,
+        size: Union[int, Sequence[int]],
+        n_dim: int,
+        wavelet: str = "db4",
+        mode: str = "symmetric",
+    ) -> None:
+        super().__init__()
+        
+    # ------------------------------- helpers -------------------------------
+        
+        
+    # ------------------------------- forward -------------------------------
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+         pass

--- a/neuralop/layers/spectral_convolution_wavelet.py
+++ b/neuralop/layers/spectral_convolution_wavelet.py
@@ -1,4 +1,3 @@
-from __features__ import Feature
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 import numpy as np
 import torch
@@ -6,7 +5,7 @@ import torch.nn as nn
 
 try: 
     from pytorch_wavelets import DWT1D, IDWT1D
-    from pytorch_waqvelets import DWT, IDWT
+    from pytorch_wavelets import DWT, IDWT
     _HAS_PTW = True
 except Exception: 
     _HAS_PTW = False
@@ -84,7 +83,7 @@ class SpectralConvWavelet(nn.Module):
         self.wavelet = wavelet
         self.mode = mode
         self.size = _ensure_tuple_size(size, self.n_dim)
-        
+
         # Dependency checks per-dimension
         if self.n_dim in (1, 2) and not _HAS_PTW:
             raise ImportError("pytorch_wavelets is required for n_dim=1 or 2")

--- a/neuralop/layers/spectral_convolution_wavelet.py
+++ b/neuralop/layers/spectral_convolution_wavelet.py
@@ -29,6 +29,12 @@ def _ensure_tuple_size(size: Union[int, Sequence[int]], n_dim: int) -> Tuple[int
             raise ValueError(f"For n_dim={n_dim}, size must be a list/tuple of length {n_dim}.")
         return tuple(int(s) for s in size)
 
+def _einsum_pattern(n_dim: int) -> str:
+    """Return einsum pattern to map (B, Cin, *S) x (Cin, Cout, *S) → (B, Cout, *S)."""
+    axes = "xyzuvw"
+    idx = axes[:n_dim]
+    return f"bi{idx},io{idx}->bo{idx}"
+
 
 class SpectralConvWavelet(nn.Module):
     """Implements Unified Wavelet-based Spectral Convolution for n_dim ∈ {1,2,3}.

--- a/neuralop/layers/tests/test_spectral_convolution_wavelet.py
+++ b/neuralop/layers/tests/test_spectral_convolution_wavelet.py
@@ -1,0 +1,78 @@
+import pytest
+import torch
+from ..spectral_convolution_wavelet import SpectralConvWavelet 
+
+
+# ----------------------- helpers -----------------------
+
+def _size_for_dim(n_dim: int):
+    if n_dim == 1:
+        return 32
+    if n_dim == 2:
+        return (32, 32)
+    if n_dim == 3:
+        return (32, 32, 32)
+    raise ValueError
+
+# ----------------------- tests -----------------------
+
+@pytest.mark.parametrize("n_dim", [1, 2, 3])
+def test_waveconvnd_forward_and_shapes(n_dim, in_channels=4, out_channels=4, level=2):
+    """Smoke test: forward pass completes and output shape matches input shape.
+
+    Mirrors the reference style: multiple dims & channel counts, minimal assertions.
+    """
+    size = _size_for_dim(n_dim)
+    # Modes: use 'symmetric' for 1/2D, 'periodic' for 3D (ptwt expects 'periodic')
+    mode = "periodic" if n_dim == 3 else "symmetric"
+
+    layer = SpectralConvWavelet(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        level=level,
+        size=size,
+        n_dim=n_dim,
+        wavelet="db4",
+        mode=mode,
+    )
+
+    x_shape = (2, in_channels) + (size if isinstance(size, tuple) else (size,))
+    x = torch.randn(*x_shape)
+
+    y = layer(x)
+
+    assert y.shape[0] == x.shape[0]
+    assert y.shape[1] == out_channels
+    assert list(y.shape[2:]) == list(x.shape[2:])
+
+
+@pytest.mark.parametrize("n_dim", [1, 2, 3])
+def test_waveconvnd_zero_weights_outputs_zero(n_dim, level=1):
+    """If all weights are zero, output should be (near) zero after IDWT/waverec.
+    Useful for catching broadcasting/misalignment errors in coefficient mixing.
+    """
+    
+    size = _size_for_dim(n_dim)
+    mode = "periodic" if n_dim == 3 else "symmetric"
+
+    layer = SpectralConvWavelet(
+        in_channels=3,
+        out_channels=3,
+        level=level,
+        size=size,
+        n_dim=n_dim,
+        wavelet="db6",
+        mode=mode,
+    )
+
+    # Zero all learned weights
+    for name, p in layer.named_parameters():
+        if name.startswith("weights"):
+            with torch.no_grad():
+                p.zero_()
+
+    x_shape = (2, 3) + (size if isinstance(size, tuple) else (size,))
+    x = torch.randn(*x_shape)
+
+    y = layer(x)
+    assert torch.allclose(y, torch.zeros_like(y), atol=1e-6, rtol=0)


### PR DESCRIPTION
# Wavelet Neural Operator (WNO) 

| Resource | Link |
|----------|------|
| Paper | <https://arxiv.org/pdf/2205.02191> |
| Original implementation | <https://github.com/TapasTripura/WNO> |

Spectral convolution class and its helper functions for operator learning in wavelet space. Main added class is "SpectralConvWavelet" in "neuralop/layers/spectral_convolution_laplace.py",  which handles 1-3 dimensions in an abstract way. 

The code mostly follows the paper code, just reformed in an abstract way to handle all 3 dimensions in a single class, via helper functions for building einsums sentences, some other common features through different paper classes. 
A set of test cases is included in this PR under neuralop/layers/tests/test_spectral_convolution_laplace.py to test the basic features of the forward method of the spectral convolution. 

@dhpitt , please provide initial comments to help refine possible missed features or suggest any other improvements. The class is performing similarly to the paper code and results. I will post the full report after getting all of your comments on the initial PR.