### PR TITLE
Clarifying central differences code

### DIFF
--- a/neuralop/losses/finite_diff.py
+++ b/neuralop/losses/finite_diff.py
@@ -3,12 +3,21 @@ import torch
 finite_diff.py implements utilities for computing derivatives via finite-difference method
 """
 
-#Set fix{x,y,z}_bnd if function is non-periodic in {x,y,z} direction
 #x: (*, s)
 #y: (*, s)
 def central_diff_1d(x, h, fix_x_bnd=False):
     """central_diff_1d computes the first spatial derivative
     of x using central finite-difference 
+
+    This function computes df/dx using the central difference formula:
+    df/dx \approx (f(x+h) - f(x-h)) / (2h)
+    
+    For periodic domains (fix_x_bnd=False), the function uses torch.roll to handle
+    boundary wrapping, treating the domain as periodic.
+    
+    For non-periodic domains (fix_x_bnd=True), the function uses forward differences
+    at the left boundary and backward differences at the right boundary to avoid
+    accessing points outside the domain.
 
     Parameters
     ----------
@@ -18,19 +27,30 @@ def central_diff_1d(x, h, fix_x_bnd=False):
     h : float
         discretization size of input x
     fix_x_bnd : bool, optional
-        whether to average boundary and second-outermost 
-        derivative values, by default False
+        whether to use non-periodic boundary conditions:
+        - False: periodic domain (default)
+        - True: non-periodic domain with forward/backward differences at boundaries
+        by default False
 
     Returns
     -------
-    dx
+    dx : torch.Tensor
         output tensor of df(x)/dx at each point
     """
-    dx = (torch.roll(x, -1, dims=-1) - torch.roll(x, 1, dims=-1))/(2.0*h)
-
     if fix_x_bnd:
-        dx[...,0] = (x[...,1] - x[...,0])/h
-        dx[...,-1] = (x[...,-1] - x[...,-2])/h
+        # Non-periodic case: handle boundaries separately
+        dx = torch.zeros_like(x)
+        
+        # Interior points: central difference
+        dx[..., 1:-1] = (x[..., 2:] - x[..., :-2]) / (2.0 * h)
+        
+        # Boundary points: forward and backward differences
+        dx[..., 0] = (x[..., 1] - x[..., 0]) / h
+        dx[..., -1] = (x[..., -1] - x[..., -2]) / h
+        
+    else:
+        # Periodic case: use torch.roll for boundary wrapping
+        dx = (torch.roll(x, -1, dims=-1) - torch.roll(x, 1, dims=-1)) / (2.0 * h)
     
     return dx
 
@@ -41,6 +61,17 @@ def central_diff_2d(x, h, fix_x_bnd=False, fix_y_bnd=False):
     df(x,y)/dx and df(x,y)/dy for f(x,y) defined 
     on a regular 2d grid using finite-difference
 
+    This function computes partial derivatives using the central difference formula:
+    df/dx \approx (f(x+h,y) - f(x-h,y)) / (2h_x)
+    df/dy \approx (f(x,y+h) - f(x,y-h)) / (2h_y)
+    
+    For periodic dimensions (fix_*_bnd=False), the function uses torch.roll to handle
+    boundary wrapping, treating those dimensions as periodic.
+    
+    For non-periodic dimensions (fix_*_bnd=True), the function uses forward differences
+    at the left boundary and backward differences at the right boundary to avoid
+    accessing points outside the domain.
+
     Parameters
     ----------
     x : torch.Tensor
@@ -48,29 +79,54 @@ def central_diff_2d(x, h, fix_x_bnd=False, fix_y_bnd=False):
     h : float or list
         discretization size of grid for each dimension
     fix_x_bnd : bool, optional
-        whether to fix dx on the x boundaries, by default False
+        whether to use non-periodic boundary conditions in x-direction:
+        - False: periodic in x (default)
+        - True: non-periodic in x with forward/backward differences at boundaries
+        by default False
     fix_y_bnd : bool, optional
-        whether to fix dy on the y boundaries, by default False
+        whether to use non-periodic boundary conditions in y-direction:
+        - False: periodic in y (default)
+        - True: non-periodic in y with forward/backward differences at boundaries
+        by default False
 
     Returns
     -------
-    dx, dy
+    dx, dy : tuple of torch.Tensor
         tuple such that dx[:, i,j]= df(x_i,y_j)/dx
         and dy[:, i,j]= df(x_i,y_j)/dy
     """
     if isinstance(h, float):
         h = [h, h]
 
-    dx = (torch.roll(x, -1, dims=-2) - torch.roll(x, 1, dims=-2))/(2.0*h[0])
-    dy = (torch.roll(x, -1, dims=-1) - torch.roll(x, 1, dims=-1))/(2.0*h[1])
-
     if fix_x_bnd:
-        dx[...,0,:] = (x[...,1,:] - x[...,0,:])/h[0]
-        dx[...,-1,:] = (x[...,-1,:] - x[...,-2,:])/h[0]
-    
+        # Non-periodic case in x-direction: handle boundaries separately
+        dx = torch.zeros_like(x)
+        
+        # Interior points: central difference
+        dx[..., 1:-1, :] = (x[..., 2:, :] - x[..., :-2, :]) / (2.0 * h[0])
+        
+        # Boundary points: forward and backward differences
+        dx[..., 0, :] = (x[..., 1, :] - x[..., 0, :]) / h[0]
+        dx[..., -1, :] = (x[..., -1, :] - x[..., -2, :]) / h[0]
+        
+    else:
+        # Periodic case in x-direction: use torch.roll for boundary wrapping
+        dx = (torch.roll(x, -1, dims=-2) - torch.roll(x, 1, dims=-2)) / (2.0 * h[0])
+
     if fix_y_bnd:
-        dy[...,:,0] = (x[...,:,1] - x[...,:,0])/h[1]
-        dy[...,:,-1] = (x[...,:,-1] - x[...,:,-2])/h[1]
+        # Non-periodic case in y-direction: handle boundaries separately
+        dy = torch.zeros_like(x)
+        
+        # Interior points: central difference
+        dy[..., :, 1:-1] = (x[..., :, 2:] - x[..., :, :-2]) / (2.0 * h[1])
+        
+        # Boundary points: forward and backward differences
+        dy[..., :, 0] = (x[..., :, 1] - x[..., :, 0]) / h[1]
+        dy[..., :, -1] = (x[..., :, -1] - x[..., :, -2]) / h[1]
+        
+    else:
+        # Periodic case in y-direction: use torch.roll for boundary wrapping
+        dy = (torch.roll(x, -1, dims=-1) - torch.roll(x, 1, dims=-1)) / (2.0 * h[1])
         
     return dx, dy
 
@@ -78,25 +134,46 @@ def central_diff_2d(x, h, fix_x_bnd=False, fix_y_bnd=False):
 #y: (*, s1, s2, s3)
 def central_diff_3d(x, h, fix_x_bnd=False, fix_y_bnd=False, fix_z_bnd=False):
     """central_diff_3d computes derivatives 
-    df(x,y,z)/dx and df(x,y,z)/dy for f(x,y,z) defined 
-    on a regular 2d grid using finite-difference
+    df(x,y,z)/dx, df(x,y,z)/dy, and df(x,y,z)/dz for f(x,y,z) defined 
+    on a regular 3d grid using finite-difference
+
+    This function computes partial derivatives using the central difference formula:
+    df/dx \approx (f(x+h,y,z) - f(x-h,y,z)) / (2h_x)
+    df/dy \approx (f(x,y+h,z) - f(x,y-h,z)) / (2h_y)
+    df/dz \approx (f(x,y,z+h) - f(x,y,z-h)) / (2h_z)
+    
+    For periodic dimensions (fix_*_bnd=False), the function uses torch.roll to handle
+    boundary wrapping, treating those dimensions as periodic.
+    
+    For non-periodic dimensions (fix_*_bnd=True), the function uses forward differences
+    at the left boundary and backward differences at the right boundary to avoid
+    accessing points outside the domain.
 
     Parameters
     ----------
     x : torch.Tensor
-        input function defined x[:,i,j,k] = f(x_i, y_j,z_k)
+        input function defined x[:,i,j,k] = f(x_i, y_j, z_k)
     h : float or list
         discretization size of grid for each dimension
     fix_x_bnd : bool, optional
-        whether to fix dx on the x boundaries, by default False
+        whether to use non-periodic boundary conditions in x-direction:
+        - False: periodic in x (default)
+        - True: non-periodic in x with forward/backward differences at boundaries
+        by default False
     fix_y_bnd : bool, optional
-        whether to fix dy on the y boundaries, by default False
+        whether to use non-periodic boundary conditions in y-direction:
+        - False: periodic in y (default)
+        - True: non-periodic in y with forward/backward differences at boundaries
+        by default False
     fix_z_bnd : bool, optional
-        whether to fix dz on the z boundaries, by default False
+        whether to use non-periodic boundary conditions in z-direction:
+        - False: periodic in z (default)
+        - True: non-periodic in z with forward/backward differences at boundaries
+        by default False
 
     Returns
     -------
-    dx, dy, dz
+    dx, dy, dz : tuple of torch.Tensor
         tuple such that dx[:, i,j,k]= df(x_i,y_j,z_k)/dx
         and dy[:, i,j,k]= df(x_i,y_j,z_k)/dy
         and dz[:, i,j,k]= df(x_i,y_j,z_k)/dz
@@ -104,21 +181,50 @@ def central_diff_3d(x, h, fix_x_bnd=False, fix_y_bnd=False, fix_z_bnd=False):
     if isinstance(h, float):
         h = [h, h, h]
 
-    dx = (torch.roll(x, -1, dims=-3) - torch.roll(x, 1, dims=-3))/(2.0*h[0])
-    dy = (torch.roll(x, -1, dims=-2) - torch.roll(x, 1, dims=-2))/(2.0*h[1])
-    dz = (torch.roll(x, -1, dims=-1) - torch.roll(x, 1, dims=-1))/(2.0*h[2])
-
     if fix_x_bnd:
-        dx[...,0,:,:] = (x[...,1,:,:] - x[...,0,:,:])/h[0]
-        dx[...,-1,:,:] = (x[...,-1,:,:] - x[...,-2,:,:])/h[0]
-    
+        # Non-periodic case in x-direction: handle boundaries separately
+        dx = torch.zeros_like(x)
+        
+        # Interior points: central difference
+        dx[..., 1:-1, :, :] = (x[..., 2:, :, :] - x[..., :-2, :, :]) / (2.0 * h[0])
+        
+        # Boundary points: forward and backward differences
+        dx[..., 0, :, :] = (x[..., 1, :, :] - x[..., 0, :, :]) / h[0]
+        dx[..., -1, :, :] = (x[..., -1, :, :] - x[..., -2, :, :]) / h[0]
+        
+    else:
+        # Periodic case in x-direction: use torch.roll for boundary wrapping
+        dx = (torch.roll(x, -1, dims=-3) - torch.roll(x, 1, dims=-3)) / (2.0 * h[0])
+
     if fix_y_bnd:
-        dy[...,:,0,:] = (x[...,:,1,:] - x[...,:,0,:])/h[1]
-        dy[...,:,-1,:] = (x[...,:,-1,:] - x[...,:,-2,:])/h[1]
-    
+        # Non-periodic case in y-direction: handle boundaries separately
+        dy = torch.zeros_like(x)
+        
+        # Interior points: central difference
+        dy[..., :, 1:-1, :] = (x[..., :, 2:, :] - x[..., :, :-2, :]) / (2.0 * h[1])
+        
+        # Boundary points: forward and backward differences
+        dy[..., :, 0, :] = (x[..., :, 1, :] - x[..., :, 0, :]) / h[1]
+        dy[..., :, -1, :] = (x[..., :, -1, :] - x[..., :, -2, :]) / h[1]
+        
+    else:
+        # Periodic case in y-direction: use torch.roll for boundary wrapping
+        dy = (torch.roll(x, -1, dims=-2) - torch.roll(x, 1, dims=-2)) / (2.0 * h[1])
+
     if fix_z_bnd:
-        dz[...,:,:,0] = (x[...,:,:,1] - x[...,:,:,0])/h[2]
-        dz[...,:,:,-1] = (x[...,:,:,-1] - x[...,:,:,-2])/h[2]
+        # Non-periodic case in z-direction: handle boundaries separately
+        dz = torch.zeros_like(x)
+        
+        # Interior points: central difference
+        dz[..., :, :, 1:-1] = (x[..., :, :, 2:] - x[..., :, :, :-2]) / (2.0 * h[2])
+        
+        # Boundary points: forward and backward differences
+        dz[..., :, :, 0] = (x[..., :, :, 1] - x[..., :, :, 0]) / h[2]
+        dz[..., :, :, -1] = (x[..., :, :, -1] - x[..., :, :, -2]) / h[2]
+        
+    else:
+        # Periodic case in z-direction: use torch.roll for boundary wrapping
+        dz = (torch.roll(x, -1, dims=-1) - torch.roll(x, 1, dims=-1)) / (2.0 * h[2])
         
     return dx, dy, dz
 


### PR DESCRIPTION
Just clarifying that central differences by default assume periodic BCs

Also making the periodic and non-periodic cases more distinct, instead of doing the periodic BCs, and then overwriting for the non-periodic case