### PR TITLE
BUG: Using a non-tuple sequence for multi-dim indexing is deprecated

### DIFF
--- a/neuralop/data/datasets/pt_dataset.py
+++ b/neuralop/data/datasets/pt_dataset.py
@@ -122,6 +122,7 @@ class PTDataset:
         train_input_indices = [slice(0, n_train, None)] + [slice(None, None, rate)\
                                                            for rate in input_subsampling_rate]
         train_input_indices.insert(channel_dim, slice(None))
+        train_input_indices = tuple(train_input_indices)
         x_train = x_train[train_input_indices]
         
         y_train = data["y"].clone()
@@ -145,6 +146,7 @@ class PTDataset:
         # Construct full indices along which to grab Y
         train_output_indices = [slice(0, n_train, None)] + [slice(None, None, rate) for rate in output_subsampling_rate]
         train_output_indices.insert(channel_dim, slice(None))
+        train_output_indices = tuple(train_output_indices)
         y_train = y_train[train_output_indices]
         
         del data
@@ -199,8 +201,9 @@ class PTDataset:
             if channels_squeezed:
                 x_test = x_test.unsqueeze(channel_dim)
             # optionally subsample along data indices
-            test_input_indices = [slice(0, n_test, None)] + [slice(None, None, rate) for rate in input_subsampling_rate] 
+            test_input_indices = [slice(0, n_test, None)] + [slice(None, None, rate) for rate in input_subsampling_rate]
             test_input_indices.insert(channel_dim, slice(None))
+            test_input_indices = tuple(test_input_indices)
             x_test = x_test[test_input_indices]
             
             y_test = data["y"].clone()
@@ -208,6 +211,7 @@ class PTDataset:
                 y_test = y_test.unsqueeze(channel_dim)
             test_output_indices = [slice(0, n_test, None)] + [slice(None, None, rate) for rate in output_subsampling_rate] 
             test_output_indices.insert(channel_dim, slice(None))
+            test_output_indices = tuple(test_output_indices)
             y_test = y_test[test_output_indices]
 
             del data

--- a/neuralop/layers/resample.py
+++ b/neuralop/layers/resample.py
@@ -54,6 +54,7 @@ def resample(x, res_scale, axis, output_shape=None):
 
         idx_tuple = [slice(None), slice(None)] + [slice(*b) for b in boundaries]
 
+        idx_tuple = tuple(idx_tuple)
         out_fft[idx_tuple] = X[idx_tuple]
     y = torch.fft.irfftn(out_fft, s= new_size ,norm='forward', dim=axis)
 

--- a/neuralop/layers/spectral_convolution.py
+++ b/neuralop/layers/spectral_convolution.py
@@ -452,7 +452,8 @@ class SpectralConv(BaseSpectralConv):
             # The last mode already has redundant half removed in real FFT
             slices_w += [slice(start//2, -start//2) if start else slice(start, None) for start in starts[:-1]]
             slices_w += [slice(None, -starts[-1]) if starts[-1] else slice(None)]
-        
+
+        slices_w = tuple(slices_w)
         weight = self.weight[slices_w]
 
         ### Pick the first n_modes modes of FFT signal along each dim
@@ -482,7 +483,8 @@ class SpectralConv(BaseSpectralConv):
             slices_x[-1] = slice(None, weight.shape[-1])
         else:
             slices_x[-1] = slice(None)
-        
+
+        slices_x = tuple(slices_x)
         out_fft[slices_x] = self._contract(x[slices_x], weight, separable=self.separable)
 
         if self.resolution_scaling_factor is not None and output_shape is None:

--- a/neuralop/layers/tests/test_grid_embeddings.py
+++ b/neuralop/layers/tests/test_grid_embeddings.py
@@ -37,7 +37,7 @@ def test_GridEmbeddingND(dim):
     index = [random.randint(0, res-1) for res in input_res]
     # grab pos encoding channels at coord index
     pos_channels = x[0,1:,...]
-    indices = [slice(None), *index]
+    indices = (slice(None), *index)
     true_coords = pos_channels[indices]
     expected_coords = torch.tensor([i/j for i,j in zip(index,input_res)])
     assert_close(true_coords, expected_coords)


### PR DESCRIPTION
Indexing tensors with a list is deprecated and will result in errors starting with PyTorch 2.9. 

Currently, this yields a warning for a minimal example like 
```
from neuralop.models import FNO
import torch

operator = FNO(n_modes=(16, 16), hidden_channels=64,
                in_channels=3, out_channels=1)

data = torch.randn(2, 3, 64, 64)

output = operator(data)
```

```
UserWarning: Using a non-tuple sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x[tuple(seq)] instead of x[seq]. In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will result either in an error or a different result (Triggered internally at [...]/torch/csrc/autograd/python_variable_indexing.cpp:312.)
  out_fft[slices_x] = self._contract(x[slices_x], weight, separable=self.separable)
```
due to indexing the weight tensor in FNO with a list of slices, depending on the input data. 

Replaced indexing lists with tuples. Kept lists only where mutability was required and converted them to tuples at indexing time.