### PR TITLE
Divergence-free Spectral Projection

### DIFF
--- a/examples/layers/plot_spectral_projection.py
+++ b/examples/layers/plot_spectral_projection.py
@@ -1,0 +1,199 @@
+"""
+.. _spectral_projection :
+
+Divergence-Free Spectral Projection
+========================================================
+An example demonstrating spectral projection to enforce divergence-free constraints
+in 2D velocity fields
+"""
+
+
+# %%
+# Import the library
+# ------------------
+# We first import our `neuralop` library and required dependencies.
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+from neuralop.layers.spectral_projection import spectral_projection_divergence_free
+from neuralop.losses.fourier_diff import FourierDiff2D
+from neuralop.losses.finite_diff import FiniteDiff2D
+    
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+print(f"Using device: {device}")
+
+
+# %%
+# Divergence error computation functions
+# -------------------------------------
+# We define two functions to compute the divergence error 
+# using spectral differentiation and finite differences.
+
+
+def div_error_fourier(u, L):
+    """Compute divergence error using spectral differentiation."""
+    fourier_diff_2d = FourierDiff2D(L=(L, L), use_FC=False)
+    div = fourier_diff_2d.divergence(u)
+    error_val = torch.linalg.norm(div, dim=(1, 2)) * (L**2 / (div.shape[-1] * div.shape[-2]))**(0.5)
+    return error_val.mean().item()
+
+
+def div_error_finite_diff(u, L):
+    """Compute divergence error using FiniteDiff2D."""
+    dx = L / u.shape[-1]
+    dy = L / u.shape[-2]
+    finite_diff_2d = FiniteDiff2D(h=(dx, dy), periodic_in_x=True, periodic_in_y=True)
+    div = finite_diff_2d.divergence(u)
+    error_val = torch.linalg.norm(div, dim=(1, 2)) * (L**2 / (div.shape[-1] * div.shape[-2]))**(0.5)
+    return error_val.mean().item()
+
+
+# %%
+# Setting considered
+# ------------------
+# We start from a divergence-free velocity field on [0, 2*pi] x [0, 2*pi]  
+# constructed from the stream function ψ(x,y) = sin(x) * cos(6*y)  
+# 
+# Velocity components:  
+#   u_x  =  ∂ψ/∂y  =  -6 * sin(x) * sin(6*y)  
+#
+#   u_y =  -∂ψ/∂x  = - cos(x) * cos(6*y)  
+# 
+# -------------------------------------------------------
+#
+# Mathematical verification of divergence-free property:  
+#
+#   ∇·u = ∂u_x/∂x + ∂u_y/∂y  
+#
+#   = ∂/∂x[-6*sin(x) * sin(6*y)] + ∂/∂y[-cos(x) * cos(6*y)] 
+#
+#   = -6*cos(x) * sin(6*y) + 6*cos(x) * sin(6*y)  
+#
+#   = 0  ✓  
+#
+# -------------------------------------------------------
+#
+#
+# We then add 10% noise to break the divergence-free property.  
+#
+# We then apply the spectral projection to restore the divergence-free property.  
+#
+# We then compute the divergence error for the original, noisy, and projected fields. 
+# 
+# We repeat this at various resolutions, [256, 512, 1024, 2048, 4096, 8192].
+
+L = 2 * np.pi
+noise_level = 0.1
+resolutions = [256, 512, 1024, 2048, 4096, 8192]
+
+
+errors_original_spectral = []
+errors_original_finite = []
+errors_noisy_spectral = []
+errors_noisy_finite = []
+errors_prog_spectral = []
+errors_prog_finite = []
+
+for target_resolution in resolutions:
+    
+    # Create coordinate grids for this resolution
+    xs = torch.arange(target_resolution, device=device, dtype=torch.float64) * (L / target_resolution)
+    ys = torch.arange(target_resolution, device=device, dtype=torch.float64) * (L / target_resolution)
+    X, Y = torch.meshgrid(xs, ys, indexing='ij')
+    
+    # Create divergence-free field using the stream function defined earlier
+    u_x = -6.0 * torch.sin(X) * torch.sin(6.0 * Y)
+    u_y = -torch.cos(X) * torch.cos(6.0 * Y)
+    u = torch.stack([u_x, u_y], dim=0).unsqueeze(0).to(device=device, dtype=torch.float64)
+    
+    # Add noise to break divergence-free property
+    mean_magnitude = torch.mean(torch.sqrt(u[:, 0]**2 + u[:, 1]**2))
+    noise = torch.randn_like(u, dtype=torch.float64) * noise_level * mean_magnitude
+    u_noisy = u + noise
+    
+    # Apply spectral projection to restore divergence-free property
+    u_proj = spectral_projection_divergence_free(u_noisy, L, constraint_modes=(64, 64))
+    
+    # Compute divergence errors for all three fields
+    errors_original_spectral.append(div_error_fourier(u, L))
+    errors_original_finite.append(div_error_finite_diff(u, L))
+    errors_noisy_spectral.append(div_error_fourier(u_noisy, L))
+    errors_noisy_finite.append(div_error_finite_diff(u_noisy, L))
+    errors_prog_spectral.append(div_error_fourier(u_proj, L))
+    errors_prog_finite.append(div_error_finite_diff(u_proj, L))
+
+
+
+# %%
+# Divergence Errors using Spectral Differentiation 
+# ------------------------------------------------
+# The Fourier differentiation method computes derivatives in the spectral domain  
+# by transforming the field to Fourier space, applying the appropriate wavenumber  
+# operators, and transforming back.  
+# 
+# We display the divergence error for the original, noisy, and projected fields  
+# at the different resolutions. 
+# 
+# Note that at lower resolutions, finite differences are not accurate enough 
+# to properly compute the divergence error, which is why the errors appear higher 
+# initially but improve at higher resolutions. This is a limitation of 
+# finite differences for computing derivatives, not an issue with the 
+# spectral projection itself. Spectral differentiation provides more accurate 
+# derivative calculations at lower resolutions.
+
+
+# Spectral Differentiation table
+print("-" * 55)
+print(f"{'Resolution':<12} {'Original':<15} {'Noisy':<15} {'Projected':<15}")
+print("-" * 55)
+
+for i, res in enumerate(resolutions):
+    print(f"{res:<12} {errors_original_spectral[i]:<15.2e} {errors_noisy_spectral[i]:<15.2e} {errors_prog_spectral[i]:<15.2e}")
+
+
+# Spectral Differentiation plot
+plt.figure(figsize=(10, 6))
+plt.semilogy(resolutions, errors_original_spectral, 'o-', label='Original', color='black', linewidth=2.5, markersize=6)
+plt.semilogy(resolutions, errors_noisy_spectral, 'o-', label='Noisy', color='green', linewidth=2.5, markersize=6)
+plt.semilogy(resolutions, errors_prog_spectral, 'o-', label='Projected', color='blue', linewidth=2.5, markersize=6)
+plt.xlabel('Resolution', fontsize=16)
+plt.ylabel('Divergence Error (L2 norm)', fontsize=16)
+plt.title('Spectral Divergence Errors', fontsize=18)
+plt.legend(fontsize=14)
+plt.grid(True, alpha=0.3)
+plt.xticks(fontsize=14)
+plt.yticks(fontsize=14)
+plt.tight_layout()
+plt.show()
+
+# %%
+# Divergence Errors using Finite Differences
+# --------------------------
+# The finite difference method approximates derivatives using central differences.  
+# 
+# We display the divergence error for the original, noisy, and projected fields  
+# at the different resolutions.
+
+# Finite differences table
+print("-" * 55)
+print(f"{'Resolution':<12} {'Original':<15} {'Noisy':<15} {'Projected':<15}")
+print("-" * 55)
+
+for i, res in enumerate(resolutions):
+    print(f"{res:<12} {errors_original_finite[i]:<15.2e} {errors_noisy_finite[i]:<15.2e} {errors_prog_finite[i]:<15.2e}")
+
+
+# Finite differences plot
+plt.figure(figsize=(10, 6))
+plt.semilogy(resolutions, errors_original_finite, 'o-', label='Original', color='black', linewidth=2.5, markersize=6)
+plt.semilogy(resolutions, errors_noisy_finite, 'o-', label='Noisy', color='green', linewidth=2.5, markersize=6)
+plt.semilogy(resolutions, errors_prog_finite, 'o-', label='Projected', color='blue', linewidth=2.5, markersize=6)
+plt.xlabel('Resolution', fontsize=16)
+plt.ylabel('Divergence Error (L2 norm)', fontsize=16)
+plt.title('Finite Difference Divergence Errors', fontsize=18)
+plt.legend(fontsize=14)
+plt.grid(True, alpha=0.3)
+plt.xticks(fontsize=14)
+plt.yticks(fontsize=14)
+plt.tight_layout()
+plt.show()

--- a/neuralop/layers/spectral_projection.py
+++ b/neuralop/layers/spectral_projection.py
@@ -1,0 +1,151 @@
+import torch
+import numpy as np
+import torch.nn.functional as F
+
+
+def spectral_projection_divergence_free(u, domain_size, constraint_modes):
+    """
+    Apply spectral projection to make velocity field divergence-free.
+    
+    This method implements a Helmholtz-Hodge projection in the spectral domain
+    to project velocity fields onto the divergence-free subspace.
+    
+    
+    References:
+    -----------
+    The method is based on the spectral projection approach described in:
+    
+        [1] Towards Enforcing Hard Physics Constraints in Operator Learning Frameworks
+        V. Duruisseaux, M. Liu-Schiaffini, J. Berner, and A. Anandkumar
+        ICML 2024 AI for Science Workshop
+        https://openreview.net/pdf?id=Zvxm14Rd1F
+        
+        [2] Enforcing physical constraints in CNNs through differentiable PDE layer. 
+        C. M. Jiang, K. Kashinath, P. Prabhat, and P. Marcus
+        ICLR 2020 Workshop on Integration of Deep Neural Models and Differential Equations, 2020.
+        https://openreview.net/pdf?id=q2noHUqMkK
+    
+        [1] Towards Enforcing Hard Physics Constraints in Operator Learning Frameworks
+        V. Duruisseaux, M. Liu-Schiaffini, J. Berner, and A. Anandkumar
+        ICML 2024 AI for Science Workshop
+        https://openreview.net/pdf?id=Zvxm14Rd1F
+        
+        [2] Enforcing physical constraints in CNNs through differentiable PDE layer. 
+        C. M. Jiang, K. Kashinath, P. Prabhat, and P. Marcus
+        ICLR 2020 Workshop on Integration of Deep Neural Models and Differential Equations, 2020.
+        https://openreview.net/pdf?id=q2noHUqMkK
+
+
+
+    Mathematical formulation:
+    -------------------------
+    The Helmholtz-Hodge projection is given by:
+        û_proj = û - (k·û)/|k|² * k
+    where û is the Fourier transform of the velocity field, k is the wavenumber vector, 
+    and û_proj is the projected divergence-free field.
+    
+    The projection enforces ∇·u = 0 in the spectral domain by removing the
+    irrotational component of the velocity field.
+    
+        
+    Periodicity Assumption:
+    -----------------------
+    Just like most spectral methods, this spectral projection assumes the given and 
+    desired velocity fields are periodic. 
+    
+    If the velocity fields are not periodic, 
+    one way to apply this spectral projection is to proceed as follows:
+      1) extend the velocity fields to periodic velocity fields on a larger domain, using 
+          Fourier continuation for instance (see neuralop.layers.fourier_continuation) 
+      2) apply the spectral projection to the periodic fields on the extended domain.
+      3) truncate the result back to the original domain.
+      
+    This is similar to how Fourier/spectral differentiation can still be performed 
+    on non-periodic fields (see neuralop.losses.fourier_diff for implementation details).
+    
+
+    
+    Parameters
+    ----------
+    u : torch.Tensor
+        Input velocity field [batch, 2, height, width] where the last two
+        dimensions represent the 2D velocity components (u_x, u_y)
+    domain_size : float or tuple of float
+        Physical domain size. If float, assumes square domain with same size for height and width.
+        If tuple, should be (height_size, width_size) for non-square domains.
+    constraint_modes : tuple
+        Number of modes to use for constraint resolution (height_modes, width_modes).
+        If larger than input dimensions, they are truncated to the input dimensions.
+    
+    Returns
+    -------
+    torch.Tensor
+        Divergence-free projected velocity field in [batch, 2, height, width] format.
+        The output maintains the same shape as the input while satisfying ∇·u = 0.
+    
+    """
+    
+    device = u.device
+    dtype = u.dtype
+    batch_size, channels, height, width = u.shape
+    
+    # Get domain size
+    if isinstance(domain_size, (int, float)):
+        # Square domain: use same size for both dimensions
+        domain_height = domain_width = float(domain_size)
+    elif isinstance(domain_size, (tuple, list)) and len(domain_size) == 2:
+        # Non-square domain: separate sizes for height and width
+        domain_height, domain_width = float(domain_size[0]), float(domain_size[1])
+    
+    # Ensure constraint modes do not exceed input dimensions
+    constraint_modes = (min(constraint_modes[0], height), min(constraint_modes[1], width))
+    
+    # 2D FFT over height and width
+    u_ft = torch.fft.fftn(u, dim=(2, 3))  
+    
+    # Extract lower height modes where the constraint is applied
+    if height != constraint_modes[0]:
+        pos_idx_h = torch.arange(0, constraint_modes[0]//2, 1)
+        neg_idx_h = torch.arange(height - constraint_modes[0]//2, height, 1)
+        idx_h = torch.cat((pos_idx_h, neg_idx_h)).to(device)
+        u_ft = torch.index_select(u_ft, 2, idx_h)
+    
+    # Extract lower width modes where the constraint is applied
+    if width != constraint_modes[1]:
+        pos_idx_w = torch.arange(0, constraint_modes[1]//2, 1)
+        neg_idx_w = torch.arange(width - constraint_modes[1]//2, width, 1)
+        idx_w = torch.cat((pos_idx_w, neg_idx_w)).to(device)
+        u_ft = torch.index_select(u_ft, 3, idx_w)
+    
+    # Set up wavenumber grids for spectral operations
+    ky = 2*np.pi * torch.fft.fftfreq(constraint_modes[0], d=domain_height/constraint_modes[0]).to(dtype).to(device)
+    kx = 2*np.pi * torch.fft.fftfreq(constraint_modes[1], d=domain_width/constraint_modes[1]).to(dtype).to(device)
+    KX, KY = torch.meshgrid(kx, ky, indexing='ij' if constraint_modes[0] == constraint_modes[1] else 'xy')
+    
+    
+    # Apply Helmholtz-Hodge projection: û_proj = û - (k·û)/|k|² * k
+    k_dot_u = KX * u_ft[:, 0, :, :] + KY * u_ft[:, 1, :, :]
+    k_squared = KX**2 + KY**2 + 1e-8    # Add small epsilon to avoid division by zero
+    
+    projected_u_ft = u_ft - (k_dot_u / k_squared).unsqueeze(1) * torch.stack([KX, KY], dim=0).unsqueeze(0)
+    
+    # Handle zero mode explicitly
+    projected_u_ft[:, :, 0, 0] = 0.0
+    
+    
+    # Pad zeros back to full resolution if needed
+    if height != constraint_modes[0] or width != constraint_modes[1]:
+        projected_u_ft = torch.fft.fftshift(projected_u_ft)
+        
+        # Calculate padding for width and height
+        left_pad_w = max(0, (width - constraint_modes[1]) // 2)
+        right_pad_w = max(0, width - left_pad_w - constraint_modes[1])
+        top_pad_h = max(0, (height - constraint_modes[0]) // 2)
+        bottom_pad_h = max(0, height - top_pad_h - constraint_modes[0])
+        
+        # Pad and shift back
+        projected_u_ft = F.pad(projected_u_ft, (left_pad_w, right_pad_w, top_pad_h, bottom_pad_h))
+        projected_u_ft = torch.fft.ifftshift(projected_u_ft)
+    
+    # Transform back to physical space
+    return torch.fft.ifftn(projected_u_ft, dim=(2, 3)).real

--- a/neuralop/layers/tests/test_spectral_projection.py
+++ b/neuralop/layers/tests/test_spectral_projection.py
@@ -1,0 +1,36 @@
+import torch
+import pytest
+import numpy as np
+from ..spectral_projection import spectral_projection_divergence_free
+
+@pytest.mark.parametrize("resolution", [(64, 64), (80, 60), (60, 80)])
+@pytest.mark.parametrize("constraint_modes", [(64, 64), (50, 64), (72, 60)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_spectral_projection(resolution, constraint_modes, dtype):
+    """Test spectral projection functionality with different resolutions, constraint modes and dtypes."""
+    
+    height, width = resolution
+    batch_size = 3
+    domain_size = 2 * np.pi
+    
+    # Create a simple velocity field with some divergence
+    x = torch.linspace(0, domain_size, width)
+    y = torch.linspace(0, domain_size, height)
+    X, Y = torch.meshgrid(x, y, indexing='ij')
+    
+    # Example u_x = sin(y), u_y = cos(x)
+    u_x = torch.sin(Y.T).unsqueeze(0).unsqueeze(0).expand(batch_size, 1, height, width)
+    u_y = torch.cos(X.T).unsqueeze(0).unsqueeze(0).expand(batch_size, 1, height, width)
+    u = torch.cat([u_x, u_y], dim=1).to(dtype)
+    
+    # Apply spectral projection
+    u_projected = spectral_projection_divergence_free(u, domain_size, constraint_modes)
+    
+    # Check output shape and properties
+    assert u_projected.shape == u.shape
+    assert u_projected.dtype == dtype
+    assert u_projected.device == u.device
+    
+    # Check no NaN or inf values
+    assert not torch.isnan(u_projected).any()
+    assert not torch.isinf(u_projected).any()

--- a/neuralop/losses/__init__.py
+++ b/neuralop/losses/__init__.py
@@ -1,4 +1,4 @@
 from .data_losses import LpLoss, H1Loss
 from .equation_losses import BurgersEqnLoss, ICLoss
 from .meta_losses import WeightedSumLoss, FieldwiseAggregatorLoss, Aggregator, Relobralo, SoftAdapt
-from .fourier_diff import fourier_derivative_1d
+from .fourier_diff import FourierDiff2D

--- a/neuralop/losses/finite_diff.py
+++ b/neuralop/losses/finite_diff.py
@@ -3,224 +3,719 @@ import torch
 finite_diff.py implements utilities for computing derivatives via finite-difference method
 """
 
-#x: (*, s)
-#y: (*, s)
+class FiniteDiff1D:
+    """
+    A comprehensive class for computing 1D finite differences with boundary handling.
+    
+    This class provides methods for computing derivatives of 1D fields using central finite differences.
+    """
+    
+    def __init__(self, h=1.0, periodic_in_x=True):
+        """
+        Parameters
+        ----------
+        h : float, optional
+            Grid spacing, by default 1.0
+        periodic_in_x : bool, optional
+            Whether to use periodic boundary conditions, by default True
+        """
+        self.h = h
+        self.periodic_in_x = periodic_in_x
+    
+    def dx(self, u, order=1):
+        """
+        Compute derivative with respect to x.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            Derivative with respect to x
+        """
+        if order == 1:
+            return self._dx_1st(u)
+        elif order == 2:
+            return self._dx_2nd(u)
+        else:
+            raise ValueError("Only 1st and 2nd order derivatives currently supported")
+    
+    def _dx_1st(self, u):
+        """First order derivative with respect to x."""
+        
+        if self.periodic_in_x:
+            # Periodic case: use torch.roll for boundary wrapping
+            # Central difference: (f_{i+1} - f_{i-1})/(2h)
+            dx = (torch.roll(u, -1, dims=-1) - torch.roll(u, 1, dims=-1)) / (2.0 * self.h)
+            
+        else:
+            # Non-periodic case: handle boundaries separately
+            dx = torch.zeros_like(u)
+            
+            # Interior points: Second-order central differences
+            # (f_{i+1} - f_{i-1})/(2h)
+            dx[..., 1:-1] = (u[..., 2:] - u[..., :-2]) / (2.0 * self.h)
+            
+            # Left boundary: 3rd-order forward differences (-11f_{0} + 18f_{1} - 9f_{2} + 2f_{3})/(6h)
+            dx[..., 0] = (-11*u[..., 0] + 18*u[..., 1] - 9*u[..., 2] + 2*u[..., 3]) / (6.0 * self.h)
+            
+            # Right boundary: 3rd-order backward differences (-2f_{n-4} + 9f_{n-3} - 18f_{n-2} + 11f_{n-1})/(6h)
+            dx[..., -1] = (-2*u[..., -4] + 9*u[..., -3] - 18*u[..., -2] + 11*u[..., -1]) / (6.0 * self.h)
+        
+        return dx
+    
+    def _dx_2nd(self, u):
+        """Second order derivative with respect to x."""
+        
+        if self.periodic_in_x:
+            # Periodic case: use torch.roll for boundary wrapping
+            # Central difference: (f_{i+1} - 2f_{i} + f_{i-1})/(h²)
+            dxx = (torch.roll(u, -1, dims=-1) - 2*u + torch.roll(u, 1, dims=-1)) / (self.h**2)
+        
+        else:
+            # Non-periodic case: handle boundaries separately
+            dxx = torch.zeros_like(u)
+            
+            # Interior points: Second-order central differences
+            # (f_{i+1} - 2f_{i} + f_{i-1})/(h²)
+            dxx[..., 1:-1] = (u[..., 2:] - 2*u[..., 1:-1] + u[..., :-2]) / (self.h**2)
+            
+            # Boundary points: 3rd-order one-sided differences
+            # Left boundary: 3rd-order forward differences (2f_{0} - 5f_{1} + 4f_{2} - f_{3})/h²
+            dxx[..., 0] = (2*u[..., 0] - 5*u[..., 1] + 4*u[..., 2] - u[..., 3]) / (self.h**2)
+            # Right boundary: 3rd-order backward differences (-f_{n-4} + 4f_{n-3} - 5f_{n-2} + 2f_{n-1})/h²
+            dxx[..., -1] = (-u[..., -4] + 4*u[..., -3] - 5*u[..., -2] + 2*u[..., -1]) / (self.h**2)
+        
+        return dxx
+
+
+class FiniteDiff2D:
+    """
+    A comprehensive class for computing 2D finite differences with boundary handling.
+    
+    This class provides methods for computing partial derivatives, gradients,
+    divergence, curl, and Laplacian of 2D fields using central finite differences.
+    """
+    
+    def __init__(self, h=(1.0, 1.0), periodic_in_x=True, periodic_in_y=True):
+        """
+        Parameters
+        ----------
+        h : tuple or float, optional
+            Grid spacing for (y, x) directions, by default (1.0, 1.0)
+        periodic_in_x : bool, optional
+            Whether to use periodic boundary conditions in x-direction, by default True
+        periodic_in_y : bool, optional
+            Whether to use periodic boundary conditions in y-direction, by default True
+        """
+        if isinstance(h, float):
+            self.h = (h, h)
+        else:
+            self.h = h
+        self.periodic_in_x = periodic_in_x
+        self.periodic_in_y = periodic_in_y
+        
+        # Validate parameters
+        if len(self.h) != 2:
+            raise ValueError("h must be a float or a tuple of length 2")
+
+
+    def dx(self, u, order=1):
+        """
+        Compute partial derivative with respect to x.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            Partial derivative with respect to x
+        """
+        if order == 1:
+            return self._dx_1st(u)
+        elif order == 2:
+            return self._dx_2nd(u)
+        else:
+            raise ValueError("Only 1st and 2nd order derivatives currently supported")
+    
+    def dy(self, u, order=1):
+        """
+        Compute partial derivative with respect to y.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            Partial derivative with respect to y
+        """
+        if order == 1:
+            return self._dy_1st(u)
+        elif order == 2:
+            return self._dy_2nd(u)
+        else:
+            raise ValueError("Only 1st and 2nd order derivatives currently supported")
+    
+    
+    def _dx_1st(self, u):
+        """First order derivative with respect to x."""
+        
+        if self.periodic_in_x:
+            # Periodic case: use torch.roll for boundary wrapping
+            # Central difference: (f_{i+1,j} - f_{i-1,j})/(2h_{x})
+            dx = (torch.roll(u, -1, dims=-2) - torch.roll(u, 1, dims=-2)) / (2.0 * self.h[0])
+            
+        else:
+            # Non-periodic case: handle boundaries separately
+            dx = torch.zeros_like(u)
+            
+            # Interior points: Second-order central differences
+            # (f_{i+1,j} - f_{i-1,j})/(2h_{x})
+            dx[..., 1:-1, :] = (u[..., 2:, :] - u[..., :-2, :]) / (2.0 * self.h[0])
+            
+            # Left boundary: 3rd-order forward differences (-11f_{0} + 18f_{1} - 9f_{2} + 2f_{3})/(6h_{x})
+            dx[..., 0, :] = (-11*u[..., 0, :] + 18*u[..., 1, :] - 9*u[..., 2, :] + 2*u[..., 3, :]) / (6.0 * self.h[0])
+            
+            # Right boundary: 3rd-order backward differences (-2f_{n-4} + 9f_{n-3} - 18f_{n-2} + 11f_{n-1})/(6h_{x})
+            dx[..., -1, :] = (-2*u[..., -4, :] + 9*u[..., -3, :] - 18*u[..., -2, :] + 11*u[..., -1, :]) / (6.0 * self.h[0])
+        
+        return dx
+    
+    
+    def _dy_1st(self, u):
+        """First order derivative with respect to y."""
+        
+        if self.periodic_in_y:
+            # Periodic case: use torch.roll for boundary wrapping
+            # Central difference: (f_{i,j+1} - f_{i,j-1})/(2h_{y})
+            dy = (torch.roll(u, -1, dims=-1) - torch.roll(u, 1, dims=-1)) / (2.0 * self.h[1])
+            
+        else:
+            # Non-periodic case: handle boundaries separately
+            dy = torch.zeros_like(u)
+            
+            # Interior points: Second-order central differences
+            # (f_{i,j+1} - f_{i,j-1})/(2h_{y})
+            dy[..., :, 1:-1] = (u[..., :, 2:] - u[..., :, :-2]) / (2.0 * self.h[1])
+            
+            # Bottom boundary: 3rd-order forward differences (-11f_{0} + 18f_{1} - 9f_{2} + 2f_{3})/(6h_{y})
+            dy[..., :, 0] = (-11*u[..., :, 0] + 18*u[..., :, 1] - 9*u[..., :, 2] + 2*u[..., :, 3]) / (6.0 * self.h[1])
+            
+            # Top boundary: 3rd-order backward differences (-2f_{n-4} + 9f_{n-3} - 18f_{n-2} + 11f_{n-1})/(6h_{y})
+            dy[..., :, -1] = (-2*u[..., :, -4] + 9*u[..., :, -3] - 18*u[..., :, -2] + 11*u[..., :, -1]) / (6.0 * self.h[1])
+        
+        return dy
+    
+    
+    def _dx_2nd(self, u):
+        """Second order derivative with respect to x."""
+        
+        if self.periodic_in_x:
+            # Periodic case: use torch.roll for boundary wrapping
+            # Central difference: (f_{i+1,j} - 2f_{i,j} + f_{i-1,j})/(h_{x}²)
+            dxx = (torch.roll(u, -1, dims=-2) - 2*u + torch.roll(u, 1, dims=-2)) / (self.h[0]**2)
+        
+        else:
+            # Non-periodic case: handle boundaries separately
+            dxx = torch.zeros_like(u)
+            
+            # Interior points: Second-order central differences
+            # (f_{i+1,j} - 2f_{i,j} + f_{i-1,j})/(h_{x}²)
+            dxx[..., 1:-1, :] = (u[..., 2:, :] - 2*u[..., 1:-1, :] + u[..., :-2, :]) / (self.h[0]**2)
+            
+            # Boundary points: 3rd-order one-sided differences
+            # Left boundary: 3rd-order forward differences (2f_{0} - 5f_{1} + 4f_{2} - f_{3})/h_{x}²
+            dxx[..., 0, :] = (2*u[..., 0, :] - 5*u[..., 1, :] + 4*u[..., 2, :] - u[..., 3, :]) / (self.h[0]**2)
+            # Right boundary: 3rd-order backward differences (-f_{n-4} + 4f_{n-3} - 5f_{n-2} + 2f_{n-1})/h_{x}²
+            dxx[..., -1, :] = (-u[..., -4, :] + 4*u[..., -3, :] - 5*u[..., -2, :] + 2*u[..., -1, :]) / (self.h[0]**2)
+        
+        return dxx
+    
+    
+    def _dy_2nd(self, u):
+        """Second order derivative with respect to y."""
+        
+        if self.periodic_in_y:
+            # Periodic case: use torch.roll for boundary wrapping
+            # Central difference: (f_{i,j+1} - 2f_{i,j} + f_{i,j-1})/(h_{y}²)
+            dyy = (torch.roll(u, -1, dims=-1) - 2*u + torch.roll(u, 1, dims=-1)) / (self.h[1]**2)
+        
+        else:
+            # Non-periodic case: handle boundaries separately
+            dyy = torch.zeros_like(u)
+            
+            # Interior points: Second-order central differences
+            # (f_{i,j+1} - 2f_{i,j} + f_{i,j-1})/(h_{y}²)
+            dyy[..., :, 1:-1] = (u[..., :, 2:] - 2*u[..., :, 1:-1] + u[..., :, :-2]) / (self.h[1]**2)
+            
+            # Boundary points: 3rd-order one-sided differences
+            # Bottom boundary: 3rd-order forward differences (2f_{0} - 5f_{1} + 4f_{2} - f_{3})/h_{y}²
+            dyy[..., :, 0] = (2*u[..., :, 0] - 5*u[..., :, 1] + 4*u[..., :, 2] - u[..., :, 3]) / (self.h[1]**2)
+            # Top boundary: 3rd-order backward differences (-f_{n-4} + 4f_{n-3} - 5f_{n-2} + 2f_{n-1})/h_{y}²
+            dyy[..., :, -1] = (-u[..., :, -4] + 4*u[..., :, -3] - 5*u[..., :, -2] + 2*u[..., :, -1]) / (self.h[1]**2)
+        
+        return dyy
+    
+    
+    def laplacian(self, u):
+        """
+        Compute the Laplacian ∇²f.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+            
+        Returns
+        -------
+        torch.Tensor
+            The Laplacian of the input tensor
+        """
+        return self._dx_2nd(u) + self._dy_2nd(u)
+    
+    def divergence(self, u):
+        """
+        Compute the divergence ∇·u for 2D vector fields.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input vector field with shape (..., 2, height, width)
+            
+        Returns
+        -------
+        torch.Tensor
+            The divergence of the vector field
+        """
+        if u.shape[-3] != 2:
+            raise ValueError("Input must be a 2D vector field with 2 components")
+        
+        u1, u2 = u[..., 0, :, :], u[..., 1, :, :]
+        return self.dx(u1) + self.dy(u2)
+    
+    
+    def curl(self, u):
+        """
+        Compute the curl ∇×u for 2D vector fields.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input vector field with shape (..., 2, height, width)
+            
+        Returns
+        -------
+        torch.Tensor
+            The curl of the vector field (scalar field in 2D)
+        """
+        if u.shape[-3] != 2:
+            raise ValueError("Input must be a 2D vector field with 2 components")
+        
+        u1, u2 = u[..., 0, :, :], u[..., 1, :, :]
+        return self.dx(u2) - self.dy(u1)
+    
+    
+    def gradient(self, u):
+        """
+        Compute the gradient ∇f for scalar fields.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input scalar field
+            
+        Returns
+        -------
+        torch.Tensor
+            The gradient of the scalar field with shape (..., 2, height, width)
+        """
+        grad_x = self.dx(u)
+        grad_y = self.dy(u)
+        
+        return torch.stack([grad_x, grad_y], dim=-3)
+
+
+class FiniteDiff3D:
+    """
+    A comprehensive class for computing 3D finite differences with boundary handling.
+    
+    This class provides methods for computing partial derivatives, gradients,
+    divergence, curl, and Laplacian of 3D fields using central finite differences.
+    """
+    
+    def __init__(self, h=(1.0, 1.0, 1.0), periodic_in_x=True, periodic_in_y=True, periodic_in_z=True):
+        """
+        Parameters
+        ----------
+        h : tuple or float, optional
+            Grid spacing for (z, y, x) directions, by default (1.0, 1.0, 1.0)
+        periodic_in_x : bool, optional
+            Whether to use periodic boundary conditions in x-direction, by default True
+        periodic_in_y : bool, optional
+            Whether to use periodic boundary conditions in y-direction, by default True
+        periodic_in_z : bool, optional
+            Whether to use periodic boundary conditions in z-direction, by default True
+        """
+        if isinstance(h, float):
+            self.h = (h, h, h)
+        else:
+            self.h = h
+        self.periodic_in_x = periodic_in_x
+        self.periodic_in_y = periodic_in_y
+        self.periodic_in_z = periodic_in_z
+        
+        # Validate parameters
+        if len(self.h) != 3:
+            raise ValueError("h must be a float or a tuple of length 3")
+
+    
+    def dx(self, u, order=1):
+        """
+        Compute partial derivative with respect to x.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            Partial derivative with respect to x
+        """
+        if order == 1:
+            return self._dx_1st(u)
+        elif order == 2:
+            return self._dx_2nd(u)
+        else:
+            raise ValueError("Only 1st and 2nd order derivatives currently supported")
+    
+    def dy(self, u, order=1):
+        """
+        Compute partial derivative with respect to y.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            Partial derivative with respect to y
+        """
+        if order == 1:
+            return self._dy_1st(u)
+        elif order == 2:
+            return self._dy_2nd(u)
+        else:
+            raise ValueError("Only 1st and 2nd order derivatives currently supported")
+    
+    def dz(self, u, order=1):
+        """
+        Compute partial derivative with respect to z.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            Partial derivative with respect to z
+        """
+        if order == 1:
+            return self._dz_1st(u)
+        elif order == 2:
+            return self._dz_2nd(u)
+        else:
+            raise ValueError("Only 1st and 2nd order derivatives currently supported")
+    
+    
+    def _dx_1st(self, u):
+        """First order derivative with respect to x."""
+        
+        if self.periodic_in_x:
+            # Periodic case: use torch.roll for boundary wrapping
+            # Central difference: (f_{i+1,j,k} - f_{i-1,j,k})/(2h_{x})
+            dx = (torch.roll(u, -1, dims=-3) - torch.roll(u, 1, dims=-3)) / (2.0 * self.h[0])
+        
+        else:
+            # Non-periodic case: handle boundaries separately
+            dx = torch.zeros_like(u)
+            
+            # Interior points: Second-order central differences
+            # (f_{i+1,j,k} - f_{i-1,j,k})/(2h_{x})
+            dx[..., 1:-1, :, :] = (u[..., 2:, :, :] - u[..., :-2, :, :]) / (2.0 * self.h[0])
+            
+            # Left boundary: 3rd-order forward differences (-11f_{0} + 18f_{1} - 9f_{2} + 2f_{3})/(6h_{x})
+            dx[..., 0, :, :] = (-11*u[..., 0, :, :] + 18*u[..., 1, :, :] - 9*u[..., 2, :, :] + 2*u[..., 3, :, :]) / (6.0 * self.h[0])
+            
+            # Right boundary: 3rd-order backward differences (-2f_{n-4} + 9f_{n-3} - 18f_{n-2} + 11f_{n-1})/(6h_{x})
+            dx[..., -1, :, :] = (-2*u[..., -4, :, :] + 9*u[..., -3, :, :] - 18*u[..., -2, :, :] + 11*u[..., -1, :, :]) / (6.0 * self.h[0])
+        
+        return dx
+    
+    
+    def _dy_1st(self, u):
+        """First order derivative with respect to y."""
+        
+        if self.periodic_in_y:
+            # Periodic case: use torch.roll for boundary wrapping
+            # Central difference: (f_{i,j+1,k} - f_{i,j-1,k})/(2h_{y})
+            dy = (torch.roll(u, -1, dims=-2) - torch.roll(u, 1, dims=-2)) / (2.0 * self.h[1])
+        
+        else:
+            # Non-periodic case: handle boundaries separately
+            dy = torch.zeros_like(u)
+            
+            # Interior points: Second-order central differences
+            # (f_{i,j+1,k} - f_{i,j-1,k})/(2h_{y})
+            dy[..., :, 1:-1, :] = (u[..., :, 2:, :] - u[..., :, :-2, :]) / (2.0 * self.h[1])
+            
+            # Bottom boundary: 3rd-order forward differences (-11f_{0} + 18f_{1} - 9f_{2} + 2f_{3})/(6h_{y})
+            dy[..., :, 0, :] = (-11*u[..., :, 0, :] + 18*u[..., :, 1, :] - 9*u[..., :, 2, :] + 2*u[..., :, 3, :]) / (6.0 * self.h[1])
+            
+            # Top boundary: 3rd-order backward differences (-2f_{n-4} + 9f_{n-3} - 18f_{n-2} + 11f_{n-1})/(6h_{y})
+            dy[..., :, -1, :] = (-2*u[..., :, -4, :] + 9*u[..., :, -3, :] - 18*u[..., :, -2, :] + 11*u[..., :, -1, :]) / (6.0 * self.h[1])
+        
+        return dy
+    
+    def _dz_1st(self, u):
+        """First order derivative with respect to z."""
+        
+        if self.periodic_in_z:
+            # Periodic case: use torch.roll for boundary wrapping
+            # Central difference: (f_{i,j,k+1} - f_{i,j,k-1})/(2h_{z})
+            dz = (torch.roll(u, -1, dims=-1) - torch.roll(u, 1, dims=-1)) / (2.0 * self.h[2])
+        
+        else:
+            # Non-periodic case: handle boundaries separately
+            dz = torch.zeros_like(u)
+            
+            # Interior points: Second-order central differences
+            # (f_{i,j,k+1} - f_{i,j,k-1})/(2h_{z})
+            dz[..., :, :, 1:-1] = (u[..., :, :, 2:] - u[..., :, :, :-2]) / (2.0 * self.h[2])
+            
+            # Front boundary: 3rd-order forward differences (-11f_{0} + 18f_{1} - 9f_{2} + 2f_{3})/(6h_{z})
+            dz[..., :, :, 0] = (-11*u[..., :, :, 0] + 18*u[..., :, :, 1] - 9*u[..., :, :, 2] + 2*u[..., :, :, 3]) / (6.0 * self.h[2])
+            
+            # Back boundary: 3rd-order backward differences (-2f_{n-4} + 9f_{n-3} - 18f_{n-2} + 11f_{n-1})/(6h_{z})
+            dz[..., :, :, -1] = (-2*u[..., :, :, -4] + 9*u[..., :, :, -3] - 18*u[..., :, :, -2] + 11*u[..., :, :, -1]) / (6.0 * self.h[2])
+        
+        return dz
+    
+    
+    def _dx_2nd(self, u):
+        """Second order derivative with respect to x."""
+        
+        if self.periodic_in_x:
+            # Periodic case: use torch.roll for boundary wrapping
+            # Central difference: (f_{i+1,j,k} - 2f_{i,j,k} + f_{i-1,j,k})/(h_{x}²)
+            dxx = (torch.roll(u, -1, dims=-3) - 2*u + torch.roll(u, 1, dims=-3)) / (self.h[0]**2)
+        
+        else:
+            # Non-periodic case: handle boundaries separately
+            dxx = torch.zeros_like(u)
+            
+            # Interior points: Second-order central differences
+            # (f_{i+1,j,k} - 2f_{i,j,k} + f_{i-1,j,k})/(h_{x}²)
+            dxx[..., 1:-1, :, :] = (u[..., 2:, :, :] - 2*u[..., 1:-1, :, :] + u[..., :-2, :, :]) / (self.h[0]**2)
+            
+            # Boundary points: 3rd-order one-sided differences
+            # Left boundary: 3rd-order forward differences (2f_{0} - 5f_{1} + 4f_{2} - f_{3})/h_{x}²
+            dxx[..., 0, :, :] = (2*u[..., 0, :, :] - 5*u[..., 1, :, :] + 4*u[..., 2, :, :] - u[..., 3, :, :]) / (self.h[0]**2)
+            # Right boundary: 3rd-order backward differences (-f_{n-4} + 4f_{n-3} - 5f_{n-2} + 2f_{n-1})/h_{x}²
+            dxx[..., -1, :, :] = (-u[..., -4, :, :] + 4*u[..., -3, :, :] - 5*u[..., -2, :, :] + 2*u[..., -1, :, :]) / (self.h[0]**2)
+        
+        return dxx
+    
+    
+    def _dy_2nd(self, u):
+        """Second order derivative with respect to y."""
+        
+        if self.periodic_in_y:
+            # Periodic case: use torch.roll for boundary wrapping
+            # Central difference: (f_{i,j+1,k} - 2f_{i,j,k} + f_{i,j-1,k})/(h_{y}²)
+            dyy = (torch.roll(u, -1, dims=-2) - 2*u + torch.roll(u, 1, dims=-2)) / (self.h[1]**2)
+        
+        else:
+            # Non-periodic case: handle boundaries separately
+            dyy = torch.zeros_like(u)
+            
+            # Interior points: Second-order central differences
+            # (f_{i,j+1,k} - 2f_{i,j,k} + f_{i,j-1,k})/(h_{y}²)
+            dyy[..., :, 1:-1, :] = (u[..., :, 2:, :] - 2*u[..., :, 1:-1, :] + u[..., :, :-2, :]) / (self.h[1]**2)
+            
+            # Boundary points: 3rd-order one-sided differences
+            # Bottom boundary: 3rd-order forward differences (2f_{0} - 5f_{1} + 4f_{2} - f_{3})/h_{y}²
+            dyy[..., :, 0, :] = (2*u[..., :, 0, :] - 5*u[..., :, 1, :] + 4*u[..., :, 2, :] - u[..., :, 3, :]) / (self.h[1]**2)
+            # Top boundary: 3rd-order backward differences (-f_{n-4} + 4f_{n-3} - 5f_{n-2} + 2f_{n-1})/h_{y}²
+            dyy[..., :, -1, :] = (-u[..., :, -4, :] + 4*u[..., :, -3, :] - 5*u[..., :, -2, :] + 2*u[..., :, -1, :]) / (self.h[1]**2)
+        
+        return dyy
+    
+    
+    def _dz_2nd(self, u):
+        """Second order derivative with respect to z."""
+        
+        if self.periodic_in_z:
+            # Periodic case: use torch.roll for boundary wrapping
+            # Central difference: (f_{i,j,k+1} - 2f_{i,j,k} + f_{i,j,k-1})/(h_{z}²)
+            dzz = (torch.roll(u, -1, dims=-1) - 2*u + torch.roll(u, 1, dims=-1)) / (self.h[2]**2)
+        
+        else:
+            # Non-periodic case: handle boundaries separately
+            dzz = torch.zeros_like(u)
+            
+            # Interior points: Second-order central differences
+            # (f_{i,j,k+1} - 2f_{i,j,k} + f_{i,j,k-1})/(h_{z}²)
+            dzz[..., :, :, 1:-1] = (u[..., :, :, 2:] - 2*u[..., :, :, 1:-1] + u[..., :, :, :-2]) / (self.h[2]**2)
+            
+            # Boundary points: 3rd-order one-sided differences
+            # Front boundary: 3rd-order forward differences (2f_{0} - 5f_{1} + 4f_{2} - f_{3})/h_{z}²
+            dzz[..., :, :, 0] = (2*u[..., :, :, 0] - 5*u[..., :, :, 1] + 4*u[..., :, :, 2] - u[..., :, :, 3]) / (self.h[2]**2)
+            # Back boundary: 3rd-order backward differences (-f_{n-4} + 4f_{n-3} - 5f_{n-2} + 2f_{n-1})/h_{z}²
+            dzz[..., :, :, -1] = (-u[..., :, :, -4] + 4*u[..., :, :, -3] - 5*u[..., :, :, -2] + 2*u[..., :, :, -1]) / (self.h[2]**2)
+        
+        return dzz
+    
+    
+    def laplacian(self, u):
+        """
+        Compute the Laplacian ∇²f.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+            
+        Returns
+        -------
+        torch.Tensor
+            The Laplacian of the input tensor
+        """
+        return self._dx_2nd(u) + self._dy_2nd(u) + self._dz_2nd(u)
+    
+    
+    def divergence(self, u):
+        """
+        Compute the divergence ∇·u for 3D vector fields.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input vector field with shape (..., 3, depth, height, width)
+            
+        Returns
+        -------
+        torch.Tensor
+            The divergence of the vector field
+        """
+        if u.shape[-4] != 3:
+            raise ValueError("Input must be a 3D vector field with 3 components")
+        
+        u1, u2, u3 = u[..., 0, :, :, :], u[..., 1, :, :, :], u[..., 2, :, :, :]
+        return self.dx(u1) + self.dy(u2) + self.dz(u3)
+    
+    
+    def curl(self, u):
+        """
+        Compute the curl ∇×u for 3D vector fields.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input vector field with shape (..., 3, depth, height, width)
+            
+        Returns
+        -------
+        torch.Tensor
+            The curl of the vector field with shape (..., 3, depth, height, width)
+        """
+        if u.shape[-4] != 3:
+            raise ValueError("Input must be a 3D vector field with 3 components")
+        
+        u1, u2, u3 = u[..., 0, :, :, :], u[..., 1, :, :, :], u[..., 2, :, :, :]
+        
+        curl_x = self.dy(u3) - self.dz(u2)
+        curl_y = self.dz(u1) - self.dx(u3)
+        curl_z = self.dx(u2) - self.dy(u1)
+        
+        return torch.stack([curl_x, curl_y, curl_z], dim=-4)
+    
+    
+    def gradient(self, u):
+        """
+        Compute the gradient ∇f for scalar fields.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input scalar field
+            
+        Returns
+        -------
+        torch.Tensor
+            The gradient of the scalar field with shape (..., 3, depth, height, width)
+        """
+        grad_x = self.dx(u)
+        grad_y = self.dy(u)
+        grad_z = self.dz(u)
+        
+        return torch.stack([grad_x, grad_y, grad_z], dim=-4)
+
+
+
+
+# Backward compatibility functions
 def central_diff_1d(x, h, periodic_in_x=True):
-    """central_diff_1d computes the first spatial derivative
-    of x using central finite-difference 
-
-    This function computes df/dx using the central difference formula:
-    df/dx \approx (f(x+h) - f(x-h)) / (2h)
-    
-    For periodic domains (periodic_in_x=True), the function uses torch.roll to handle
-    boundary wrapping, treating the domain as periodic.
-    
-    For non-periodic domains (periodic_in_x=False), the function uses forward differences
-    at the left boundary and backward differences at the right boundary to avoid
-    accessing points outside the domain.
-
-    Parameters
-    ----------
-    x : torch.Tensor
-        input data on a regular 1d grid, such that
-        x[i] = f(x_i)
-    h : float
-        discretization size of input x
-    periodic_in_x : bool, optional
-        whether to use periodic boundary conditions:
-        - True: periodic domain (default)
-        - False: non-periodic domain with forward/backward differences at boundaries
-        by default True
-
-    Returns
-    -------
-    dx : torch.Tensor
-        output tensor of df(x)/dx at each point
     """
-    if periodic_in_x:
-        # Periodic case: use torch.roll for boundary wrapping
-        dx = (torch.roll(x, -1, dims=-1) - torch.roll(x, 1, dims=-1)) / (2.0 * h)
-    else:
-        # Non-periodic case: handle boundaries separately
-        dx = torch.zeros_like(x)
-        
-        # Interior points: central difference
-        dx[..., 1:-1] = (x[..., 2:] - x[..., :-2]) / (2.0 * h)
-        
-        # Boundary points: forward and backward differences
-        dx[..., 0] = (x[..., 1] - x[..., 0]) / h
-        dx[..., -1] = (x[..., -1] - x[..., -2]) / h
-    
-    return dx
+    Backward compatibility function for central_diff_1d.
+    Creates a FiniteDiff1D instance and returns dx.
+    """
+    fd1d = FiniteDiff1D(h=h, periodic_in_x=periodic_in_x)
+    return fd1d.dx(x)
 
-#x: (*, s1, s2)
-#y: (*, s1, s2)
+
 def central_diff_2d(x, h, periodic_in_x=True, periodic_in_y=True):
-    """central_diff_2d computes derivatives 
-    df(x,y)/dx and df(x,y)/dy for f(x,y) defined 
-    on a regular 2d grid using finite-difference
-
-    This function computes partial derivatives using the central difference formula:
-    df/dx \approx (f(x+h,y) - f(x-h,y)) / (2h_x)
-    df/dy \approx (f(x,y+h) - f(x,y-h)) / (2h_y)
-    
-    For periodic dimensions (periodic_in_*=True), the function uses torch.roll to handle
-    boundary wrapping, treating those dimensions as periodic.
-    
-    For non-periodic dimensions (periodic_in_*=False), the function uses forward differences
-    at the left boundary and backward differences at the right boundary to avoid
-    accessing points outside the domain.
-
-    Parameters
-    ----------
-    x : torch.Tensor
-        input function defined x[:,i,j] = f(x_i, y_j)
-    h : float or list
-        discretization size of grid for each dimension
-    periodic_in_x : bool, optional
-        whether to use periodic boundary conditions in x-direction:
-        - True: periodic in x (default)
-        - False: non-periodic in x with forward/backward differences at boundaries
-        by default True
-    periodic_in_y : bool, optional
-        whether to use periodic boundary conditions in y-direction:
-        - True: periodic in y (default)
-        - False: non-periodic in y with forward/backward differences at boundaries
-        by default True
-
-    Returns
-    -------
-    dx, dy : tuple of torch.Tensor
-        tuple such that dx[:, i,j]= df(x_i,y_j)/dx
-        and dy[:, i,j]= df(x_i,y_j)/dy
     """
-    if isinstance(h, float):
-        h = [h, h]
+    Backward compatibility function for central_diff_2d.
+    Creates a FiniteDiff2D instance and returns dx, dy.
+    """
+    fd2d = FiniteDiff2D(h=h, periodic_in_x=periodic_in_x, periodic_in_y=periodic_in_y)
+    return fd2d.dx(x), fd2d.dy(x)
 
-    if periodic_in_x:
-        # Periodic case in x-direction: use torch.roll for boundary wrapping
-        dx = (torch.roll(x, -1, dims=-2) - torch.roll(x, 1, dims=-2)) / (2.0 * h[0])
-    else:
-        # Non-periodic case in x-direction: handle boundaries separately
-        dx = torch.zeros_like(x)
-        
-        # Interior points: central difference
-        dx[..., 1:-1, :] = (x[..., 2:, :] - x[..., :-2, :]) / (2.0 * h[0])
-        
-        # Boundary points: forward and backward differences
-        dx[..., 0, :] = (x[..., 1, :] - x[..., 0, :]) / h[0]
-        dx[..., -1, :] = (x[..., -1, :] - x[..., -2, :]) / h[0]
 
-    if periodic_in_y:
-        # Periodic case in y-direction: use torch.roll for boundary wrapping
-        dy = (torch.roll(x, -1, dims=-1) - torch.roll(x, 1, dims=-1)) / (2.0 * h[1])
-    else:
-        # Non-periodic case in y-direction: handle boundaries separately
-        dy = torch.zeros_like(x)
-        
-        # Interior points: central difference
-        dy[..., :, 1:-1] = (x[..., :, 2:] - x[..., :, :-2]) / (2.0 * h[1])
-        
-        # Boundary points: forward and backward differences
-        dy[..., :, 0] = (x[..., :, 1] - x[..., :, 0]) / h[1]
-        dy[..., :, -1] = (x[..., :, -1] - x[..., :, -2]) / h[1]
-        
-    return dx, dy
-
-#x: (*, s1, s2, s3)
-#y: (*, s1, s2, s3)
 def central_diff_3d(x, h, periodic_in_x=True, periodic_in_y=True, periodic_in_z=True):
-    """central_diff_3d computes derivatives 
-    df(x,y,z)/dx, df(x,y,z)/dy, and df(x,y,z)/dz for f(x,y,z) defined 
-    on a regular 3d grid using finite-difference
-
-    This function computes partial derivatives using the central difference formula:
-    df/dx \approx (f(x+h,y,z) - f(x-h,y,z)) / (2h_x)
-    df/dy \approx (f(x,y+h,z) - f(x,y-h,z)) / (2h_y)
-    df/dz \approx (f(x,y,z+h) - f(x,y,z-h)) / (2h_z)
-    
-    For periodic dimensions (periodic_in_*=True), the function uses torch.roll to handle
-    boundary wrapping, treating those dimensions as periodic.
-    
-    For non-periodic dimensions (periodic_in_*=False), the function uses forward differences
-    at the left boundary and backward differences at the right boundary to avoid
-    accessing points outside the domain.
-
-    Parameters
-    ----------
-    x : torch.Tensor
-        input function defined x[:,i,j,k] = f(x_i, y_j, z_k)
-    h : float or list
-        discretization size of grid for each dimension
-    periodic_in_x : bool, optional
-        whether to use periodic boundary conditions in x-direction:
-        - True: periodic in x (default)
-        - False: non-periodic in x with forward/backward differences at boundaries
-        by default True
-    periodic_in_y : bool, optional
-        whether to use periodic boundary conditions in y-direction:
-        - True: periodic in y (default)
-        - False: non-periodic in y with forward/backward differences at boundaries
-        by default True
-    periodic_in_z : bool, optional
-        whether to use periodic boundary conditions in z-direction:
-        - True: periodic in z (default)
-        - False: non-periodic in z with forward/backward differences at boundaries
-        by default True
-
-    Returns
-    -------
-    dx, dy, dz : tuple of torch.Tensor
-        tuple such that dx[:, i,j,k]= df(x_i,y_j,z_k)/dx
-        and dy[:, i,j,k]= df(x_i,y_j,z_k)/dy
-        and dz[:, i,j,k]= df(x_i,y_j,z_k)/dz
     """
-    if isinstance(h, float):
-        h = [h, h, h]
-
-    if periodic_in_x:
-        # Periodic case in x-direction: use torch.roll for boundary wrapping
-        dx = (torch.roll(x, -1, dims=-3) - torch.roll(x, 1, dims=-3)) / (2.0 * h[0])
-    else:
-        # Non-periodic case in x-direction: handle boundaries separately
-        dx = torch.zeros_like(x)
-        
-        # Interior points: central difference
-        dx[..., 1:-1, :, :] = (x[..., 2:, :, :] - x[..., :-2, :, :]) / (2.0 * h[0])
-        
-        # Boundary points: forward and backward differences
-        dx[..., 0, :, :] = (x[..., 1, :, :] - x[..., 0, :, :]) / h[0]
-        dx[..., -1, :, :] = (x[..., -1, :, :] - x[..., -2, :, :]) / h[0]
-
-    if periodic_in_y:
-        # Periodic case in y-direction: use torch.roll for boundary wrapping
-        dy = (torch.roll(x, -1, dims=-2) - torch.roll(x, 1, dims=-2)) / (2.0 * h[1])
-    else:
-        # Non-periodic case in y-direction: handle boundaries separately
-        dy = torch.zeros_like(x)
-        
-        # Interior points: central difference
-        dy[..., :, 1:-1, :] = (x[..., :, 2:, :] - x[..., :, :-2, :]) / (2.0 * h[1])
-        
-        # Boundary points: forward and backward differences
-        dy[..., :, 0, :] = (x[..., :, 1, :] - x[..., :, 0, :]) / h[1]
-        dy[..., :, -1, :] = (x[..., :, -1, :] - x[..., :, -2, :]) / h[1]
-
-    if periodic_in_z:
-        # Periodic case in z-direction: use torch.roll for boundary wrapping
-        dz = (torch.roll(x, -1, dims=-1) - torch.roll(x, 1, dims=-1)) / (2.0 * h[2])
-    else:
-        # Non-periodic case in z-direction: handle boundaries separately
-        dz = torch.zeros_like(x)
-        
-        # Interior points: central difference
-        dz[..., :, :, 1:-1] = (x[..., :, :, 2:] - x[..., :, :, :-2]) / (2.0 * h[2])
-        
-        # Boundary points: forward and backward differences
-        dz[..., :, :, 0] = (x[..., :, :, 1] - x[..., :, :, 0]) / h[2]
-        dz[..., :, :, -1] = (x[..., :, :, -1] - x[..., :, :, -2]) / h[2]
-        
-    return dx, dy, dz
+    Backward compatibility function for central_diff_3d.
+    Creates a FiniteDiff3D instance and returns dx, dy, dz.
+    """
+    fd3d = FiniteDiff3D(h=h, periodic_in_x=periodic_in_x, periodic_in_y=periodic_in_y, periodic_in_z=periodic_in_z)
+    return fd3d.dx(x), fd3d.dy(x), fd3d.dz(x)
 
 
 

--- a/neuralop/losses/fourier_diff.py
+++ b/neuralop/losses/fourier_diff.py
@@ -1,95 +1,762 @@
-from neuralop.layers.fourier_continuation import FCLegendre, FCGram
+from ..layers.fourier_continuation import FCLegendre, FCGram
 import torch
 import warnings
 
 
-def fourier_derivative_1d(u, order=1, L=2*torch.pi, use_FC=False, FC_d=4, FC_n_additional_pts=50, low_pass_filter_ratio=None):
+class FourierDiff1D:
     """
-    Compute the 1D Fourier derivative of a given tensor.
-    Use with care, as Fourier continuation and Fourier derivatives are not always stable.
+    A class for computing 1D Fourier derivatives with Fourier continuation support.
     
-    FC derivatives are more stable when the original signal is nearly periodic 
-        (i.e., values and slopes at boundaries match or are close).
-        and when the signal is smooth and has no sharp jumps/discontinuities at the boundaries.
+    Provides methods for computing 1D Fourier derivatives,
+    with optional Fourier continuation for handling non-periodic functions.
+    """
     
-    Use Fourier continuation to extend the signal if it is non-periodic. 
-    
-    Unstable behavior can occur if the signal has strong discontinuities or non-matching derivatives at boundaries,
-        and if the continuation introduces artificial oscillations (Gibbs phenomenon).
+    def __init__(self, 
+                 L=2*torch.pi, 
+                 use_FC=False, FC_d=4, 
+                 FC_n_additional_pts=50, 
+                 low_pass_filter_ratio=None):
+        """
+        Parameters
+        ----------
+        L : float, optional
+            Length of the domain, by default 2*pi
+        use_FC : str, optional
+            Whether to use Fourier continuation. Use for non-periodic functions.
+            Options: None, 'Legendre', 'Gram', by default False
+        FC_d : int, optional
+            'Degree' of the Fourier continuation, by default 4
+        FC_n_additional_pts : int, optional
+            Number of points to add using the Fourier continuation layer, by default 50
+        low_pass_filter_ratio : float, optional
+            If not None, apply a low-pass filter to the Fourier coefficients, by default None
+        """
+        self.L = L
+        self.use_FC = use_FC
+        self.FC_d = FC_d
+        self.FC_n_additional_pts = FC_n_additional_pts
+        self.low_pass_filter_ratio = low_pass_filter_ratio
 
-    Signs of instability include boundary artifacts, high-frequency ringing, or growing errors with higher resolution.
     
-    
-    Parameters
-    ----------
-    u : torch.Tensor
-        Input tensor. The derivative will be computed along the last dimension.
-    order : int, optional
-        Order of the derivative, by default 1
-    L : float, optional
-        Length of the domain considered, by default 2*pi
-    use_FC : str, optional
-        Whether to use Fourier continuation. Use for non-periodic functions.
-        Options: None, 'Legendre', 'Gram', by default False
-    FC_d : int, optional
-        'Degree' of the Fourier continuation, by default 4
-    FC_n_additional_pts : int, optional
-        Number of points to add using the Fourier continuation layer, by default 50
-        For FC-Gram continuation, it is usually not necessary to change this parameter. 
-        This has a bigger effect on FC-Legendre continuation.
-    low_pass_filter_ratio : float, optional
-        If not None, apply a low-pass filter to the Fourier coefficients. 
-        Can help reduce artificial oscillations. 1.0 means no filtering, 
-        0.5 means keep half of the coefficients, etc., by default None
-
-    Returns
-    -------
-    torch.Tensor
-        The derivative of the input tensor.
+    def compute_multiple_derivatives(self, u, orders):
+        """
+        Compute multiple derivatives in a single FFT/IFFT call for better performance.
         
-    Notes
-    -----
-    When using Fourier continuation, the function automatically adjusts the 
-    domain length L to account for the extended signal. The result is cropped 
-    back to the original interval size.
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor. Expected shape: (..., length)
+        orders : list of int
+            List of derivative orders to compute.
+            Example: [1, 2, 3] for first, second, and third derivatives
+            
+        Returns
+        -------
+        list of torch.Tensor
+            List of computed derivatives in the same order as the input orders list
+        """
+        if u is None:
+            raise ValueError("Input tensor u is None")
+
+        L_x = self.L
+        nx = u.shape[-1]
+        u_clone = u.clone()
+
+        # Apply Fourier continuation if specified
+        if self.use_FC == 'Legendre':
+            FC = FCLegendre(d=self.FC_d, n_additional_pts=self.FC_n_additional_pts).to(u_clone.device)
+            u_clone = FC(u_clone, dim=1)
+            L_x *= (nx + self.FC_n_additional_pts) / nx
+        elif self.use_FC == 'Gram':
+            FC = FCGram(d=self.FC_d, n_additional_pts=self.FC_n_additional_pts).to(u_clone.device)
+            u_clone = FC(u_clone, dim=1)
+            L_x *= (nx + self.FC_n_additional_pts) / nx
+
+        # Update grid parameters after extension
+        nx = u_clone.shape[-1]
+        dx = L_x / nx
+
+        # FFT
+        u_h = torch.fft.rfft(u_clone, dim=-1)
+
+        # Frequency array
+        k_x = torch.fft.rfftfreq(nx, d=dx, device=u_h.device) * (2 * torch.pi)
+
+        # Apply low-pass filter if specified
+        if self.low_pass_filter_ratio is not None:
+            cutoff = int(u_h.shape[-1] * self.low_pass_filter_ratio)
+            u_h[..., cutoff:] = 0
+
+        # Compute derivatives
+        results = []
+        for order in orders:
+            derivative_u_h = ((1j * k_x) ** order) * u_h
+            results.append(derivative_u_h)
+
+        derivatives_ft = torch.stack(results, dim=0)
+        derivatives_real = torch.fft.irfft(derivatives_ft, dim=-1, n=nx)
+
+        # Crop result if Fourier continuation was used
+        if self.use_FC:
+            start_x = self.FC_n_additional_pts // 2
+            end_x = start_x + u.shape[-1]
+            derivatives_real = derivatives_real[..., start_x:end_x]
+
+        return [derivatives_real[i] for i in range(len(orders))]
     
-    Warnings
-    --------
-    Consider using Fourier continuation if the input is not periodic (use_FC=True).
-    Fourier continuation and Fourier derivatives can be numerically unstable
-    for certain functions and parameter combinations.
+    
+    def derivative(self, u, order=1):
+        """
+        Compute the 1D Fourier derivative of a given tensor.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor. Expected shape: (..., length)
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            The 1D derivative of the input tensor.
+        """
+        derivatives = self.compute_multiple_derivatives(u, [order])
+        return derivatives[0]
+    
+    
+
+
+
+class FourierDiff2D:
+    """
+    A class for computing 2D Fourier derivatives with Fourier continuation support.
+    
+    Provides methods for computing partial and mixed 2D Fourier derivatives,
+    with optional Fourier continuation for handling non-periodic functions.
     """
     
-    # Extend signal using Fourier continuation if specified
-    if use_FC=='Legendre':
-        L = L *  (u.shape[-1] + FC_n_additional_pts) / u.shape[-1]   # Define extended length
-        FC = FCLegendre(d=FC_d, n_additional_pts=FC_n_additional_pts).to(u.device)
-        u = FC(u, dim=1)
-    elif use_FC=='Gram':
-        L = L *  (u.shape[-1] + FC_n_additional_pts) / u.shape[-1]   # Define extended length
-        FC = FCGram(d=FC_d, n_additional_pts=FC_n_additional_pts).to(u.device)
-        u = FC(u, dim=1)
-    else:
-        warnings.warn("Consider using Fourier continuation if the input is not periodic (use_FC=True).", category=UserWarning)
+    def __init__(self, 
+                 L=(2*torch.pi, 2*torch.pi), 
+                 use_FC=False, FC_d=4, 
+                 FC_n_additional_pts=50, 
+                 low_pass_filter_ratio=None):
+        """
+        Parameters
+        ----------
+        L : tuple or list, optional
+            Length of the domain along (y, x) directions, by default (2*pi, 2*pi)
+        use_FC : str, optional
+            Whether to use Fourier continuation. Use for non-periodic functions.
+            Options: None, 'Legendre', 'Gram', by default False
+        FC_d : int, optional
+            'Degree' of the Fourier continuation, by default 4
+        FC_n_additional_pts : int, optional
+            Number of points to add using the Fourier continuation layer, by default 50
+        low_pass_filter_ratio : float, optional
+            If not None, apply a low-pass filter to the Fourier coefficients, by default None
+        """
+        self.L = L
+        self.use_FC = use_FC
+        self.FC_d = FC_d
+        self.FC_n_additional_pts = FC_n_additional_pts
+        self.low_pass_filter_ratio = low_pass_filter_ratio
 
-    nx = u.size(-1) 
-    dx = L / nx   
-    u_h = torch.fft.rfft(u, dim=-1) 
-    k_x = torch.fft.rfftfreq(nx, d=dx, device=u_h.device) * (2*torch.pi)
     
-    if low_pass_filter_ratio is not None:
-        # Apply a low-pass filter to the Fourier coefficients
-        cutoff = int(u_h.shape[-1] * low_pass_filter_ratio)
-        u_h[..., cutoff:] = 0
-    
-    # Fourier differentiation    
-    derivative_u_h = (1j * k_x)**order * u_h
-    
-    # Inverse Fourier transform to get the derivative in physical space
-    derivative_u = torch.fft.irfft(derivative_u_h, dim=-1, n=nx) 
+    def compute_multiple_derivatives(self, u, derivatives):
+        """
+        Compute multiple derivatives in a single FFT/IFFT call for better performance.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor. Expected shape: (..., height, width)
+        derivatives : list of tuples
+            List of (order_x, order_y) tuples specifying which derivatives to compute.
+            Example: [(1, 0), (0, 1), (2, 0), (0, 2)] for dx, dy, dxx, dyy
+            
+        Returns
+        -------
+        list of torch.Tensor
+            List of computed derivatives in the same order as the input derivatives list
+        """
+        if u is None:
+            raise ValueError("Input tensor u is None")
 
-    # If Fourier continuation is used, crop the result to retrieve the derivative on the original interval
-    if use_FC:
-        derivative_u = derivative_u[..., FC_n_additional_pts//2: -FC_n_additional_pts//2]
+        L_x, L_y = self.L[0], self.L[1]
+        nx, ny = u.shape[-2], u.shape[-1]
+        u_clone = u.clone()
 
-    return derivative_u
+        # Apply Fourier continuation if specified
+        if self.use_FC == 'Legendre':
+            FC = FCLegendre(d=self.FC_d, n_additional_pts=self.FC_n_additional_pts).to(u_clone.device)
+            u_clone = FC.extend2d(u_clone)
+            L_x *= (nx + self.FC_n_additional_pts) / nx
+            L_y *= (ny + self.FC_n_additional_pts) / ny
+        elif self.use_FC == 'Gram':
+            FC = FCGram(d=self.FC_d, n_additional_pts=self.FC_n_additional_pts).to(u_clone.device)
+            u_clone = FC.extend2d(u_clone)
+            L_x *= (nx + self.FC_n_additional_pts) / nx
+            L_y *= (ny + self.FC_n_additional_pts) / ny
+
+        # Update grid parameters after extension
+        nx, ny = u_clone.shape[-2], u_clone.shape[-1]
+        dx, dy = L_x / nx, L_y / ny
+
+        # FFT with transposed axes (shape -> (ny, nx))
+        u_h = torch.fft.fft2(u_clone.transpose(-2, -1), dim=(-2, -1))
+
+        # Frequency arrays
+        k_x = torch.fft.fftfreq(nx, d=dx, device=u_h.device) * (2 * torch.pi)
+        k_y = torch.fft.fftfreq(ny, d=dy, device=u_h.device) * (2 * torch.pi)
+
+        # Create frequency meshgrid
+        KY, KX = torch.meshgrid(k_y, k_x, indexing="ij")  
+
+        # Apply low-pass filter if specified
+        if self.low_pass_filter_ratio is not None:
+            cutoff_x = int(nx * self.low_pass_filter_ratio)
+            cutoff_y = int(ny * self.low_pass_filter_ratio)
+            u_h[..., cutoff_y:, :] = 0
+            u_h[..., :, cutoff_x:] = 0
+
+        # Compute derivatives
+        results = []
+        for order_x, order_y in derivatives:
+            # Expand meshgrid tensors for proper broadcasting
+            KX_expanded = KX.expand(u_h.shape)
+            KY_expanded = KY.expand(u_h.shape)
+            
+            derivative_u_h = ((1j * KX_expanded) ** order_x) * ((1j * KY_expanded) ** order_y) * u_h
+            results.append(derivative_u_h)
+
+        derivatives_ft = torch.stack(results, dim=0)
+        derivatives_real = torch.fft.ifft2(derivatives_ft, dim=(-2, -1)).real
+
+        # Transpose back to original shape (nx, ny)
+        derivatives_real = derivatives_real.transpose(-2, -1)
+
+        # Crop result if Fourier continuation was used
+        if self.use_FC:
+            start_x = self.FC_n_additional_pts // 2
+            end_x = start_x + u.shape[-2]
+            start_y = self.FC_n_additional_pts // 2
+            end_y = start_y + u.shape[-1]
+            derivatives_real = derivatives_real[..., start_x:end_x, start_y:end_y]
+
+        return [derivatives_real[i] for i in range(len(derivatives))]
+    
+    
+    def derivative(self, u, order_x=1, order_y=1):
+        """
+        Compute the 2D Fourier derivative of a given tensor.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor. Expected shape: (..., height, width)
+        order_x : int, optional
+            Order of the derivative along the x-direction (last dimension), by default 1
+        order_y : int, optional
+            Order of the derivative along the y-direction (second-to-last dimension), by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            The 2D derivative of the input tensor.
+        """
+        derivatives = self.compute_multiple_derivatives(u, [(order_x, order_y)])
+        return derivatives[0]
+    
+    
+    def partial(self, u, direction='x', order=1):
+        """
+        Compute partial 2D Fourier derivative along a specific direction.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor. Expected shape: (..., height, width)
+        direction : str, optional
+            Direction of differentiation: 'x' (last dimension) or 'y' (second-to-last dimension), by default 'x'
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            The partial derivative of the input tensor along the specified direction.
+        """
+        if direction == 'x':
+            return self.derivative(u, order_x=order, order_y=0)
+        elif direction == 'y':
+            return self.derivative(u, order_x=0, order_y=order)
+        else:
+            raise ValueError("Direction must be 'x' or 'y'")
+    
+    
+    def dx(self, u, order=1):
+        """
+        Compute partial derivative with respect to x.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            The partial derivative with respect to x
+        """
+        return self.partial(u, direction='x', order=order)
+    
+    
+    def dy(self, u, order=1):
+        """
+        Compute partial derivative with respect to y.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            The partial derivative with respect to y
+        """
+        return self.partial(u, direction='y', order=order)
+    
+    
+    def laplacian(self, u):
+        """
+        Compute the 2D Laplacian ∇²f = ∂²f/∂x² + ∂²f/∂y².
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+            
+        Returns
+        -------
+        torch.Tensor
+            The Laplacian of the input tensor
+        """
+        dxx, dyy = self.compute_multiple_derivatives(u, [(2, 0), (0, 2)])
+        return dxx + dyy
+    
+    
+    def divergence(self, u):
+        """
+        Compute the 2D divergence ∇·u = ∂u₁/∂x + ∂u₂/∂y.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input vector field with shape (..., 2, height, width)
+            
+        Returns
+        -------
+        torch.Tensor
+            The divergence of the vector field
+        """
+        if u.shape[-3] != 2:
+            raise ValueError("Input must be a 2D vector field with shape (..., 2, height, width)")
+        
+        # Extract components and ensure they have the right shape
+        u1 = u[..., 0, :, :].contiguous()  # First component
+        u2 = u[..., 1, :, :].contiguous()  # Second component
+        
+        # Ensure the components are not None and have the right shape
+        if u1 is None or u2 is None:
+            raise ValueError("Vector field components cannot be None")
+        
+        return self.dx(u1) + self.dy(u2)
+    
+    
+    def curl(self, u):
+        """
+        Compute the 2D curl ∇×u = ∂u₂/∂x - ∂u₁/∂y.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input vector field with shape (..., 2, height, width)
+            
+        Returns
+        -------
+        torch.Tensor
+            The curl of the vector field (scalar field in 2D)
+        """
+        if u.shape[-3] != 2:
+            raise ValueError("Input must be a 2D vector field with shape (..., 2, height, width)")
+        
+        u1 = u[..., 0, :, :] 
+        u2 = u[..., 1, :, :]  
+        
+        return self.dx(u2) - self.dy(u1)
+    
+    
+    def gradient(self, u):
+        """
+        Compute the 2D gradient ∇f = [∂f/∂x, ∂f/∂y].
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input scalar field
+            
+        Returns
+        -------
+        torch.Tensor
+            The gradient of the scalar field with shape (..., 2, height, width)
+        """
+        grad_x = self.dx(u)
+        grad_y = self.dy(u)
+        
+        return torch.stack([grad_x, grad_y], dim=-3)
+
+
+class FourierDiff3D:
+    """
+    A class for computing 3D Fourier derivatives with Fourier continuation support.
+    
+    Provides methods for computing partial and mixed 3D Fourier derivatives,
+    with optional Fourier continuation for handling non-periodic functions.
+    """
+    
+    def __init__(self, 
+                 L=(2*torch.pi, 2*torch.pi, 2*torch.pi), 
+                 use_FC=False, FC_d=4, 
+                 FC_n_additional_pts=50, 
+                 low_pass_filter_ratio=None):
+        """
+        Parameters
+        ----------
+        L : tuple or list, optional
+            Length of the domain along (z, y, x) directions, by default (2*pi, 2*pi, 2*pi)
+        use_FC : str, optional
+            Whether to use Fourier continuation. Use for non-periodic functions.
+            Options: None, 'Legendre', 'Gram', by default False
+        FC_d : int, optional
+            'Degree' of the Fourier continuation, by default 4
+        FC_n_additional_pts : int, optional
+            Number of points to add using the Fourier continuation layer, by default 50
+        low_pass_filter_ratio : float, optional
+            If not None, apply a low-pass filter to the Fourier coefficients, by default None
+        """
+        self.L = L
+        self.use_FC = use_FC
+        self.FC_d = FC_d
+        self.FC_n_additional_pts = FC_n_additional_pts
+        self.low_pass_filter_ratio = low_pass_filter_ratio
+        
+        
+    def compute_multiple_derivatives(self, u, derivatives):
+        """
+        Compute multiple derivatives in a single FFT/IFFT call for better performance.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor. Expected shape: (..., width, height, depth)
+        derivatives : list of tuples
+            List of (order_x, order_y, order_z) tuples specifying which derivatives to compute.
+            Example: [(1, 0, 0), (0, 1, 0), (0, 0, 1), (2, 0, 0), (0, 2, 0), (0, 0, 2)] 
+            for dx, dy, dz, dxx, dyy, dzz
+            
+        Returns
+        -------
+        list of torch.Tensor
+            List of computed derivatives in the same order as the input derivatives list
+        """
+        if u is None:
+            raise ValueError("Input tensor u is None")
+
+        L_x, L_y, L_z = self.L[0], self.L[1], self.L[2]
+        nx, ny, nz = u.shape[-3], u.shape[-2], u.shape[-1]
+        u_clone = u.clone()
+
+        # Apply Fourier continuation if specified
+        if self.use_FC == 'Legendre':
+            FC = FCLegendre(d=self.FC_d, n_additional_pts=self.FC_n_additional_pts).to(u_clone.device)
+            u_clone = FC.extend3d(u_clone)
+            L_x *= (nx + self.FC_n_additional_pts) / nx
+            L_y *= (ny + self.FC_n_additional_pts) / ny
+            L_z *= (nz + self.FC_n_additional_pts) / nz
+        elif self.use_FC == 'Gram':
+            FC = FCGram(d=self.FC_d, n_additional_pts=self.FC_n_additional_pts).to(u_clone.device)
+            u_clone = FC.extend3d(u_clone)
+            L_x *= (nx + self.FC_n_additional_pts) / nx
+            L_y *= (ny + self.FC_n_additional_pts) / ny
+            L_z *= (nz + self.FC_n_additional_pts) / nz
+
+        # Update grid parameters after extension
+        nx, ny, nz = u_clone.shape[-3], u_clone.shape[-2], u_clone.shape[-1]
+        dx, dy, dz = L_x / nx, L_y / ny, L_z / nz
+
+        # FFT with permuted axes (shape -> (nz, ny, nx))
+        u_clone_permuted = u_clone.permute(*range(u_clone.ndim-3), -1, -2, -3)
+        u_h = torch.fft.fftn(u_clone_permuted, dim=(-3, -2, -1))
+
+        # Frequency arrays
+        k_x = torch.fft.fftfreq(nx, d=dx, device=u_h.device) * (2 * torch.pi)
+        k_y = torch.fft.fftfreq(ny, d=dy, device=u_h.device) * (2 * torch.pi)
+        k_z = torch.fft.fftfreq(nz, d=dz, device=u_h.device) * (2 * torch.pi)
+
+        # Create frequency meshgrid
+        KZ, KY, KX = torch.meshgrid(k_z, k_y, k_x, indexing="ij")
+   
+        # Apply low-pass filter if specified
+        if self.low_pass_filter_ratio is not None:
+            cutoff_x = int(nx * self.low_pass_filter_ratio)
+            cutoff_y = int(ny * self.low_pass_filter_ratio)
+            cutoff_z = int(nz * self.low_pass_filter_ratio)
+            u_h[..., cutoff_y:, :, :] = 0
+            u_h[..., :, cutoff_x:, :] = 0
+            u_h[..., :, :, cutoff_z:] = 0
+
+
+        # Compute derivatives
+        results = []
+        for order_x, order_y, order_z in derivatives:
+            # Expand meshgrid tensors for proper broadcasting
+            KX_expanded = KX.expand(u_h.shape)
+            KY_expanded = KY.expand(u_h.shape)
+            KZ_expanded = KZ.expand(u_h.shape)
+            
+            derivative_u_h = ((1j * KX_expanded) ** order_x) * ((1j * KY_expanded) ** order_y) * ((1j * KZ_expanded) ** order_z) * u_h
+            results.append(derivative_u_h)
+
+        derivatives_ft = torch.stack(results, dim=0)
+        derivatives_real = torch.fft.ifftn(derivatives_ft, dim=(-3, -2, -1)).real
+
+        # Permute back to original shape (..., nx, ny, nz)
+        derivatives_real = derivatives_real.permute(*range(derivatives_real.ndim-3), -1, -2, -3)
+
+        # Crop result if Fourier continuation was used
+        if self.use_FC:
+            start_x = self.FC_n_additional_pts // 2
+            end_x = start_x + u.shape[-3]
+            start_y = self.FC_n_additional_pts // 2
+            end_y = start_y + u.shape[-2]
+            start_z = self.FC_n_additional_pts // 2
+            end_z = start_z + u.shape[-1]
+            derivatives_real = derivatives_real[..., start_x:end_x, start_y:end_y, start_z:end_z]
+
+        return [derivatives_real[i] for i in range(len(derivatives))]
+       
+       
+    def derivative(self, u, order_x=1, order_y=1, order_z=1):
+        """
+        Compute the 3D Fourier derivative of a given tensor.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor. Expected shape: (..., width, height, depth)
+        order_x : int, optional
+            Order of the derivative along the x-direction (last dimension), by default 1
+        order_y : int, optional
+            Order of the derivative along the y-direction (second-to-last dimension), by default 1
+        order_z : int, optional
+            Order of the derivative along the z-direction (third-to-last dimension), by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            The 3D derivative of the input tensor.
+        """
+        derivatives = self.compute_multiple_derivatives(u, [(order_x, order_y, order_z)])
+        return derivatives[0]
+    
+    
+    def partial(self, u, direction='x', order=1):
+        """
+        Compute partial 3D Fourier derivative along a specific direction.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor. Expected shape: (..., width, height, depth)
+        direction : str, optional
+            Direction of differentiation: 'x' (last dimension), 'y' (second-to-last dimension), 
+            or 'z' (third-to-last dimension), by default 'x'
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            The partial derivative of the input tensor along the specified direction.
+        """
+        if direction == 'x':
+            derivatives = self.compute_multiple_derivatives(u, [(order, 0, 0)])
+            return derivatives[0]
+        elif direction == 'y':
+            derivatives = self.compute_multiple_derivatives(u, [(0, order, 0)])
+            return derivatives[0]
+        elif direction == 'z':
+            derivatives = self.compute_multiple_derivatives(u, [(0, 0, order)])
+            return derivatives[0]
+        else:
+            raise ValueError("Direction must be 'x', 'y', or 'z'")
+    
+    
+    def dx(self, u, order=1):
+        """
+        Compute partial derivative with respect to x.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            The partial derivative with respect to x
+        """
+        return self.partial(u, direction='x', order=order)
+    
+    
+    def dy(self, u, order=1):
+        """
+        Compute partial derivative with respect to y.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            The partial derivative with respect to y
+        """
+        return self.partial(u, direction='y', order=order)
+    
+    
+    def dz(self, u, order=1):
+        """
+        Compute partial derivative with respect to z.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+        order : int, optional
+            Order of the derivative, by default 1
+            
+        Returns
+        -------
+        torch.Tensor
+            The partial derivative with respect to z
+        """
+        return self.partial(u, direction='z', order=order)
+    
+    
+    def laplacian(self, u):
+        """
+        Compute the 3D Laplacian ∇²f = ∂²f/∂x² + ∂²f/∂y² + ∂²f/∂z².
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input tensor
+            
+        Returns
+        -------
+        torch.Tensor
+            The Laplacian of the input tensor
+        """
+        # Use efficient multiple derivatives computation
+        dxx, dyy, dzz = self.compute_multiple_derivatives(u, [(2, 0, 0), (0, 2, 0), (0, 0, 2)])
+        return dxx + dyy + dzz
+    
+    
+    def divergence(self, u):
+        """
+        Compute the 3D divergence ∇·u = ∂u₁/∂x + ∂u₂/∂y + ∂u₃/∂z.
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input vector field with shape (..., 3, width, height, depth)
+            
+        Returns
+        -------
+        torch.Tensor
+            The divergence of the vector field
+        """
+        if u.shape[-4] != 3:
+            raise ValueError("Input must be a 3D vector field with shape (..., 3, width, height, depth)")
+        
+        # Extract components and ensure they have the right shape
+        u1 = u[..., 0, :, :, :].contiguous()  # First component
+        u2 = u[..., 1, :, :, :].contiguous()  # Second component
+        u3 = u[..., 2, :, :, :].contiguous()  # Third component
+        
+        # Ensure the components are not None and have the right shape
+        if u1 is None or u2 is None or u3 is None:
+            raise ValueError("Vector field components cannot be None")
+        
+        return self.dx(u1) + self.dy(u2) + self.dz(u3)
+    
+    
+    def curl(self, u):
+        """
+        Compute the 3D curl ∇×u = [∂u₃/∂y - ∂u₂/∂z, ∂u₁/∂z - ∂u₃/∂x, ∂u₂/∂x - ∂u₁/∂y].
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input vector field with shape (..., 3, width, height, depth)
+            
+        Returns
+        -------
+        torch.Tensor
+            The curl of the vector field with shape (..., 3, width, height, depth)
+        """
+        if u.shape[-4] != 3:
+            raise ValueError("Input must be a 3D vector field with shape (..., 3, width, height, depth)")
+        
+        u1 = u[..., 0, :, :, :]  # First component
+        u2 = u[..., 1, :, :, :]  # Second component
+        u3 = u[..., 2, :, :, :]  # Third component
+        
+        curl_x = self.dy(u3) - self.dz(u2)
+        curl_y = self.dz(u1) - self.dx(u3)
+        curl_z = self.dx(u2) - self.dy(u1)
+        
+        return torch.stack([curl_x, curl_y, curl_z], dim=-4)
+    
+    
+    def gradient(self, u):
+        """
+        Compute the 3D gradient ∇f = [∂f/∂x, ∂f/∂y, ∂f/∂z].
+        
+        Parameters
+        ----------
+        u : torch.Tensor
+            Input scalar field
+            
+        Returns
+        -------
+        torch.Tensor
+            The gradient of the scalar field with shape (..., 3, width, height, depth)
+        """
+        grad_x = self.dx(u)
+        grad_y = self.dy(u)
+        grad_z = self.dz(u)
+        
+        return torch.stack([grad_x, grad_y, grad_z], dim=-4)


### PR DESCRIPTION
This is code for enforcing the divergence-free constraint in 2d vector field.

This is based on our [ICML Workshop Paper](https://openreview.net/forum?id=Zvxm14Rd1F)

I updated completely our earlier projection code to use an explicit formula for the linear least-squares problem for the divergence-free constraint, instead of keeping the memory-heavy and time-consuming pinv

@mliuschi  can also have a look

Note that the example and test are based on the new differentiation code from [PR643](https://github.com/neuraloperator/neuraloperator/pull/643)