### PR TITLE
Fix missing **kwargs in FNO1d, FNO2d & FNO3d to allow passing arguments like positional_embedding

### DIFF
--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -463,6 +463,7 @@ class FNO1d(FNO):
             implementation=implementation,
             decomposition_kwargs=decomposition_kwargs,
             domain_padding=domain_padding,
+            **kwargs
         )
         self.n_modes_height = n_modes_height
 
@@ -537,6 +538,7 @@ class FNO2d(FNO):
             implementation=implementation,
             decomposition_kwargs=decomposition_kwargs,
             domain_padding=domain_padding,
+            **kwargs
         )
         self.n_modes_height = n_modes_height
         self.n_modes_width = n_modes_width
@@ -614,6 +616,7 @@ class FNO3d(FNO):
             implementation=implementation,
             decomposition_kwargs=decomposition_kwargs,
             domain_padding=domain_padding,
+            **kwargs
         )
         self.n_modes_height = n_modes_height
         self.n_modes_width = n_modes_width

--- a/neuralop/models/tests/test_fno.py
+++ b/neuralop/models/tests/test_fno.py
@@ -6,7 +6,7 @@ from tensorly import tenalg
 from configmypy import Bunch
 
 from neuralop import TFNO
-from neuralop.models import FNO
+from neuralop.models import FNO, FNO1d
 
 tenalg.set_backend("einsum")
 
@@ -139,3 +139,24 @@ def test_fno_superresolution(resolution_scaling_factor):
     factor = prod(resolution_scaling_factor)
 
     assert list(out.shape) == [batch_size, 1] + [int(round(factor * s)) for s in size]
+
+
+@pytest.mark.parametrize("n_dim", [1])
+def test_fno1d_kwargs_fix(n_dim):
+    s = 16
+    modes = 8
+    width = 16
+    n_modes = (modes,) * n_dim
+    n_modes_height = modes
+
+    model_fixed = FNO1d(
+        n_modes_height=n_modes_height,
+        hidden_channels=width,
+        in_channels=1,
+        out_channels=1,
+        n_layers=2,
+        positional_embedding=None
+    )
+
+    assert model_fixed.positional_embedding is None
+    assert model_fixed.lifting.in_channels == 1


### PR DESCRIPTION
Hello there,

In my project I needed to use FNO1d with positional_embedding=None, and it was not working. I noticed the **kwargs argument was not passed to super().__init__(...) calls. I wrote a test, proved it wasn't working, fixed it, test is passing.

Let me know if instead of passing **kwargs you'd like to pass a specific list of arguments (or feel free to do this change on your own).

Marine