### PR TITLE
Fixing naming convention in ICLoss

### DIFF
--- a/neuralop/losses/equation_losses.py
+++ b/neuralop/losses/equation_losses.py
@@ -63,18 +63,19 @@ class BurgersEqnLoss(object):
 class ICLoss(object):
     """
     Computes loss for initial value problems.
+
+    Extracts the initial condition and computes the loss between predicted 
+    and true initial conditions for all channels.
+    
+    Expected input shape: (batch_size, channels, time_dim, *spatial_dims)
     """
 
     def __init__(self, loss=F.mse_loss):
         super().__init__()
         self.loss = loss
-
-    def initial_condition_loss(self, y_pred, y):
-        boundary_true = y[:, 0, 0, :]
-        boundary_pred = y_pred[:, 0, 0, :]
-        return self.loss(boundary_pred, boundary_true)
-
+        
     def __call__(self, y_pred, y, **kwargs):
+        """Expected input shape: (batch_size, channels, time_dim, *spatial_dims)"""
         if kwargs:
             warnings.warn(
                 f"ICLoss.__call__() received unexpected keyword arguments: {list(kwargs.keys())}. "
@@ -82,7 +83,7 @@ class ICLoss(object):
                 UserWarning,
                 stacklevel=2,
             )
-        return self.initial_condition_loss(y_pred, y)
+        return self.loss(y_pred[:, :, 0], y[:, :, 0])
 
 
 class PoissonInteriorLoss(object):


### PR DESCRIPTION
Currently, the trainer calls `loss(out, **sample)` for all loss classes. This creates a problem since the `ICLoss` class takes in a positional argument named `x` that is intended to be the target `y` . When the element in the sample is passed in as keyword arguments, it will select `sample["x"]` for the positional argument `x`.  This creates complication in normalizations. Specifically, `DefaultDataProcessor` normalizes input `x` all the time, while at training time the training target `y` is normalized and `y_pred` is unchanged, and at evaluation time `y` is unchanged and `y_pred` is denormalized. This pipeline works for most losses, except for `ICLoss` where it takes in `x` as input:

A minimum reproducing example:
```
import torch
from torch.nn import Identity
from neuralop.data.transforms.normalizers import UnitGaussianNormalizer
from neuralop.data.transforms.data_processors import DefaultDataProcessor
from neuralop.losses.equation_losses import ICLoss

# defines the simplest task: identity mapping with normalization
# Sample output data with mean 0 and std 5
x = 5 * torch.randn(10, 1, 16, 16)
y = torch.clone(x)
data = {"x": x, "y": y}

# Fit normalizers to data
input_transform = UnitGaussianNormalizer()
output_transform = UnitGaussianNormalizer()
input_transform.fit(x)
output_transform.fit(y)

# define the model
model = Identity()

# create data processor
data_processor = DefaultDataProcessor(
    in_normalizer=input_transform,
    out_normalizer=output_transform,
)

# create loss function
loss = ICLoss()

# mimic the behavior at training time
model.train()
data_processor.train()
sample = data_processor.preprocess(data)
# get model prediction
out = model(sample["x"])
out, sample = data_processor.postprocess(out, sample)
# compute loss
print("Loss:", loss(out, **sample).item())
# output: "Loss: 0.0"

# mimic the behavior at evaluation time
model.eval()
data_processor.eval()
sample = data_processor.preprocess(data)
# get model prediction
out = model(sample["x"])
out, sample = data_processor.postprocess(out, sample)
# compute loss
print("Loss:", loss(out, **sample).item())
# output: "Loss: 0.6973892450332642"
```