### PR TITLE
Skip Zenodo API call when files_to_download is empty

### DIFF
--- a/neuralop/data/datasets/web_utils.py
+++ b/neuralop/data/datasets/web_utils.py
@@ -149,6 +149,8 @@ def download_from_zenodo_record(
         list of filenames to download from record.
         If None, downloads all. Default None
     """
+    if files_to_download is not None and len(files_to_download) == 0:
+        return
     zenodo_api_url = "https://zenodo.org/api/records/"
     url = f"{zenodo_api_url}{record_id}"
     resp = requests.get(url)


### PR DESCRIPTION
When DarcyDataset(..., download=True) is used and all required data files already exist locally, the loader correctly identifies that no files need to be downloaded and sets files_to_download = [].

However, download_from_zenodo_record still unconditionally contacts the Zenodo API, fetches the full record metadata, and parses it—even though no downloading will occur.

This causes a significant delay during dataset initialization, especially on slow or unstable network connections. In my case, with a poor internet connection, this adds ~13 seconds of unnecessary wait time on every run—despite the data already being fully present.