### PR TITLE
feat: KGSpectralConv — physics-constrained spectral layer for wave-type PDEs

### DIFF
--- a/examples/layers/plot_kg_spectral_filter.py
+++ b/examples/layers/plot_kg_spectral_filter.py
@@ -1,0 +1,252 @@
+"""
+
+Klein-Gordon Spectral Filter
+=============================
+
+This example visualizes the Klein-Gordon (KG) spectral convolution filter
+and compares it to other common spectral filters used in neural operators.
+
+The KG spectral filter is derived from the dispersion relation of the
+Klein-Gordon equation:
+
+.. math::
+   H(k) = \\cos\\left(T \\sqrt{c^2 |k|^2 + \\chi^2}\\right)
+
+where :math:`T` is the propagation time, :math:`c` the wave speed,
+and :math:`\\chi` the mass parameter. This filter is the exact
+single-step solution operator for the Klein-Gordon PDE and is a member
+of the Matern kernel family (Whittle 1954).
+
+We compare:
+
+1. **KG filter**: oscillatory bandpass with mass gap
+2. **Low-pass (GCN-style)**: 1 - |k|/k_max
+3. **Gaussian (diffusion)**: exp(-sigma |k|^2)
+4. **FNO truncation**: sharp rectangular cutoff in frequency space
+
+"""
+
+# %%
+# .. raw:: html
+#
+#    <div style="margin-top: 3em;"></div>
+#
+# Setup
+# -----
+
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+
+from neuralop.layers.kg_spectral_conv import KGSpectralConv
+
+device = torch.device("cpu")
+
+# %%
+# .. raw:: html
+#
+#    <div style="margin-top: 3em;"></div>
+#
+# 1D spectral filter comparison
+# -----------------------------
+# We plot four different spectral filter profiles as a function of
+# wavenumber :math:`|k|`.
+
+k = np.linspace(0, 20, 500)
+
+# KG filter for several mass values
+T, c = 1.0, 1.0
+fig, axes = plt.subplots(1, 3, figsize=(15, 4))
+
+# Panel 1: KG filter with varying chi (mass parameter)
+ax = axes[0]
+for chi in [0.0, 1.0, 5.0, 10.0]:
+    omega = np.sqrt(c**2 * k**2 + chi**2)
+    H = np.cos(T * omega)
+    ax.plot(k, H, label=f"$\\chi={chi}$")
+ax.set_xlabel("Wavenumber $|k|$")
+ax.set_ylabel("Filter response $H(k)$")
+ax.set_title("KG filter: varying mass $\\chi$")
+ax.legend()
+ax.axhline(0, color="gray", linewidth=0.5)
+ax.set_ylim(-1.2, 1.2)
+
+# Panel 2: KG filter with varying T (propagation time)
+ax = axes[1]
+chi = 2.0
+for T_val in [0.1, 0.5, 1.0, 2.0]:
+    omega = np.sqrt(c**2 * k**2 + chi**2)
+    H = np.cos(T_val * omega)
+    ax.plot(k, H, label=f"$T={T_val}$")
+ax.set_xlabel("Wavenumber $|k|$")
+ax.set_ylabel("Filter response $H(k)$")
+ax.set_title("KG filter: varying time $T$")
+ax.legend()
+ax.axhline(0, color="gray", linewidth=0.5)
+ax.set_ylim(-1.2, 1.2)
+
+# Panel 3: Comparison with standard filters
+ax = axes[2]
+chi, T_val = 2.0, 0.8
+omega = np.sqrt(c**2 * k**2 + chi**2)
+H_kg = np.cos(T_val * omega)
+H_lowpass = np.maximum(0, 1 - k / k.max())
+H_gauss = np.exp(-0.02 * k**2)
+H_fno = np.where(k <= 8, 1.0, 0.0)
+
+ax.plot(k, H_kg, label="KG ($\\chi=2, T=0.8$)", linewidth=2)
+ax.plot(k, H_lowpass, "--", label="Low-pass (GCN)", alpha=0.8)
+ax.plot(k, H_gauss, "--", label="Gaussian (diffusion)", alpha=0.8)
+ax.plot(k, H_fno, ":", label="FNO truncation", alpha=0.8)
+ax.set_xlabel("Wavenumber $|k|$")
+ax.set_ylabel("Filter response $H(k)$")
+ax.set_title("Filter comparison")
+ax.legend()
+ax.axhline(0, color="gray", linewidth=0.5)
+ax.set_ylim(-1.2, 1.2)
+
+fig.suptitle(
+    "Klein-Gordon spectral filter vs standard neural operator filters", y=1.02
+)
+plt.tight_layout()
+fig.show()
+
+# %%
+# .. raw:: html
+#
+#    <div style="margin-top: 3em;"></div>
+#
+# 2D spectral filter visualization
+# ---------------------------------
+# The KG filter is isotropic (depends only on :math:`|k|`), creating
+# concentric rings in 2D Fourier space.
+
+kx = np.linspace(-15, 15, 200)
+ky = np.linspace(-15, 15, 200)
+KX, KY = np.meshgrid(kx, ky)
+K2 = KX**2 + KY**2
+
+fig, axes = plt.subplots(1, 4, figsize=(16, 3.5))
+
+configs = [
+    (0.5, 1.0, 0.0, "Wave ($\\chi=0$)"),
+    (0.5, 1.0, 3.0, "KG ($\\chi=3$)"),
+    (0.5, 1.0, 8.0, "KG ($\\chi=8$)"),
+    (1.0, 1.0, 3.0, "KG ($T=1.0$)"),
+]
+
+for ax, (T_val, c_val, chi_val, title) in zip(axes, configs):
+    omega = np.sqrt(c_val**2 * K2 + chi_val**2)
+    H = np.cos(T_val * omega)
+    im = ax.imshow(
+        H,
+        extent=[kx[0], kx[-1], ky[0], ky[-1]],
+        cmap="RdBu_r",
+        vmin=-1,
+        vmax=1,
+        origin="lower",
+    )
+    ax.set_title(title, fontsize=10)
+    ax.set_xlabel("$k_x$")
+    ax.set_ylabel("$k_y$")
+
+fig.colorbar(im, ax=axes, shrink=0.8, label="$H(k)$")
+fig.suptitle("2D Klein-Gordon spectral filter in Fourier space", y=1.02)
+fig.show()
+
+# %%
+# .. raw:: html
+#
+#    <div style="margin-top: 3em;"></div>
+#
+# Parameter efficiency demonstration
+# -----------------------------------
+# We compare the number of learnable parameters between a standard
+# ``SpectralConv`` (unconstrained Fourier weights) and the
+# ``KGSpectralConv`` (physics-constrained).
+
+from neuralop.layers.spectral_convolution import SpectralConv
+
+in_ch = 16
+out_ch = 16
+print(f"{'Configuration':<35} {'SpectralConv':<18} {'KGSpectralConv':<18} {'Ratio':<8}")
+print("-" * 85)
+
+for label, modes in [
+    ("1D, modes=32", (32,)),
+    ("1D, modes=64", (64,)),
+    ("2D, modes=16x16", (16, 16)),
+    ("2D, modes=32x32", (32, 32)),
+    ("3D, modes=8x8x8", (8, 8, 8)),
+]:
+    fno = SpectralConv(in_ch, out_ch, modes)
+    kg = KGSpectralConv(in_ch, out_ch, modes)
+
+    n_fno = sum(p.numel() for p in fno.parameters())
+    n_kg = sum(p.numel() for p in kg.parameters())
+    ratio = n_fno / n_kg
+
+    print(f"{label:<35} {n_fno:<18,} {n_kg:<18,} {ratio:<8.1f}x")
+
+# %%
+# .. raw:: html
+#
+#    <div style="margin-top: 3em;"></div>
+#
+# Applying the KG filter to a signal
+# ------------------------------------
+# We apply the KG spectral conv to a 1D signal containing a Gaussian
+# pulse and show how different mass parameters affect the output.
+
+nx = 256
+x_grid = torch.linspace(0, 2 * np.pi, nx)
+signal = torch.exp(-20 * (x_grid - np.pi) ** 2).unsqueeze(0).unsqueeze(0)
+
+fig, ax = plt.subplots(figsize=(10, 4))
+ax.plot(x_grid.numpy(), signal[0, 0].numpy(), "k-", linewidth=2, label="Input")
+
+for chi_val in [0.1, 2.0, 5.0]:
+    layer = KGSpectralConv(
+        1, 1, n_modes=(32,), init_T=1.0, init_c=1.0, init_chi=chi_val, bias=False
+    )
+    with torch.no_grad():
+        layer.channel_weight.fill_(1.0)
+        out = layer(signal)
+    ax.plot(
+        x_grid.numpy(),
+        out[0, 0].detach().numpy(),
+        label=f"KG output ($\\chi={chi_val}$)",
+    )
+
+ax.set_xlabel("$x$")
+ax.set_ylabel("Amplitude")
+ax.set_title("Effect of KG spectral filter on a Gaussian pulse")
+ax.legend()
+plt.tight_layout()
+fig.show()
+
+# %%
+# .. raw:: html
+#
+#    <div style="margin-top: 3em;"></div>
+#
+# Summary
+# -------
+# The ``KGSpectralConv`` layer provides a physics-constrained alternative
+# to the unconstrained ``SpectralConv`` used in FNO. Key properties:
+#
+# - **Oscillatory bandpass**: Unlike diffusion-based (Gaussian) low-pass
+#   filters, the KG filter retains and modulates high-frequency modes.
+#
+# - **Mass gap**: The :math:`\chi` parameter creates a minimum oscillation
+#   frequency, providing built-in regularization.
+#
+# - **Parameter efficient**: 3 scalar parameters (T, c, chi) vs
+#   O(C_in * C_out * prod(modes)) for standard FNO.
+#
+# - **Physically interpretable**: Each parameter has a clear physical
+#   meaning tied to the Klein-Gordon dispersion relation.
+#
+# - **Matern kernel connection**: The Green's function of the KG equation
+#   is the Matern kernel family. The standard RBF kernel (used in SVMs
+#   and GPs) is the :math:`\nu \to \infty` limit (diffusion).

--- a/examples/layers/plot_kg_spectral_filter.py
+++ b/examples/layers/plot_kg_spectral_filter.py
@@ -105,9 +105,7 @@ ax.legend()
 ax.axhline(0, color="gray", linewidth=0.5)
 ax.set_ylim(-1.2, 1.2)
 
-fig.suptitle(
-    "Klein-Gordon spectral filter vs standard neural operator filters", y=1.02
-)
+fig.suptitle("Klein-Gordon spectral filter vs standard neural operator filters", y=1.02)
 plt.tight_layout()
 fig.show()
 

--- a/examples/models/benchmark_fno_vs_kg_fno.py
+++ b/examples/models/benchmark_fno_vs_kg_fno.py
@@ -1,0 +1,258 @@
+"""
+Benchmark: FNO vs KG-FNO on Klein-Gordon Equation
+==================================================
+
+Compares standard FNO (unconstrained SpectralConv) against KG-FNO
+(KGSpectralConv with physics-constrained filter) on the Klein-Gordon
+equation time-evolution task.
+
+Both models map u(x, t=0) -> u(x, t=T) for the 1D Klein-Gordon PDE:
+    d²u/dt² = c² d²u/dx² - m² u
+
+Metrics: relative L2 error, H1 loss, parameter count, training time.
+"""
+
+import time
+import json
+import torch
+import numpy as np
+from neuralop.models import FNO
+from neuralop.layers.kg_spectral_conv import KGSpectralConv
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+print(f"Device: {device}")
+
+# ── Data generation ─────────────────────────────────────────────────
+
+
+def solve_klein_gordon_1d(u0, nx, dx, dt, nt, c, m):
+    """Leapfrog solver for 1D Klein-Gordon equation."""
+    u = u0.clone()
+
+    def laplacian(v):
+        return (torch.roll(v, -1, 0) + torch.roll(v, 1, 0) - 2 * v) / dx**2
+
+    u_xx = laplacian(u)
+    u_prev = u + 0.5 * dt**2 * (c**2 * u_xx - m**2 * u)
+
+    for _ in range(nt):
+        u_xx = laplacian(u)
+        u_next = 2 * u - u_prev + dt**2 * (c**2 * u_xx - m**2 * u)
+        u_prev = u.clone()
+        u = u_next.clone()
+
+    return u
+
+
+def generate_dataset(n_samples, nx, mass, c=1.0, T=0.5, seed=0):
+    """Generate KG input-output pairs from random Fourier initial conditions."""
+    rng = np.random.RandomState(seed)
+    dx = 1.0 / nx
+    dt = 0.4 * dx / c  # CFL stable
+    nt = int(T / dt)
+
+    inputs = []
+    outputs = []
+
+    for _ in range(n_samples):
+        # Random superposition of Fourier modes
+        n_fourier = rng.randint(3, 10)
+        x = torch.linspace(0, 1, nx, device="cpu")
+        u0 = torch.zeros(nx)
+        for _ in range(n_fourier):
+            k = rng.randint(1, nx // 4)
+            amp = rng.randn() * 0.5
+            phase = rng.uniform(0, 2 * np.pi)
+            u0 += amp * torch.sin(2 * np.pi * k * x + phase)
+
+        # Normalize amplitude
+        u0 = u0 / (u0.abs().max() + 1e-8)
+
+        u_final = solve_klein_gordon_1d(u0, nx, dx, dt, nt, c, mass)
+        inputs.append(u0.unsqueeze(0))
+        outputs.append(u_final.unsqueeze(0))
+
+    return torch.stack(inputs), torch.stack(outputs)
+
+
+# ── Training loop ───────────────────────────────────────────────────
+
+
+def relative_l2(pred, target):
+    """Relative L2 error per sample, averaged."""
+    diff = (pred - target).flatten(1)
+    ref = target.flatten(1)
+    return (diff.norm(dim=1) / (ref.norm(dim=1) + 1e-8)).mean().item()
+
+
+def train_and_evaluate(
+    model, train_x, train_y, test_x, test_y, epochs=50, lr=1e-2, batch_size=32, label=""
+):
+    """Train model and return metrics dictionary."""
+    model = model.to(device)
+    n_params = sum(p.numel() for p in model.parameters())
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=1e-4)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
+
+    n_train = train_x.shape[0]
+    train_x_d = train_x.to(device)
+    train_y_d = train_y.to(device)
+    test_x_d = test_x.to(device)
+    test_y_d = test_y.to(device)
+
+    # Training
+    t0 = time.time()
+    model.train()
+    loss_history = []
+
+    for epoch in range(epochs):
+        perm = torch.randperm(n_train)
+        epoch_loss = 0.0
+        n_batches = 0
+        for i in range(0, n_train, batch_size):
+            idx = perm[i : i + batch_size]
+            bx = train_x_d[idx]
+            by = train_y_d[idx]
+
+            pred = model(bx)
+            loss = ((pred - by) ** 2).mean()
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            epoch_loss += loss.item()
+            n_batches += 1
+
+        scheduler.step()
+        avg_loss = epoch_loss / n_batches
+        loss_history.append(avg_loss)
+
+        if (epoch + 1) % 10 == 0 or epoch == 0:
+            print(f"  [{label}] Epoch {epoch+1:3d}/{epochs}  loss={avg_loss:.6f}")
+
+    train_time = time.time() - t0
+
+    # Evaluation
+    model.eval()
+    with torch.no_grad():
+        pred_test = model(test_x_d)
+        pred_train = model(train_x_d)
+
+    test_rl2 = relative_l2(pred_test, test_y_d)
+    train_rl2 = relative_l2(pred_train, train_y_d)
+
+    result = {
+        "label": label,
+        "n_params": n_params,
+        "train_time_s": round(train_time, 2),
+        "train_rel_l2": round(train_rl2, 6),
+        "test_rel_l2": round(test_rl2, 6),
+        "final_loss": round(loss_history[-1], 8),
+    }
+    return result
+
+
+# ── Main benchmark ──────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    # Configuration
+    nx = 64
+    n_train = 500
+    n_test = 100
+    hidden = 32
+    modes = 16
+    epochs = 80
+    lr = 1e-2
+
+    # Mass values: 0 (wave), 5 (moderate KG), 15 (heavy KG)
+    mass_values = [0.0, 5.0, 15.0]
+
+    all_results = []
+
+    for mass in mass_values:
+        print(f"\n{'='*60}")
+        print(f"  MASS = {mass}  (nx={nx}, {n_train} train, {n_test} test)")
+        print(f"{'='*60}")
+
+        train_x, train_y = generate_dataset(n_train, nx, mass, seed=42)
+        test_x, test_y = generate_dataset(n_test, nx, mass, seed=999)
+
+        # Standard FNO
+        fno = FNO(
+            n_modes=(modes,),
+            in_channels=1,
+            out_channels=1,
+            hidden_channels=hidden,
+            n_layers=4,
+        )
+        res_fno = train_and_evaluate(
+            fno,
+            train_x,
+            train_y,
+            test_x,
+            test_y,
+            epochs=epochs,
+            lr=lr,
+            label=f"FNO m={mass}",
+        )
+        res_fno["mass"] = mass
+        res_fno["model"] = "FNO"
+        all_results.append(res_fno)
+
+        # KG-FNO
+        fno_kg = FNO(
+            n_modes=(modes,),
+            in_channels=1,
+            out_channels=1,
+            hidden_channels=hidden,
+            n_layers=4,
+            conv_module=KGSpectralConv,
+        )
+        res_kg = train_and_evaluate(
+            fno_kg,
+            train_x,
+            train_y,
+            test_x,
+            test_y,
+            epochs=epochs,
+            lr=lr,
+            label=f"KG-FNO m={mass}",
+        )
+        res_kg["mass"] = mass
+        res_kg["model"] = "KG-FNO"
+        all_results.append(res_kg)
+
+        # Print comparison
+        print(f"\n  Results for mass={mass}:")
+        print(
+            f"  {'Model':<12} {'Params':>8} {'Train L2':>10} {'Test L2':>10} {'Time':>8}"
+        )
+        print(f"  {'-'*50}")
+        print(
+            f"  {'FNO':<12} {res_fno['n_params']:>8,} {res_fno['train_rel_l2']:>10.4%} {res_fno['test_rel_l2']:>10.4%} {res_fno['train_time_s']:>7.1f}s"
+        )
+        print(
+            f"  {'KG-FNO':<12} {res_kg['n_params']:>8,} {res_kg['train_rel_l2']:>10.4%} {res_kg['test_rel_l2']:>10.4%} {res_kg['train_time_s']:>7.1f}s"
+        )
+        ratio = res_fno["n_params"] / res_kg["n_params"]
+        print(f"  Parameter ratio: {ratio:.1f}x fewer in KG-FNO")
+
+    # Final summary
+    print(f"\n\n{'='*60}")
+    print(f"  FINAL SUMMARY")
+    print(f"{'='*60}")
+    print(
+        f"\n  {'Model':<12} {'Mass':>6} {'Params':>8} {'Train L2':>10} {'Test L2':>10} {'Time':>8}"
+    )
+    print(f"  {'-'*58}")
+    for r in all_results:
+        print(
+            f"  {r['model']:<12} {r['mass']:>6.0f} {r['n_params']:>8,} {r['train_rel_l2']:>10.4%} {r['test_rel_l2']:>10.4%} {r['train_time_s']:>7.1f}s"
+        )
+
+    # Save results
+    with open("benchmark_results.json", "w") as f:
+        json.dump(all_results, f, indent=2)
+    print("\nResults saved to benchmark_results.json")

--- a/neuralop/layers/kg_spectral_conv.py
+++ b/neuralop/layers/kg_spectral_conv.py
@@ -18,6 +18,8 @@ enough expressiveness for practical learning.
 Like the standard SpectralConv, this layer operates only on the
 first ``n_modes`` low-frequency modes and zeros out higher
 frequencies (the skip connection in FNOBlocks handles the residual).
+For multi-dimensional inputs, mode truncation uses centered frequency
+windows via ``fftshift`` (matching SpectralConv behavior).
 
 Mathematical background
 -----------------------
@@ -41,12 +43,14 @@ References
     Differential Equations" (2021). ICLR 2021.
 """
 
+import warnings
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import torch
 from torch import nn
 
+from ..utils import validate_scaling_factor
 from .base_spectral_conv import BaseSpectralConv
 
 Number = Union[int, float]
@@ -67,9 +71,9 @@ class KGSpectralConv(BaseSpectralConv):
 
     This is a drop-in replacement for
     :class:`~neuralop.layers.spectral_convolution.SpectralConv`. It
-    matches SpectralConv's mode-truncation behavior (operating only on
-    the first ``n_modes`` low-frequency modes) while using far fewer
-    parameters.
+    matches SpectralConv's mode-truncation behavior: centered frequency
+    windows via ``fftshift`` for multi-D inputs, rFFT-aware last-dimension
+    handling, and ``max_n_modes`` support for incremental training.
 
     Parameters
     ----------
@@ -79,6 +83,11 @@ class KGSpectralConv(BaseSpectralConv):
         Number of output channels.
     n_modes : int or tuple of int
         Number of Fourier modes to retain along each spatial dimension.
+        For real-valued data, the last dimension is automatically adjusted
+        to ``n // 2 + 1`` to match rFFT output size (same as SpectralConv).
+    max_n_modes : int or tuple of int or None, optional
+        Maximum number of modes for parameter allocation (for incremental
+        training). If None, uses ``n_modes``. Default: None.
     init_T : float, optional
         Initial propagation time. Default: 1.0.
     init_c : float, optional
@@ -91,6 +100,12 @@ class KGSpectralConv(BaseSpectralConv):
         If True, input is complex in the spatial domain. Default: False.
     fft_norm : str, optional
         FFT normalization mode. Default: ``'forward'``.
+    resolution_scaling_factor : float or list of float or None, optional
+        Resolution scaling for super-resolution workflows. Applied in
+        both ``transform()`` and ``forward()``. Default: None.
+    fno_block_precision : str or None, optional
+        Precision mode. Currently only ``'full'`` is supported; non-default
+        values emit a warning. Default: None.
     device : torch.device or None, optional
         Device for parameters. Default: None.
 
@@ -123,7 +138,7 @@ class KGSpectralConv(BaseSpectralConv):
         device=None,
         # Backward compat: ignored old arg
         per_channel=None,
-        # Accept (and ignore) FNOBlocks kwargs for drop-in compatibility
+        # FNOBlocks compatibility kwargs
         max_n_modes=None,
         rank=None,
         factorization=None,
@@ -142,18 +157,51 @@ class KGSpectralConv(BaseSpectralConv):
         self.out_channels = out_channels
         self.complex_data = complex_data
         self.fft_norm = fft_norm
+        self.fno_block_precision = fno_block_precision
 
         if isinstance(n_modes, int):
             n_modes = [n_modes]
-        self._n_modes = list(n_modes)
-        self.order = len(self._n_modes)
+        self.order = len(n_modes)
+
+        # n_modes setter adjusts last dim for rFFT (matches SpectralConv)
+        self.n_modes = n_modes
+
+        # max_n_modes for alpha allocation (matches SpectralConv pattern)
+        if max_n_modes is not None:
+            if isinstance(max_n_modes, int):
+                max_n_modes = [max_n_modes] * self.order
+            else:
+                max_n_modes = list(max_n_modes)
+            if not self.complex_data:
+                max_n_modes[-1] = max_n_modes[-1] // 2 + 1
+            self.max_n_modes = max_n_modes
+        else:
+            self.max_n_modes = list(self._n_modes)
+
+        # resolution_scaling_factor (matches SpectralConv)
+        self.resolution_scaling_factor: Union[
+            None, List[float]
+        ] = validate_scaling_factor(resolution_scaling_factor, self.order)
+
+        # Warn about unsupported precision modes
+        if fno_block_precision is not None and fno_block_precision != "full":
+            warnings.warn(
+                f"KGSpectralConv does not yet support fno_block_precision="
+                f"'{fno_block_precision}'. Falling back to full precision. "
+                f"For mixed/half precision, use SpectralConv.",
+                stacklevel=2,
+            )
 
         # Per-channel KG dispersion parameters (log-space for positivity)
         self.log_T = nn.Parameter(
-            torch.full((out_channels,), float(np.log(max(init_T, 1e-8))), device=device)
+            torch.full(
+                (out_channels,), float(np.log(max(init_T, 1e-8))), device=device
+            )
         )
         self.log_c = nn.Parameter(
-            torch.full((out_channels,), float(np.log(max(init_c, 1e-8))), device=device)
+            torch.full(
+                (out_channels,), float(np.log(max(init_c, 1e-8))), device=device
+            )
         )
         self.log_chi = nn.Parameter(
             torch.full(
@@ -161,8 +209,8 @@ class KGSpectralConv(BaseSpectralConv):
             )
         )
 
-        # Per-mode learnable complex amplitude: (out_channels, *n_modes)
-        alpha_shape = (out_channels, *self._n_modes)
+        # Per-mode learnable complex amplitude: (out_channels, *max_n_modes)
+        alpha_shape = (out_channels, *self.max_n_modes)
         self.alpha_real = nn.Parameter(torch.ones(alpha_shape, device=device))
         self.alpha_imag = nn.Parameter(torch.zeros(alpha_shape, device=device))
 
@@ -183,19 +231,34 @@ class KGSpectralConv(BaseSpectralConv):
     def transform(self, x, output_shape=None):
         """Transform input for skip connections (identity or resample).
 
+        Matches SpectralConv: when ``output_shape`` is not given, applies
+        ``resolution_scaling_factor`` if set.
+
         Parameters
         ----------
         x : torch.Tensor
             Input tensor.
         output_shape : tuple of int or None
-            Target spatial shape. If None or same as input, returns identity.
+            Target spatial shape.
         """
         in_shape = list(x.shape[2:])
-        if output_shape is None or list(output_shape) == in_shape:
+        if self.resolution_scaling_factor is not None and output_shape is None:
+            out_shape = tuple(
+                round(s * r)
+                for s, r in zip(in_shape, self.resolution_scaling_factor)
+            )
+        elif output_shape is not None:
+            out_shape = output_shape
+        else:
+            out_shape = tuple(in_shape)
+
+        if list(out_shape) == in_shape:
             return x
         from .resample import resample
 
-        return resample(x, 1.0, list(range(2, x.ndim)), output_shape=list(output_shape))
+        return resample(
+            x, 1.0, list(range(2, x.ndim)), output_shape=list(out_shape)
+        )
 
     @property
     def n_modes(self):
@@ -205,17 +268,29 @@ class KGSpectralConv(BaseSpectralConv):
     def n_modes(self, n_modes):
         if isinstance(n_modes, int):
             n_modes = [n_modes]
-        self._n_modes = list(n_modes)
+        else:
+            n_modes = list(n_modes)
+        # Match SpectralConv: auto-adjust last dim for rFFT redundancy
+        if not self.complex_data:
+            n_modes[-1] = n_modes[-1] // 2 + 1
+        self._n_modes = n_modes
 
-    def _compute_kg_filter(self, kept_sizes, spatial_sizes):
+    def _compute_kg_filter(self, kept_sizes, fft_sizes, spatial_sizes, shifted_dims):
         """Compute the KG spectral filter on the truncated frequency grid.
+
+        Builds correct wavenumber grids accounting for ``fftshift`` on
+        multi-D dims and non-shifted rFFT last dimension.
 
         Parameters
         ----------
         kept_sizes : list of int
-            Number of modes kept per dimension (after truncation).
+            Number of modes kept per dimension.
+        fft_sizes : list of int
+            Full FFT output sizes per dimension.
         spatial_sizes : list of int
             Full spatial dimensions of the input.
+        shifted_dims : set of int
+            Spatial dim indices (0-based) that were fftshift'd.
 
         Returns
         -------
@@ -226,33 +301,45 @@ class KGSpectralConv(BaseSpectralConv):
         c = torch.exp(self.log_c)
         chi = torch.exp(self.log_chi)
 
-        # Build wavenumber grid only for the kept low-frequency modes
         freq_components = []
-        for i, (kept, full_size) in enumerate(zip(kept_sizes, spatial_sizes)):
-            # Frequencies: 0, 2π/N, 2·2π/N, ..., (kept-1)·2π/N
-            freqs = torch.arange(kept, device=T.device, dtype=torch.float32)
-            freqs = freqs * (2 * np.pi / full_size)
+        for i, (kept, fft_sz, sp_sz) in enumerate(
+            zip(kept_sizes, fft_sizes, spatial_sizes)
+        ):
+            if i in shifted_dims:
+                # Centered window: frequencies symmetric around DC
+                freq_idx = torch.arange(kept, device=T.device, dtype=torch.float32)
+                freq_idx = freq_idx - (kept // 2)
+            else:
+                # Non-shifted (rFFT last dim): 0, 1, ..., kept-1
+                freq_idx = torch.arange(kept, device=T.device, dtype=torch.float32)
+            freqs = freq_idx * (2 * np.pi / sp_sz)
             freq_components.append(freqs)
 
         grids = torch.meshgrid(*freq_components, indexing="ij")
         k_squared = sum(g**2 for g in grids)  # |k|^2
 
-        # Reshape (out_channels,) -> (out_channels, 1, 1, ...)
         ndim = len(kept_sizes)
         shape = (-1,) + (1,) * ndim
         omega = torch.sqrt(
             c.view(shape) ** 2 * k_squared.unsqueeze(0) + chi.view(shape) ** 2
         )
 
-        # Complex propagator: exp(-i T omega)
         phase = -T.view(shape) * omega
         H = torch.complex(torch.cos(phase), torch.sin(phase))
 
-        # Modulate by per-mode learnable amplitude
+        # Slice alpha from max_n_modes to current kept_sizes
+        # (symmetric cropping matching SpectralConv for incremental training)
         alpha = torch.complex(self.alpha_real, self.alpha_imag)
-        # Truncate alpha to match actual kept sizes (may differ from n_modes)
-        slices = tuple(slice(0, k) for k in kept_sizes)
-        alpha_trunc = alpha[(slice(None),) + slices]
+        starts = [
+            max_nm - kept for max_nm, kept in zip(self.max_n_modes, kept_sizes)
+        ]
+        alpha_slices = [slice(None)]  # out_channels dim
+        for s in starts:
+            if s:
+                alpha_slices.append(slice(s // 2, -s // 2))
+            else:
+                alpha_slices.append(slice(None))
+        alpha_trunc = alpha[tuple(alpha_slices)]
         H = alpha_trunc * H
 
         return H
@@ -279,8 +366,9 @@ class KGSpectralConv(BaseSpectralConv):
     ) -> torch.Tensor:
         """Apply the Klein-Gordon spectral filter.
 
-        Matches SpectralConv behavior: operates only on the first
-        ``n_modes`` low-frequency modes and zeros out higher frequencies.
+        Matches SpectralConv mode-truncation: uses centered frequency
+        windows via ``fftshift`` for multi-D inputs, and rFFT-aware
+        last-dimension handling.
 
         Parameters
         ----------
@@ -300,13 +388,26 @@ class KGSpectralConv(BaseSpectralConv):
         # Forward FFT
         if self.complex_data:
             x_hat = torch.fft.fftn(x, norm=self.fft_norm, dim=fft_dims)
+            dims_to_shift = fft_dims
         else:
             x_hat = torch.fft.rfftn(x, norm=self.fft_norm, dim=fft_dims)
+            dims_to_shift = fft_dims[:-1]  # Skip last dim (rFFT)
+
+        # fftshift for centered mode selection (2D+)
+        if self.order > 1 and len(dims_to_shift) > 0:
+            x_hat = torch.fft.fftshift(x_hat, dim=dims_to_shift)
 
         fft_sizes = list(x_hat.shape[2:])
 
-        # Allocate output at full FFT resolution, initialized to zeros
-        # (high-frequency modes stay zero — same as SpectralConv)
+        # Track which spatial dims (0-indexed) were shifted
+        shifted_dims = set()
+        if self.order > 1:
+            if self.complex_data:
+                shifted_dims = set(range(self.order))
+            else:
+                shifted_dims = set(range(self.order - 1))
+
+        # Allocate zero-padded output in Fourier space
         out_hat = torch.zeros(
             batchsize,
             self.out_channels,
@@ -315,32 +416,61 @@ class KGSpectralConv(BaseSpectralConv):
             dtype=torch.cfloat,
         )
 
-        # Determine how many modes to keep per dimension
+        # Mode truncation
         kept_sizes = [min(nm, fs) for nm, fs in zip(self._n_modes, fft_sizes)]
-        mode_slices = tuple(slice(0, k) for k in kept_sizes)
-        full_slices = (slice(None), slice(None)) + mode_slices
+
+        # Build slices: centered window for shifted dims, low-freq for others
+        mode_slices = []
+        for i, (kept, fft_sz) in enumerate(zip(kept_sizes, fft_sizes)):
+            if i in shifted_dims:
+                center = fft_sz // 2
+                neg = kept // 2
+                pos = kept // 2 + kept % 2
+                mode_slices.append(slice(center - neg, center + pos))
+            else:
+                mode_slices.append(slice(0, kept))
+
+        full_slices = tuple([slice(None), slice(None)] + mode_slices)
 
         # Extract low-frequency modes from input
-        x_low = x_hat[full_slices]  # (B, C_in, *kept_sizes)
+        x_low = x_hat[full_slices]
 
         # Channel mixing: (B, C_in, *k) @ (C_in, C_out) -> (B, C_out, *k)
         w = self.channel_weight.to(x_low.dtype)
         out_low = torch.einsum("bi...,io->bo...", x_low, w)
 
         # Compute and apply KG spectral filter (complex, per-channel)
-        H = self._compute_kg_filter(kept_sizes, spatial_sizes)
+        H = self._compute_kg_filter(
+            kept_sizes, fft_sizes, spatial_sizes, shifted_dims
+        )
         out_low = out_low * H.unsqueeze(0)  # broadcast over batch
 
         # Place back into zero-padded output
-        out_slices = (slice(None), slice(None)) + mode_slices
-        out_hat[out_slices] = out_low
+        out_hat[full_slices] = out_low
+
+        # ifftshift before inverse FFT
+        if self.order > 1 and len(dims_to_shift) > 0:
+            out_hat = torch.fft.ifftshift(out_hat, dim=dims_to_shift)
+
+        # Determine output size
+        out_sizes = list(spatial_sizes)
+        if self.resolution_scaling_factor is not None and output_shape is None:
+            out_sizes = [
+                round(s * r)
+                for s, r in zip(out_sizes, self.resolution_scaling_factor)
+            ]
+        if output_shape is not None:
+            out_sizes = list(output_shape)
 
         # Inverse FFT
-        out_sizes = output_shape if output_shape is not None else spatial_sizes
         if self.complex_data:
-            x = torch.fft.ifftn(out_hat, s=out_sizes, dim=fft_dims, norm=self.fft_norm)
+            x = torch.fft.ifftn(
+                out_hat, s=out_sizes, dim=fft_dims, norm=self.fft_norm
+            )
         else:
-            x = torch.fft.irfftn(out_hat, s=out_sizes, dim=fft_dims, norm=self.fft_norm)
+            x = torch.fft.irfftn(
+                out_hat, s=out_sizes, dim=fft_dims, norm=self.fft_norm
+            )
 
         if self.bias is not None:
             x = x + self.bias
@@ -353,7 +483,7 @@ class KGSpectralConv(BaseSpectralConv):
         chi = torch.exp(self.log_chi).detach()
         return (
             f"in_channels={self.in_channels}, out_channels={self.out_channels}, "
-            f"n_modes={self._n_modes}, "
+            f"n_modes={self._n_modes}, max_n_modes={self.max_n_modes}, "
             f"T_range=[{T.min().item():.3g}, {T.max().item():.3g}], "
             f"c_range=[{c.min().item():.3g}, {c.max().item():.3g}], "
             f"chi_range=[{chi.min().item():.3g}, {chi.max().item():.3g}], "

--- a/neuralop/layers/kg_spectral_conv.py
+++ b/neuralop/layers/kg_spectral_conv.py
@@ -1,0 +1,323 @@
+"""Klein-Gordon Spectral Convolution Layer
+
+A physics-constrained spectral convolution layer that encodes the
+Klein-Gordon dispersion relation as a learnable spectral filter.
+
+Instead of learning arbitrary complex weights in Fourier space
+(as in the standard FNO SpectralConv), this layer uses the exact
+solution operator of the Klein-Gordon equation:
+
+    H(k) = cos(T * sqrt(c^2 |k|^2 + chi^2))
+
+with only 3 learnable scalar parameters (T, c, chi), plus a linear
+channel mixing matrix. This makes it dramatically more
+parameter-efficient for wave-type (hyperbolic) PDEs.
+
+Mathematical background
+-----------------------
+The Klein-Gordon equation d^2u/dt^2 = c^2 nabla^2 u - chi^2 u has
+the dispersion relation omega^2 = c^2 |k|^2 + chi^2. Its Green's
+function in d dimensions is the Matern kernel family [1]_:
+
+- Matern(nu=0.5) = exp(-r/l)            ... 1D KG Green's function
+- Matern(nu=1.5) = (1+sqrt(3)r/l)e^(-sqrt(3)r/l)  ... 3D KG
+- Matern(nu -> inf) = exp(-r^2/2l^2)    ... RBF (diffusion limit)
+
+The standard RBF kernel used in SVMs and GPs is the diffusion
+(infinite smoothness) limit. The KG filter offers finite-smoothness
+alternatives motivated by wave physics.
+
+References
+----------
+.. [1] Whittle, P. "On stationary processes in the plane" (1954).
+    Biometrika, 41(3-4), 434-449.
+
+.. [2] Rasmussen, C.E. & Williams, C.K.I. "Gaussian Processes for
+    Machine Learning" (2006). MIT Press. Chapter 4.
+
+.. [3] Li, Z. et al. "Fourier Neural Operator for Parametric Partial
+    Differential Equations" (2021). ICLR 2021.
+"""
+
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+from torch import nn
+
+from .base_spectral_conv import BaseSpectralConv
+
+Number = Union[int, float]
+
+
+class KGSpectralConv(BaseSpectralConv):
+    """Klein-Gordon Spectral Convolution
+
+    Applies a physics-constrained spectral filter based on the Klein-Gordon
+    dispersion relation: ``H(k) = cos(T * sqrt(c^2 |k|^2 + chi^2))``.
+
+    This layer is a drop-in alternative to
+    :class:`~neuralop.layers.spectral_convolution.SpectralConv` for
+    wave-type PDEs. It trades the FNO's unconstrained Fourier weights
+    (O(C_in * C_out * prod(n_modes)) parameters) for a physics-constrained
+    filter with only 3 scalar parameters plus a channel mixing matrix
+    (O(C_in * C_out + 3) parameters).
+
+    Parameters
+    ----------
+    in_channels : int
+        Number of input channels.
+    out_channels : int
+        Number of output channels.
+    n_modes : int or tuple of int
+        Number of Fourier modes to retain along each spatial dimension.
+        For real-valued data, the last dimension is automatically adjusted
+        for the real FFT redundancy.
+    init_T : float, optional
+        Initial propagation time parameter. Default: 1.0.
+    init_c : float, optional
+        Initial wave speed parameter. Default: 1.0.
+    init_chi : float, optional
+        Initial mass/dispersion parameter. Default: 0.1.
+    per_channel : bool, optional
+        If True, learn separate (T, c, chi) per output channel.
+        Default: False (shared across channels).
+    bias : bool, optional
+        If True, add a learnable bias term. Default: True.
+    complex_data : bool, optional
+        If True, input data is complex-valued in the spatial domain.
+        Default: False.
+    fft_norm : str, optional
+        Normalization mode for FFT. Default: ``'forward'``.
+    device : torch.device or None, optional
+        Device for parameters. Default: None.
+
+    Notes
+    -----
+    **When to use this layer:**
+
+    - The underlying PDE is hyperbolic (wave equation, Klein-Gordon,
+      Maxwell's equations, linearized Euler)
+    - Training data is limited and you need parameter efficiency
+    - You want a physically interpretable spectral filter
+
+    **When to prefer standard SpectralConv:**
+
+    - The PDE is parabolic (diffusion, heat equation)
+    - You have abundant training data
+    - Maximum expressiveness is more important than parameter efficiency
+
+    **Dispersion relation limits:**
+
+    - chi = 0: reduces to the wave equation filter cos(T c |k|)
+    - T = 0: identity operator (no time evolution)
+    - c -> 0: uniform damping cos(T chi) independent of k
+
+    Examples
+    --------
+    >>> layer = KGSpectralConv(in_channels=3, out_channels=3, n_modes=(16,))
+    >>> x = torch.randn(4, 3, 64)   # batch=4, channels=3, nx=64
+    >>> y = layer(x)
+    >>> y.shape
+    torch.Size([4, 3, 64])
+
+    >>> # 2D case
+    >>> layer_2d = KGSpectralConv(in_channels=1, out_channels=1, n_modes=(16, 16))
+    >>> x2d = torch.randn(2, 1, 64, 64)
+    >>> y2d = layer_2d(x2d)
+    >>> y2d.shape
+    torch.Size([2, 1, 64, 64])
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        n_modes: Union[int, Tuple[int, ...]],
+        init_T: float = 1.0,
+        init_c: float = 1.0,
+        init_chi: float = 0.1,
+        per_channel: bool = False,
+        bias: bool = True,
+        complex_data: bool = False,
+        fft_norm: str = "forward",
+        device=None,
+    ):
+        super().__init__(device=device)
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.complex_data = complex_data
+        self.fft_norm = fft_norm
+
+        if isinstance(n_modes, int):
+            n_modes = [n_modes]
+        self._n_modes = list(n_modes)
+        self.order = len(self._n_modes)
+
+        # KG dispersion parameters (learnable, stored in log-space for positivity)
+        param_shape = (out_channels,) if per_channel else (1,)
+        self.log_T = nn.Parameter(
+            torch.full(param_shape, float(np.log(max(init_T, 1e-8))), device=device)
+        )
+        self.log_c = nn.Parameter(
+            torch.full(param_shape, float(np.log(max(init_c, 1e-8))), device=device)
+        )
+        self.log_chi = nn.Parameter(
+            torch.full(param_shape, float(np.log(max(init_chi, 1e-8))), device=device)
+        )
+
+        # Channel mixing weights
+        init_std = (2 / (in_channels + out_channels)) ** 0.5
+        self.channel_weight = nn.Parameter(
+            init_std * torch.randn(in_channels, out_channels, device=device)
+        )
+
+        if bias:
+            self.bias = nn.Parameter(
+                init_std
+                * torch.randn(
+                    *((out_channels,) + (1,) * self.order), device=device
+                )
+            )
+        else:
+            self.bias = None
+
+    @property
+    def n_modes(self):
+        return self._n_modes
+
+    @n_modes.setter
+    def n_modes(self, n_modes):
+        if isinstance(n_modes, int):
+            n_modes = [n_modes]
+        self._n_modes = list(n_modes)
+
+    def _compute_kg_filter(self, spatial_sizes):
+        """Compute the KG spectral filter H(k) on the FFT frequency grid.
+
+        Parameters
+        ----------
+        spatial_sizes : list of int
+            Spatial dimensions of the input (e.g. [nx] or [nx, ny]).
+
+        Returns
+        -------
+        H : torch.Tensor
+            Real-valued spectral filter of shape
+            ``(out_channels or 1, k1, k2, ...)``.
+        """
+        T = torch.exp(self.log_T)
+        c = torch.exp(self.log_c)
+        chi = torch.exp(self.log_chi)
+
+        # Build wavenumber grid
+        freq_components = []
+        for i, size in enumerate(spatial_sizes):
+            if i == len(spatial_sizes) - 1 and not self.complex_data:
+                freqs = torch.fft.rfftfreq(size, device=T.device) * 2 * np.pi
+            else:
+                freqs = torch.fft.fftfreq(size, device=T.device) * 2 * np.pi
+            freq_components.append(freqs)
+
+        grids = torch.meshgrid(*freq_components, indexing="ij")
+        k_squared = sum(g**2 for g in grids)  # |k|^2
+
+        # Reshape parameters for broadcasting: (channels, 1, 1, ...)
+        ndim = len(spatial_sizes)
+        shape = (-1,) + (1,) * ndim
+        c_sq = c.view(shape) ** 2
+        chi_sq = chi.view(shape) ** 2
+        T_val = T.view(shape)
+
+        # omega(k) = sqrt(c^2 |k|^2 + chi^2)
+        omega = torch.sqrt(c_sq * k_squared.unsqueeze(0) + chi_sq)
+
+        # H(k) = cos(T * omega(k))
+        H = torch.cos(T_val * omega)
+
+        return H
+
+    @property
+    def n_kernel_params(self):
+        """Number of learnable parameters in the spectral filter (T, c, chi)."""
+        return self.log_T.numel() + self.log_c.numel() + self.log_chi.numel()
+
+    @property
+    def n_total_params(self):
+        """Total learnable parameters including channel mixing and bias."""
+        total = self.n_kernel_params + self.channel_weight.numel()
+        if self.bias is not None:
+            total += self.bias.numel()
+        return total
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        output_shape: Optional[Tuple[int, ...]] = None,
+    ) -> torch.Tensor:
+        """Apply the Klein-Gordon spectral filter.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of shape ``(batch, in_channels, n1, ..., nd)``.
+        output_shape : tuple of int or None, optional
+            If provided, the output spatial dimensions will be resized
+            to this shape via the inverse FFT. Default: None (same size
+            as input).
+
+        Returns
+        -------
+        torch.Tensor
+            Output tensor of shape ``(batch, out_channels, n1, ..., nd)``
+            (or ``output_shape`` if provided).
+        """
+        batchsize, channels, *mode_sizes = x.shape
+        fft_dims = list(range(-self.order, 0))
+
+        # Forward FFT
+        if self.complex_data:
+            x_hat = torch.fft.fftn(x, norm=self.fft_norm, dim=fft_dims)
+        else:
+            x_hat = torch.fft.rfftn(x, norm=self.fft_norm, dim=fft_dims)
+
+        # Channel mixing: (batch, in_ch, k...) -> (batch, out_ch, k...)
+        # Cast weight to match x_hat dtype (real -> complex is fine)
+        w = self.channel_weight.to(x_hat.dtype)
+        out_hat = torch.einsum("bi...,io->bo...", x_hat, w)
+
+        # Apply KG spectral filter (real-valued, broadcasts over batch)
+        H = self._compute_kg_filter(mode_sizes)
+        out_hat = out_hat * H.unsqueeze(0).to(out_hat.dtype)
+
+        # Inverse FFT
+        out_sizes = output_shape if output_shape is not None else mode_sizes
+        if self.complex_data:
+            x = torch.fft.ifftn(
+                out_hat, s=out_sizes, dim=fft_dims, norm=self.fft_norm
+            )
+        else:
+            x = torch.fft.irfftn(
+                out_hat, s=out_sizes, dim=fft_dims, norm=self.fft_norm
+            )
+
+        if self.bias is not None:
+            x = x + self.bias
+
+        return x
+
+    def extra_repr(self) -> str:
+        T = torch.exp(self.log_T).detach()
+        c = torch.exp(self.log_c).detach()
+        chi = torch.exp(self.log_chi).detach()
+        T_str = f"{T.item():.4g}" if T.numel() == 1 else str(T.tolist())
+        c_str = f"{c.item():.4g}" if c.numel() == 1 else str(c.tolist())
+        chi_str = f"{chi.item():.4g}" if chi.numel() == 1 else str(chi.tolist())
+        return (
+            f"in_channels={self.in_channels}, out_channels={self.out_channels}, "
+            f"n_modes={self._n_modes}, "
+            f"T={T_str}, c={c_str}, chi={chi_str}, "
+            f"kernel_params={self.n_kernel_params}, "
+            f"total_params={self.n_total_params}"
+        )

--- a/neuralop/layers/kg_spectral_conv.py
+++ b/neuralop/layers/kg_spectral_conv.py
@@ -4,14 +4,20 @@ A physics-constrained spectral convolution layer that encodes the
 Klein-Gordon dispersion relation as a learnable spectral filter.
 
 Instead of learning arbitrary complex weights in Fourier space
-(as in the standard FNO SpectralConv), this layer uses the exact
-solution operator of the Klein-Gordon equation:
+(as in the standard FNO SpectralConv), this layer parameterizes the
+spectral filter via the exact solution operator of the Klein-Gordon
+equation:
 
-    H(k) = cos(T * sqrt(c^2 |k|^2 + chi^2))
+    H(k) = exp(-i T sqrt(c^2 |k|^2 + chi^2))
 
-with only 3 learnable scalar parameters (T, c, chi), plus a linear
-channel mixing matrix. This makes it dramatically more
-parameter-efficient for wave-type (hyperbolic) PDEs.
+with per-channel learnable (T, c, chi) parameters, plus per-mode
+learnable amplitude weights. This makes it dramatically more
+parameter-efficient for wave-type (hyperbolic) PDEs while retaining
+enough expressiveness for practical learning.
+
+Like the standard SpectralConv, this layer operates only on the
+first ``n_modes`` low-frequency modes and zeros out higher
+frequencies (the skip connection in FNOBlocks handles the residual).
 
 Mathematical background
 -----------------------
@@ -22,10 +28,6 @@ function in d dimensions is the Matern kernel family [1]_:
 - Matern(nu=0.5) = exp(-r/l)            ... 1D KG Green's function
 - Matern(nu=1.5) = (1+sqrt(3)r/l)e^(-sqrt(3)r/l)  ... 3D KG
 - Matern(nu -> inf) = exp(-r^2/2l^2)    ... RBF (diffusion limit)
-
-The standard RBF kernel used in SVMs and GPs is the diffusion
-(infinite smoothness) limit. The KG filter offers finite-smoothness
-alternatives motivated by wave physics.
 
 References
 ----------
@@ -54,14 +56,20 @@ class KGSpectralConv(BaseSpectralConv):
     """Klein-Gordon Spectral Convolution
 
     Applies a physics-constrained spectral filter based on the Klein-Gordon
-    dispersion relation: ``H(k) = cos(T * sqrt(c^2 |k|^2 + chi^2))``.
+    dispersion relation, with per-mode learnable amplitudes.
 
-    This layer is a drop-in alternative to
-    :class:`~neuralop.layers.spectral_convolution.SpectralConv` for
-    wave-type PDEs. It trades the FNO's unconstrained Fourier weights
-    (O(C_in * C_out * prod(n_modes)) parameters) for a physics-constrained
-    filter with only 3 scalar parameters plus a channel mixing matrix
-    (O(C_in * C_out + 3) parameters).
+    The spectral weight for output channel ``o`` at wavenumber ``k`` is::
+
+        W_o(k) = alpha_o(k) * exp(-i T_o sqrt(c_o^2 |k|^2 + chi_o^2))
+
+    where ``alpha_o(k)`` is a learnable complex amplitude per mode, and
+    ``(T_o, c_o, chi_o)`` are per-channel dispersion parameters.
+
+    This is a drop-in replacement for
+    :class:`~neuralop.layers.spectral_convolution.SpectralConv`. It
+    matches SpectralConv's mode-truncation behavior (operating only on
+    the first ``n_modes`` low-frequency modes) while using far fewer
+    parameters.
 
     Parameters
     ----------
@@ -71,57 +79,29 @@ class KGSpectralConv(BaseSpectralConv):
         Number of output channels.
     n_modes : int or tuple of int
         Number of Fourier modes to retain along each spatial dimension.
-        For real-valued data, the last dimension is automatically adjusted
-        for the real FFT redundancy.
     init_T : float, optional
-        Initial propagation time parameter. Default: 1.0.
+        Initial propagation time. Default: 1.0.
     init_c : float, optional
-        Initial wave speed parameter. Default: 1.0.
+        Initial wave speed. Default: 1.0.
     init_chi : float, optional
-        Initial mass/dispersion parameter. Default: 0.1.
-    per_channel : bool, optional
-        If True, learn separate (T, c, chi) per output channel.
-        Default: False (shared across channels).
+        Initial mass/dispersion. Default: 0.1.
     bias : bool, optional
-        If True, add a learnable bias term. Default: True.
+        If True, add a learnable bias. Default: True.
     complex_data : bool, optional
-        If True, input data is complex-valued in the spatial domain.
-        Default: False.
+        If True, input is complex in the spatial domain. Default: False.
     fft_norm : str, optional
-        Normalization mode for FFT. Default: ``'forward'``.
+        FFT normalization mode. Default: ``'forward'``.
     device : torch.device or None, optional
         Device for parameters. Default: None.
-
-    Notes
-    -----
-    **When to use this layer:**
-
-    - The underlying PDE is hyperbolic (wave equation, Klein-Gordon,
-      Maxwell's equations, linearized Euler)
-    - Training data is limited and you need parameter efficiency
-    - You want a physically interpretable spectral filter
-
-    **When to prefer standard SpectralConv:**
-
-    - The PDE is parabolic (diffusion, heat equation)
-    - You have abundant training data
-    - Maximum expressiveness is more important than parameter efficiency
-
-    **Dispersion relation limits:**
-
-    - chi = 0: reduces to the wave equation filter cos(T c |k|)
-    - T = 0: identity operator (no time evolution)
-    - c -> 0: uniform damping cos(T chi) independent of k
 
     Examples
     --------
     >>> layer = KGSpectralConv(in_channels=3, out_channels=3, n_modes=(16,))
-    >>> x = torch.randn(4, 3, 64)   # batch=4, channels=3, nx=64
+    >>> x = torch.randn(4, 3, 64)
     >>> y = layer(x)
     >>> y.shape
     torch.Size([4, 3, 64])
 
-    >>> # 2D case
     >>> layer_2d = KGSpectralConv(in_channels=1, out_channels=1, n_modes=(16, 16))
     >>> x2d = torch.randn(2, 1, 64, 64)
     >>> y2d = layer_2d(x2d)
@@ -137,11 +117,24 @@ class KGSpectralConv(BaseSpectralConv):
         init_T: float = 1.0,
         init_c: float = 1.0,
         init_chi: float = 0.1,
-        per_channel: bool = False,
         bias: bool = True,
         complex_data: bool = False,
         fft_norm: str = "forward",
         device=None,
+        # Backward compat: ignored old arg
+        per_channel=None,
+        # Accept (and ignore) FNOBlocks kwargs for drop-in compatibility
+        max_n_modes=None,
+        rank=None,
+        factorization=None,
+        implementation=None,
+        separable=None,
+        resolution_scaling_factor=None,
+        fno_block_precision=None,
+        fixed_rank_modes=None,
+        decomposition_kwargs=None,
+        init_std=None,
+        **kwargs,
     ):
         super().__init__(device=device)
 
@@ -155,33 +148,54 @@ class KGSpectralConv(BaseSpectralConv):
         self._n_modes = list(n_modes)
         self.order = len(self._n_modes)
 
-        # KG dispersion parameters (learnable, stored in log-space for positivity)
-        param_shape = (out_channels,) if per_channel else (1,)
+        # Per-channel KG dispersion parameters (log-space for positivity)
         self.log_T = nn.Parameter(
-            torch.full(param_shape, float(np.log(max(init_T, 1e-8))), device=device)
+            torch.full((out_channels,), float(np.log(max(init_T, 1e-8))), device=device)
         )
         self.log_c = nn.Parameter(
-            torch.full(param_shape, float(np.log(max(init_c, 1e-8))), device=device)
+            torch.full((out_channels,), float(np.log(max(init_c, 1e-8))), device=device)
         )
         self.log_chi = nn.Parameter(
-            torch.full(param_shape, float(np.log(max(init_chi, 1e-8))), device=device)
+            torch.full(
+                (out_channels,), float(np.log(max(init_chi, 1e-8))), device=device
+            )
         )
 
-        # Channel mixing weights
-        init_std = (2 / (in_channels + out_channels)) ** 0.5
+        # Per-mode learnable complex amplitude: (out_channels, *n_modes)
+        alpha_shape = (out_channels, *self._n_modes)
+        self.alpha_real = nn.Parameter(torch.ones(alpha_shape, device=device))
+        self.alpha_imag = nn.Parameter(torch.zeros(alpha_shape, device=device))
+
+        # Channel mixing (mode-independent): (in_channels, out_channels)
+        fan_std = (2 / (in_channels + out_channels)) ** 0.5
         self.channel_weight = nn.Parameter(
-            init_std * torch.randn(in_channels, out_channels, device=device)
+            fan_std * torch.randn(in_channels, out_channels, device=device)
         )
 
         if bias:
             self.bias = nn.Parameter(
-                init_std
-                * torch.randn(
-                    *((out_channels,) + (1,) * self.order), device=device
-                )
+                fan_std
+                * torch.randn(*((out_channels,) + (1,) * self.order), device=device)
             )
         else:
             self.bias = None
+
+    def transform(self, x, output_shape=None):
+        """Transform input for skip connections (identity or resample).
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor.
+        output_shape : tuple of int or None
+            Target spatial shape. If None or same as input, returns identity.
+        """
+        in_shape = list(x.shape[2:])
+        if output_shape is None or list(output_shape) == in_shape:
+            return x
+        from .resample import resample
+
+        return resample(x, 1.0, list(range(2, x.ndim)), output_shape=list(output_shape))
 
     @property
     def n_modes(self):
@@ -193,55 +207,62 @@ class KGSpectralConv(BaseSpectralConv):
             n_modes = [n_modes]
         self._n_modes = list(n_modes)
 
-    def _compute_kg_filter(self, spatial_sizes):
-        """Compute the KG spectral filter H(k) on the FFT frequency grid.
+    def _compute_kg_filter(self, kept_sizes, spatial_sizes):
+        """Compute the KG spectral filter on the truncated frequency grid.
 
         Parameters
         ----------
+        kept_sizes : list of int
+            Number of modes kept per dimension (after truncation).
         spatial_sizes : list of int
-            Spatial dimensions of the input (e.g. [nx] or [nx, ny]).
+            Full spatial dimensions of the input.
 
         Returns
         -------
         H : torch.Tensor
-            Real-valued spectral filter of shape
-            ``(out_channels or 1, k1, k2, ...)``.
+            Complex spectral filter of shape ``(out_channels, *kept_sizes)``.
         """
         T = torch.exp(self.log_T)
         c = torch.exp(self.log_c)
         chi = torch.exp(self.log_chi)
 
-        # Build wavenumber grid
+        # Build wavenumber grid only for the kept low-frequency modes
         freq_components = []
-        for i, size in enumerate(spatial_sizes):
-            if i == len(spatial_sizes) - 1 and not self.complex_data:
-                freqs = torch.fft.rfftfreq(size, device=T.device) * 2 * np.pi
-            else:
-                freqs = torch.fft.fftfreq(size, device=T.device) * 2 * np.pi
+        for i, (kept, full_size) in enumerate(zip(kept_sizes, spatial_sizes)):
+            # Frequencies: 0, 2π/N, 2·2π/N, ..., (kept-1)·2π/N
+            freqs = torch.arange(kept, device=T.device, dtype=torch.float32)
+            freqs = freqs * (2 * np.pi / full_size)
             freq_components.append(freqs)
 
         grids = torch.meshgrid(*freq_components, indexing="ij")
         k_squared = sum(g**2 for g in grids)  # |k|^2
 
-        # Reshape parameters for broadcasting: (channels, 1, 1, ...)
-        ndim = len(spatial_sizes)
+        # Reshape (out_channels,) -> (out_channels, 1, 1, ...)
+        ndim = len(kept_sizes)
         shape = (-1,) + (1,) * ndim
-        c_sq = c.view(shape) ** 2
-        chi_sq = chi.view(shape) ** 2
-        T_val = T.view(shape)
+        omega = torch.sqrt(
+            c.view(shape) ** 2 * k_squared.unsqueeze(0) + chi.view(shape) ** 2
+        )
 
-        # omega(k) = sqrt(c^2 |k|^2 + chi^2)
-        omega = torch.sqrt(c_sq * k_squared.unsqueeze(0) + chi_sq)
+        # Complex propagator: exp(-i T omega)
+        phase = -T.view(shape) * omega
+        H = torch.complex(torch.cos(phase), torch.sin(phase))
 
-        # H(k) = cos(T * omega(k))
-        H = torch.cos(T_val * omega)
+        # Modulate by per-mode learnable amplitude
+        alpha = torch.complex(self.alpha_real, self.alpha_imag)
+        # Truncate alpha to match actual kept sizes (may differ from n_modes)
+        slices = tuple(slice(0, k) for k in kept_sizes)
+        alpha_trunc = alpha[(slice(None),) + slices]
+        H = alpha_trunc * H
 
         return H
 
     @property
     def n_kernel_params(self):
-        """Number of learnable parameters in the spectral filter (T, c, chi)."""
-        return self.log_T.numel() + self.log_c.numel() + self.log_chi.numel()
+        """Number of learnable parameters in the spectral kernel."""
+        n_kg = self.log_T.numel() + self.log_c.numel() + self.log_chi.numel()
+        n_alpha = self.alpha_real.numel() + self.alpha_imag.numel()
+        return n_kg + n_alpha
 
     @property
     def n_total_params(self):
@@ -258,22 +279,22 @@ class KGSpectralConv(BaseSpectralConv):
     ) -> torch.Tensor:
         """Apply the Klein-Gordon spectral filter.
 
+        Matches SpectralConv behavior: operates only on the first
+        ``n_modes`` low-frequency modes and zeros out higher frequencies.
+
         Parameters
         ----------
         x : torch.Tensor
-            Input tensor of shape ``(batch, in_channels, n1, ..., nd)``.
+            Input of shape ``(batch, in_channels, n1, ..., nd)``.
         output_shape : tuple of int or None, optional
-            If provided, the output spatial dimensions will be resized
-            to this shape via the inverse FFT. Default: None (same size
-            as input).
+            Target spatial dimensions for the output.
 
         Returns
         -------
         torch.Tensor
-            Output tensor of shape ``(batch, out_channels, n1, ..., nd)``
-            (or ``output_shape`` if provided).
+            Output of shape ``(batch, out_channels, n1, ..., nd)``.
         """
-        batchsize, channels, *mode_sizes = x.shape
+        batchsize, channels, *spatial_sizes = x.shape
         fft_dims = list(range(-self.order, 0))
 
         # Forward FFT
@@ -282,25 +303,44 @@ class KGSpectralConv(BaseSpectralConv):
         else:
             x_hat = torch.fft.rfftn(x, norm=self.fft_norm, dim=fft_dims)
 
-        # Channel mixing: (batch, in_ch, k...) -> (batch, out_ch, k...)
-        # Cast weight to match x_hat dtype (real -> complex is fine)
-        w = self.channel_weight.to(x_hat.dtype)
-        out_hat = torch.einsum("bi...,io->bo...", x_hat, w)
+        fft_sizes = list(x_hat.shape[2:])
 
-        # Apply KG spectral filter (real-valued, broadcasts over batch)
-        H = self._compute_kg_filter(mode_sizes)
-        out_hat = out_hat * H.unsqueeze(0).to(out_hat.dtype)
+        # Allocate output at full FFT resolution, initialized to zeros
+        # (high-frequency modes stay zero — same as SpectralConv)
+        out_hat = torch.zeros(
+            batchsize,
+            self.out_channels,
+            *fft_sizes,
+            device=x.device,
+            dtype=torch.cfloat,
+        )
+
+        # Determine how many modes to keep per dimension
+        kept_sizes = [min(nm, fs) for nm, fs in zip(self._n_modes, fft_sizes)]
+        mode_slices = tuple(slice(0, k) for k in kept_sizes)
+        full_slices = (slice(None), slice(None)) + mode_slices
+
+        # Extract low-frequency modes from input
+        x_low = x_hat[full_slices]  # (B, C_in, *kept_sizes)
+
+        # Channel mixing: (B, C_in, *k) @ (C_in, C_out) -> (B, C_out, *k)
+        w = self.channel_weight.to(x_low.dtype)
+        out_low = torch.einsum("bi...,io->bo...", x_low, w)
+
+        # Compute and apply KG spectral filter (complex, per-channel)
+        H = self._compute_kg_filter(kept_sizes, spatial_sizes)
+        out_low = out_low * H.unsqueeze(0)  # broadcast over batch
+
+        # Place back into zero-padded output
+        out_slices = (slice(None), slice(None)) + mode_slices
+        out_hat[out_slices] = out_low
 
         # Inverse FFT
-        out_sizes = output_shape if output_shape is not None else mode_sizes
+        out_sizes = output_shape if output_shape is not None else spatial_sizes
         if self.complex_data:
-            x = torch.fft.ifftn(
-                out_hat, s=out_sizes, dim=fft_dims, norm=self.fft_norm
-            )
+            x = torch.fft.ifftn(out_hat, s=out_sizes, dim=fft_dims, norm=self.fft_norm)
         else:
-            x = torch.fft.irfftn(
-                out_hat, s=out_sizes, dim=fft_dims, norm=self.fft_norm
-            )
+            x = torch.fft.irfftn(out_hat, s=out_sizes, dim=fft_dims, norm=self.fft_norm)
 
         if self.bias is not None:
             x = x + self.bias
@@ -311,13 +351,12 @@ class KGSpectralConv(BaseSpectralConv):
         T = torch.exp(self.log_T).detach()
         c = torch.exp(self.log_c).detach()
         chi = torch.exp(self.log_chi).detach()
-        T_str = f"{T.item():.4g}" if T.numel() == 1 else str(T.tolist())
-        c_str = f"{c.item():.4g}" if c.numel() == 1 else str(c.tolist())
-        chi_str = f"{chi.item():.4g}" if chi.numel() == 1 else str(chi.tolist())
         return (
             f"in_channels={self.in_channels}, out_channels={self.out_channels}, "
             f"n_modes={self._n_modes}, "
-            f"T={T_str}, c={c_str}, chi={chi_str}, "
+            f"T_range=[{T.min().item():.3g}, {T.max().item():.3g}], "
+            f"c_range=[{c.min().item():.3g}, {c.max().item():.3g}], "
+            f"chi_range=[{chi.min().item():.3g}, {chi.max().item():.3g}], "
             f"kernel_params={self.n_kernel_params}, "
             f"total_params={self.n_total_params}"
         )

--- a/neuralop/layers/tests/test_kg_spectral_conv.py
+++ b/neuralop/layers/tests/test_kg_spectral_conv.py
@@ -1,0 +1,143 @@
+import pytest
+import torch
+from ..kg_spectral_conv import KGSpectralConv
+
+
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_kg_spectral_conv_output_shape(dim):
+    """Test that the output shape matches expectations for 1D-3D inputs."""
+    in_ch, out_ch = 3, 5
+    modes = (16,) * dim
+    spatial = (32,) * dim
+
+    layer = KGSpectralConv(in_ch, out_ch, n_modes=modes)
+    x = torch.randn(2, in_ch, *spatial)
+    y = layer(x)
+
+    assert y.shape == (2, out_ch, *spatial)
+
+
+@pytest.mark.parametrize("per_channel", [False, True])
+def test_kg_spectral_conv_per_channel(per_channel):
+    """Test shared vs per-channel KG parameters."""
+    in_ch, out_ch = 2, 4
+    layer = KGSpectralConv(
+        in_ch, out_ch, n_modes=(8,), per_channel=per_channel
+    )
+
+    expected_shape = (out_ch,) if per_channel else (1,)
+    assert layer.log_T.shape == expected_shape
+    assert layer.log_c.shape == expected_shape
+    assert layer.log_chi.shape == expected_shape
+
+    x = torch.randn(1, in_ch, 32)
+    y = layer(x)
+    assert y.shape == (1, out_ch, 32)
+
+
+def test_kg_spectral_conv_gradient_flow():
+    """Verify that gradients flow through all KG parameters."""
+    layer = KGSpectralConv(2, 2, n_modes=(16,))
+    x = torch.randn(1, 2, 64, requires_grad=True)
+
+    y = layer(x)
+    loss = y.sum()
+    loss.backward()
+
+    assert layer.log_T.grad is not None
+    assert layer.log_c.grad is not None
+    assert layer.log_chi.grad is not None
+    assert layer.channel_weight.grad is not None
+    assert x.grad is not None
+
+
+def test_kg_spectral_conv_identity_at_T0():
+    """When T -> 0, the KG filter is cos(0) = 1 (identity)."""
+    layer = KGSpectralConv(
+        1, 1, n_modes=(16,), init_T=1e-8, init_c=1.0, init_chi=1.0, bias=False,
+    )
+    # Set channel weight to identity
+    with torch.no_grad():
+        layer.channel_weight.fill_(1.0)
+
+    x = torch.randn(1, 1, 64)
+    y = layer(x)
+
+    # With T ~ 0, cos(T * omega) ~ 1, so output ~ input
+    torch.testing.assert_close(y, x, atol=1e-4, rtol=1e-4)
+
+
+def test_kg_spectral_conv_no_bias():
+    """Test that bias=False works correctly."""
+    layer = KGSpectralConv(2, 3, n_modes=(8,), bias=False)
+    assert layer.bias is None
+
+    x = torch.randn(1, 2, 32)
+    y = layer(x)
+    assert y.shape == (1, 3, 32)
+
+
+def test_kg_spectral_conv_complex_data():
+    """Test with complex-valued input data."""
+    layer = KGSpectralConv(2, 2, n_modes=(8,), complex_data=True)
+    x = torch.randn(1, 2, 32, dtype=torch.cfloat)
+    y = layer(x)
+
+    assert y.shape == (1, 2, 32)
+    assert y.dtype == torch.cfloat
+
+
+def test_kg_spectral_conv_parameter_efficiency():
+    """KG layer should have far fewer parameters than standard SpectralConv."""
+    in_ch, out_ch, n_modes = 16, 16, (32,)
+
+    kg_layer = KGSpectralConv(in_ch, out_ch, n_modes=n_modes)
+    kg_params = sum(p.numel() for p in kg_layer.parameters())
+
+    # Standard SpectralConv would have in_ch * out_ch * prod(n_modes) complex params
+    # plus bias. KG has: 3 (T, c, chi) + in_ch * out_ch (channel_weight) + out_ch (bias)
+    fno_spectral_params = in_ch * out_ch * n_modes[0] * 2  # *2 for complex
+    assert kg_params < fno_spectral_params
+
+
+def test_kg_spectral_conv_output_shape_with_resize():
+    """Test output_shape parameter for resolution changes."""
+    layer = KGSpectralConv(2, 2, n_modes=(16,))
+    x = torch.randn(1, 2, 64)
+
+    y = layer(x, output_shape=(128,))
+    assert y.shape == (1, 2, 128)
+
+    y = layer(x, output_shape=(32,))
+    assert y.shape == (1, 2, 32)
+
+
+def test_kg_spectral_conv_2d():
+    """Dedicated 2D test with non-square input."""
+    layer = KGSpectralConv(1, 1, n_modes=(8, 8))
+    x = torch.randn(2, 1, 32, 48)
+    y = layer(x)
+    assert y.shape == (2, 1, 32, 48)
+
+
+def test_kg_spectral_conv_repr():
+    """Test that string representation works without errors."""
+    layer = KGSpectralConv(2, 3, n_modes=(8, 8))
+    r = repr(layer)
+    assert "KGSpectralConv" in r
+    assert "in_channels=2" in r
+    assert "out_channels=3" in r
+
+
+def test_kg_spectral_conv_n_modes_property():
+    """Test dynamic n_modes update."""
+    layer = KGSpectralConv(2, 2, n_modes=(16,))
+    assert layer.n_modes == [16]
+
+    layer.n_modes = (8,)
+    assert layer.n_modes == [8]
+
+    # Should still produce valid output
+    x = torch.randn(1, 2, 64)
+    y = layer(x)
+    assert y.shape == (1, 2, 64)

--- a/neuralop/layers/tests/test_kg_spectral_conv.py
+++ b/neuralop/layers/tests/test_kg_spectral_conv.py
@@ -17,18 +17,16 @@ def test_kg_spectral_conv_output_shape(dim):
     assert y.shape == (2, out_ch, *spatial)
 
 
-@pytest.mark.parametrize("per_channel", [False, True])
-def test_kg_spectral_conv_per_channel(per_channel):
-    """Test shared vs per-channel KG parameters."""
+def test_kg_spectral_conv_per_channel():
+    """Test that KG parameters are always per-channel."""
     in_ch, out_ch = 2, 4
-    layer = KGSpectralConv(
-        in_ch, out_ch, n_modes=(8,), per_channel=per_channel
-    )
+    layer = KGSpectralConv(in_ch, out_ch, n_modes=(8,))
 
-    expected_shape = (out_ch,) if per_channel else (1,)
-    assert layer.log_T.shape == expected_shape
-    assert layer.log_c.shape == expected_shape
-    assert layer.log_chi.shape == expected_shape
+    assert layer.log_T.shape == (out_ch,)
+    assert layer.log_c.shape == (out_ch,)
+    assert layer.log_chi.shape == (out_ch,)
+    assert layer.alpha_real.shape == (out_ch, 8)
+    assert layer.alpha_imag.shape == (out_ch, 8)
 
     x = torch.randn(1, in_ch, 32)
     y = layer(x)
@@ -47,24 +45,41 @@ def test_kg_spectral_conv_gradient_flow():
     assert layer.log_T.grad is not None
     assert layer.log_c.grad is not None
     assert layer.log_chi.grad is not None
+    assert layer.alpha_real.grad is not None
+    assert layer.alpha_imag.grad is not None
     assert layer.channel_weight.grad is not None
     assert x.grad is not None
 
 
 def test_kg_spectral_conv_identity_at_T0():
-    """When T -> 0, the KG filter is cos(0) = 1 (identity)."""
+    """When T -> 0, the KG filter approaches identity."""
     layer = KGSpectralConv(
-        1, 1, n_modes=(16,), init_T=1e-8, init_c=1.0, init_chi=1.0, bias=False,
+        1,
+        1,
+        n_modes=(16,),
+        init_T=1e-8,
+        init_c=1.0,
+        init_chi=1.0,
+        bias=False,
     )
-    # Set channel weight to identity
+    # Set channel weight to identity, alpha to 1+0j
     with torch.no_grad():
         layer.channel_weight.fill_(1.0)
+        layer.alpha_real.fill_(1.0)
+        layer.alpha_imag.fill_(0.0)
 
     x = torch.randn(1, 1, 64)
     y = layer(x)
 
-    # With T ~ 0, cos(T * omega) ~ 1, so output ~ input
-    torch.testing.assert_close(y, x, atol=1e-4, rtol=1e-4)
+    # With T ~ 0, exp(-iT*omega) ~ 1, so output ~ input
+    # (only n_modes=16 low frequencies pass; high freqs zeroed)
+    # Check that the low-frequency content is preserved
+    x_hat = torch.fft.rfft(x, norm="forward")
+    y_hat = torch.fft.rfft(y, norm="forward")
+    # First 16 modes should match
+    torch.testing.assert_close(y_hat[:, :, :16], x_hat[:, :, :16], atol=1e-4, rtol=1e-4)
+    # High-frequency modes should be near zero
+    assert y_hat[:, :, 16:].abs().max() < 1e-5
 
 
 def test_kg_spectral_conv_no_bias():
@@ -88,15 +103,15 @@ def test_kg_spectral_conv_complex_data():
 
 
 def test_kg_spectral_conv_parameter_efficiency():
-    """KG layer should have far fewer parameters than standard SpectralConv."""
+    """KG layer should have fewer parameters than standard SpectralConv."""
     in_ch, out_ch, n_modes = 16, 16, (32,)
 
     kg_layer = KGSpectralConv(in_ch, out_ch, n_modes=n_modes)
     kg_params = sum(p.numel() for p in kg_layer.parameters())
 
-    # Standard SpectralConv would have in_ch * out_ch * prod(n_modes) complex params
-    # plus bias. KG has: 3 (T, c, chi) + in_ch * out_ch (channel_weight) + out_ch (bias)
-    fno_spectral_params = in_ch * out_ch * n_modes[0] * 2  # *2 for complex
+    # Standard SpectralConv: in_ch * out_ch * prod(n_modes) * 2 (complex)
+    # KG: 3*out_ch + 2*out_ch*prod(n_modes) + in_ch*out_ch + out_ch
+    fno_spectral_params = in_ch * out_ch * n_modes[0] * 2
     assert kg_params < fno_spectral_params
 
 

--- a/neuralop/layers/tests/test_kg_spectral_conv.py
+++ b/neuralop/layers/tests/test_kg_spectral_conv.py
@@ -25,8 +25,9 @@ def test_kg_spectral_conv_per_channel():
     assert layer.log_T.shape == (out_ch,)
     assert layer.log_c.shape == (out_ch,)
     assert layer.log_chi.shape == (out_ch,)
-    assert layer.alpha_real.shape == (out_ch, 8)
-    assert layer.alpha_imag.shape == (out_ch, 8)
+    # n_modes=(8,) for real data -> internally [8//2+1] = [5]
+    assert layer.alpha_real.shape == (out_ch, 5)
+    assert layer.alpha_imag.shape == (out_ch, 5)
 
     x = torch.randn(1, in_ch, 32)
     y = layer(x)
@@ -53,6 +54,8 @@ def test_kg_spectral_conv_gradient_flow():
 
 def test_kg_spectral_conv_identity_at_T0():
     """When T -> 0, the KG filter approaches identity."""
+    # n_modes=(16,) for real data -> internally [9] (16//2+1)
+    n_internal = 16 // 2 + 1  # = 9
     layer = KGSpectralConv(
         1,
         1,
@@ -72,14 +75,15 @@ def test_kg_spectral_conv_identity_at_T0():
     y = layer(x)
 
     # With T ~ 0, exp(-iT*omega) ~ 1, so output ~ input
-    # (only n_modes=16 low frequencies pass; high freqs zeroed)
-    # Check that the low-frequency content is preserved
+    # (only n_internal low frequencies pass; high freqs zeroed)
     x_hat = torch.fft.rfft(x, norm="forward")
     y_hat = torch.fft.rfft(y, norm="forward")
-    # First 16 modes should match
-    torch.testing.assert_close(y_hat[:, :, :16], x_hat[:, :, :16], atol=1e-4, rtol=1e-4)
+    # First n_internal modes should match
+    torch.testing.assert_close(
+        y_hat[:, :, :n_internal], x_hat[:, :, :n_internal], atol=1e-4, rtol=1e-4
+    )
     # High-frequency modes should be near zero
-    assert y_hat[:, :, 16:].abs().max() < 1e-5
+    assert y_hat[:, :, n_internal:].abs().max() < 1e-5
 
 
 def test_kg_spectral_conv_no_bias():
@@ -109,9 +113,10 @@ def test_kg_spectral_conv_parameter_efficiency():
     kg_layer = KGSpectralConv(in_ch, out_ch, n_modes=n_modes)
     kg_params = sum(p.numel() for p in kg_layer.parameters())
 
-    # Standard SpectralConv: in_ch * out_ch * prod(n_modes) * 2 (complex)
-    # KG: 3*out_ch + 2*out_ch*prod(n_modes) + in_ch*out_ch + out_ch
-    fno_spectral_params = in_ch * out_ch * n_modes[0] * 2
+    # Standard SpectralConv: in_ch * out_ch * adjusted_modes * 2 (complex)
+    # For real data, adjusted_modes = n_modes[-1]//2+1 = 17
+    adjusted = n_modes[0] // 2 + 1
+    fno_spectral_params = in_ch * out_ch * adjusted * 2
     assert kg_params < fno_spectral_params
 
 
@@ -145,14 +150,119 @@ def test_kg_spectral_conv_repr():
 
 
 def test_kg_spectral_conv_n_modes_property():
-    """Test dynamic n_modes update."""
+    """Test dynamic n_modes update with rFFT adjustment."""
     layer = KGSpectralConv(2, 2, n_modes=(16,))
-    assert layer.n_modes == [16]
+    # n_modes=(16,) for real data -> [16//2+1] = [9]
+    assert layer.n_modes == [9]
 
     layer.n_modes = (8,)
-    assert layer.n_modes == [8]
+    # (8,) -> [8//2+1] = [5]
+    assert layer.n_modes == [5]
 
     # Should still produce valid output
     x = torch.randn(1, 2, 64)
     y = layer(x)
     assert y.shape == (1, 2, 64)
+
+
+def test_kg_spectral_conv_2d_mode_truncation():
+    """Test that 2D mode truncation uses centered window (fftshift).
+
+    For a 2D real-data input, the first spatial dimension should use
+    a centered frequency window (via fftshift), while the last dimension
+    uses the standard rFFT low-frequency slice. This verifies the KG layer
+    matches SpectralConv's multi-D truncation behavior.
+    """
+    layer = KGSpectralConv(
+        1,
+        1,
+        n_modes=(8, 8),
+        init_T=1e-8,
+        init_c=1.0,
+        init_chi=1.0,
+        bias=False,
+    )
+    # n_modes=(8,8) for real data -> [8, 5] internally
+    assert layer.n_modes == [8, 5]
+
+    with torch.no_grad():
+        layer.channel_weight.fill_(1.0)
+        layer.alpha_real.fill_(1.0)
+        layer.alpha_imag.fill_(0.0)
+
+    # Create input with energy only at low frequencies
+    x = torch.randn(1, 1, 32, 32)
+    y = layer(x)
+    assert y.shape == (1, 1, 32, 32)
+
+    # Verify the layer preserves low-frequency content and zeros highs
+    # by checking that the output has reduced high-frequency energy
+    x_hat = torch.fft.rfftn(x, dim=[-2, -1], norm="forward")
+    y_hat = torch.fft.rfftn(y, dim=[-2, -1], norm="forward")
+
+    # High-frequency energy should be reduced (zeroed out modes)
+    high_freq_energy_x = x_hat[:, :, 8:, :].abs().pow(2).sum()
+    high_freq_energy_y = y_hat[:, :, 8:, :].abs().pow(2).sum()
+    assert high_freq_energy_y < high_freq_energy_x * 0.1
+
+
+def test_kg_spectral_conv_max_n_modes():
+    """Test max_n_modes allocates larger alpha and supports mode changes."""
+    layer = KGSpectralConv(
+        2, 2, n_modes=(8,), max_n_modes=16, bias=False
+    )
+    # n_modes=(8,) -> [5]; max_n_modes=16 -> [9]
+    assert layer.n_modes == [5]
+    assert layer.max_n_modes == [9]
+    # Alpha allocated at max_n_modes
+    assert layer.alpha_real.shape == (2, 9)
+
+    x = torch.randn(1, 2, 64)
+    y = layer(x)
+    assert y.shape == (1, 2, 64)
+
+    # Increase n_modes within max_n_modes range
+    layer.n_modes = (16,)  # -> [9], same as max_n_modes
+    assert layer.n_modes == [9]
+    y2 = layer(x)
+    assert y2.shape == (1, 2, 64)
+
+
+def test_kg_spectral_conv_precision_warning():
+    """Non-default fno_block_precision should emit a warning."""
+    import warnings
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        layer = KGSpectralConv(
+            2, 2, n_modes=(8,), fno_block_precision="half"
+        )
+        assert len(w) == 1
+        assert "fno_block_precision" in str(w[0].message)
+
+    # "full" should not warn
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        layer = KGSpectralConv(
+            2, 2, n_modes=(8,), fno_block_precision="full"
+        )
+        assert len(w) == 0
+
+
+def test_kg_spectral_conv_n_modes_rfft_adjustment():
+    """Verify rFFT adjustment of n_modes matches SpectralConv semantics."""
+    # 1D: (16,) -> [9]
+    layer_1d = KGSpectralConv(1, 1, n_modes=(16,))
+    assert layer_1d.n_modes == [16 // 2 + 1]
+
+    # 2D: (16, 16) -> [16, 9] (only last dim adjusted)
+    layer_2d = KGSpectralConv(1, 1, n_modes=(16, 16))
+    assert layer_2d.n_modes == [16, 16 // 2 + 1]
+
+    # 3D: (16, 16, 16) -> [16, 16, 9]
+    layer_3d = KGSpectralConv(1, 1, n_modes=(16, 16, 16))
+    assert layer_3d.n_modes == [16, 16, 16 // 2 + 1]
+
+    # Complex data: no adjustment
+    layer_complex = KGSpectralConv(1, 1, n_modes=(16,), complex_data=True)
+    assert layer_complex.n_modes == [16]


### PR DESCRIPTION
## Summary

Adds `KGSpectralConv`, a physics-constrained drop-in replacement for `SpectralConv` that parameterizes the spectral filter via the Klein-Gordon dispersion relation. Particularly effective for wave-type (hyperbolic) PDEs where the physics prior matches.

## Motivation

The standard `SpectralConv` learns arbitrary complex weights for each Fourier mode — expressive but parameter-heavy. For wave-type PDEs, the exact solution operator has a known structure:

\\\
H(k) = exp(-i T sqrt(c^2 |k|^2 + chi^2))
\\\

By encoding this structure directly, we can:
- **Reduce parameters by 2.5x** while maintaining competitive accuracy
- **Embed the correct dispersion relation** as an inductive bias
- **Maintain full drop-in compatibility** with existing FNO models

The mathematical connection: the Green's function of the Klein-Gordon equation is the Matérn kernel family (Whittle 1954). The standard RBF kernel (and by analogy, unconstrained spectral weights) is the ν→∞ diffusion limit. Using finite ν encodes wave-like (hyperbolic) rather than diffusion-like (parabolic) behavior.

## What's included

### Layer: `neuralop/layers/kg_spectral_conv.py`
- Complex propagator `exp(-i*omega*T)` with per-channel dispersion `(T, c, chi)`
- Per-mode learnable complex amplitudes `alpha(k)` for expressiveness
- Proper mode truncation matching `SpectralConv` behavior:
  - rFFT-aware `n_modes` adjustment (last dim: `n//2+1`)
  - Centered frequency windows via `fftshift` for 2D/3D
  - `max_n_modes` support for incremental training
  - `resolution_scaling_factor` support for super-resolution
- Accepts all `FNOBlocks` kwargs for seamless integration
- Full NumPy-style docstrings with references

### Tests: `neuralop/layers/tests/test_kg_spectral_conv.py`
- 17 tests covering: 1D/2D/3D shapes, gradient flow, identity at T=0, complex data, parameter efficiency, output resize, 2D mode truncation, max_n_modes, precision warnings, rFFT adjustment, repr, and more
- All passing

### Example: `examples/layers/plot_kg_spectral_filter.py`
- Sphinx-compatible gallery example visualizing the KG filter
- Compares against GCN low-pass, Gaussian diffusion, and FNO truncation filters
- Shows parameter efficiency table and signal filtering demo

### Benchmark: `examples/models/benchmark_fno_vs_kg_fno.py`
- Compares standard FNO vs KG-FNO on 1D Klein-Gordon time evolution
- Tests across 3 mass regimes (wave, moderate KG, heavy KG)

## Benchmark results

Both models use `n_modes=(16,)` which internally retains 9 Fourier modes (rFFT: `16//2+1`). Training: 80 epochs, hidden=32, 4 layers. Data: 500 train / 100 test, nx=64.

| Mass regime | FNO (test L2) | KG-FNO (test L2) | Delta | Params |
|-------------|---------------|-------------------|-------|--------|
| m=0 (wave eq) | 9.26% | 20.75% | +124% | 2.5x fewer |
| m=5 (moderate KG) | 7.11% | 9.56% | +34% | 2.5x fewer |
| **m=15 (heavy KG)** | **8.87%** | **7.67%** | **-14%** | **2.5x fewer** |

**Parameters**: FNO 49,953 → KG-FNO 19,873 (2.5x fewer)

**Interpretation**: The KG physics prior helps exactly where it should — at high mass where the dispersion relation is the dominant structure. At m=0 (pure wave equation, no mass term), the rigid KG structure is actively unhelpful. This is the expected behavior for a physics-informed layer: it outperforms where its assumptions match and underperforms where they don't.

**Note on earlier results**: An initial version of this layer did not apply the rFFT `n//2+1` adjustment to `n_modes`, inadvertently retaining 16 modes vs SpectralConv's 9. Those inflated results have been corrected. The current benchmark is an apples-to-apples comparison.

## Usage

\\\python
from neuralop.models import FNO
from neuralop.layers.kg_spectral_conv import KGSpectralConv

# Drop-in replacement — just pass conv_module
model = FNO(
    n_modes=(16,),
    in_channels=1,
    out_channels=1,
    hidden_channels=32,
    n_layers=4,
    conv_module=KGSpectralConv,  # only change needed
)
\\\

## When to use KGSpectralConv

| Scenario | Recommendation |
|----------|---------------|
| Hyperbolic PDEs with mass (KG, Dirac) | **Use KG-FNO** — physics prior matches |
| Pure wave equation (c only, no mass) | Use standard FNO |
| Parameter-constrained settings | **Use KG-FNO** — 2.5x fewer params |
| General-purpose PDE operator learning | Use standard FNO |

## Checklist

- [x] Code follows PEP8 and is `black`-formatted
- [x] NumPy-style docstrings on all public methods
- [x] Comprehensive unit tests (17 tests)
- [x] SpectralConv compatibility (fftshift, rFFT, max_n_modes, resolution_scaling_factor)
- [x] Sphinx gallery example with visualization
- [x] Training benchmark with quantitative results
- [x] Type hints on public API
- [x] References to relevant papers in docstrings

Happy to address any feedback. Thanks for building such a well-designed library — the `conv_module` abstraction made this a pleasure to implement!