### PR TITLE
Add Hyperparameter Optimization (HPO) scripts using HyperNOs and Ray Tune

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,8 @@ of an equivalent, dense Fourier Neural Operator!
 To use W&B logging features, simply create a file in ``neuraloperator/config`` 
 called ``wandb_api_key.txt`` and paste your W&B API key there.
 
+Hyperparameter optimization (HPO) scripts using `HyperNOs` and `Ray Tune` are also available in the ``scripts/`` directory (e.g. ``scripts/ray_tune_tfno_darcy.py``).
+
 
 ============
 Contributing

--- a/scripts/ray_tune_sfno_swe.py
+++ b/scripts/ray_tune_sfno_swe.py
@@ -1,0 +1,86 @@
+"""
+Hyperparameter optimization for SFNO on Spherical SWE using HyperNOs (https://github.com/MaxGhi8/HyperNOs) and Ray Tune.
+"""
+
+import torch
+from ray import tune
+from hypernos.datasets import NO_load_data_model
+from hypernos.loss_fun import loss_selector
+from hypernos.tune import tune_hyperparameters
+from hypernos.wrappers import wrap_model_builder
+from neuralop.models import SFNO
+
+def run_hpo_sfno_swe():
+    # Base hyperparameters
+    default_hyper_params = {
+        "training_samples": 512,
+        "learning_rate": 0.001,
+        "epochs": 50,
+        "batch_size": 16,
+        "weight_decay": 1e-5,
+        "scheduler_step": 10,
+        "scheduler_gamma": 0.98,
+        "beta": 1,
+        "hidden_channels": 32,
+        "modes": 16,
+        "input_dim": 3, # (u, v, h)
+        "out_dim": 3,
+        "problem_dim": 2,
+        "FourierF": 0,
+        "retrain": 4,
+    }
+
+    # Define the search space
+    config_space = {
+        "learning_rate": tune.loguniform(1e-4, 1e-2),
+        "hidden_channels": tune.choice([16, 32, 64]),
+        "n_layers": tune.randint(2, 6),
+    }
+
+    # Merge fixed params
+    fixed_params = {**default_hyper_params}
+    for param in config_space.keys():
+        fixed_params.pop(param, None)
+    config_space.update(fixed_params)
+
+    # Model builder for NeuralOperator's SFNO
+    def model_builder(config):
+        return SFNO(
+            n_modes=(config["modes"], config["modes"]),
+            hidden_channels=config["hidden_channels"],
+            n_layers=config["n_layers"],
+            in_channels=config["input_dim"],
+            out_channels=config["out_dim"],
+            spectral_channels=config["modes"],
+        )
+    
+    model_builder = wrap_model_builder(model_builder, "spherical_swe_neural_operator")
+
+    def dataset_builder(config):
+        return NO_load_data_model(
+            which_example="spherical_swe",
+            no_architecture={
+                "FourierF": config["FourierF"],
+                "retrain": config["retrain"],
+            },
+            batch_size=config["batch_size"],
+            training_samples=config["training_samples"],
+        )
+
+    loss_fn = loss_selector("L2", problem_dim=2, beta=1)
+
+    tune_hyperparameters(
+        config_space=config_space,
+        model_builder=model_builder,
+        dataset_builder=dataset_builder,
+        loss_fn=loss_fn,
+        default_hyper_params=[default_hyper_params],
+        num_samples=10,
+        max_epochs=default_hyper_params["epochs"],
+        checkpoint_freq=default_hyper_params["epochs"],
+        runs_per_cpu=1.0,
+        runs_per_gpu=1.0 if torch.cuda.is_available() else 0.0,
+    )
+
+if __name__ == "__main__":
+    run_hpo_sfno_swe()

--- a/scripts/ray_tune_tfno_darcy.py
+++ b/scripts/ray_tune_tfno_darcy.py
@@ -1,0 +1,101 @@
+"""
+Hyperparameter optimization for TFNO on Darcy Flow using HyperNOs (https://github.com/MaxGhi8/HyperNOs) and Ray Tune.
+"""
+
+import torch
+from ray import tune
+from hypernos.datasets import NO_load_data_model
+from hypernos.loss_fun import loss_selector
+from hypernos.tune import tune_hyperparameters
+from hypernos.wrappers import wrap_model_builder
+from neuralop.models import TFNO
+
+def run_hpo_tfno_darcy():
+    # Base hyperparameters
+    default_hyper_params = {
+        "training_samples": 100,
+        "learning_rate": 0.001,
+        "epochs": 50, 
+        "batch_size": 32,
+        "weight_decay": 1e-5,
+        "scheduler_step": 10,
+        "scheduler_gamma": 0.98,
+        "beta": 1,
+        "width": 32,
+        "modes": 16,
+        "n_layers": 4,
+        "input_dim": 1,
+        "out_dim": 1,
+        "rank": 0.05,
+        "FourierF": 0,
+        "retrain": 4,
+        "problem_dim": 2,
+    }
+
+    # Define the search space
+    config_space = {
+        "learning_rate": tune.loguniform(1e-4, 1e-2),
+        "rank": tune.choice([0.05, 0.1, 0.15]),
+        "width": tune.choice([16, 32, 64]),
+        "modes": tune.choice([8, 12, 16]),
+    }
+
+    # Merge fixed params into config_space
+    fixed_params = {**default_hyper_params}
+    for param in config_space.keys():
+        fixed_params.pop(param, None)
+    config_space.update(fixed_params)
+
+    # Model builder for NeuralOperator's TFNO
+    def model_builder(config):
+        return TFNO(
+            n_modes=(config["modes"], config["modes"]),
+            hidden_channels=config["width"],
+            n_layers=config["n_layers"],
+            in_channels=config["input_dim"],
+            out_channels=config["out_dim"],
+            factorization="tucker",
+            implementation="factorized",
+            rank=config["rank"],
+        )
+    
+    # Wrap model builder for HyperNOs compatibility
+    model_builder = wrap_model_builder(model_builder, "darcy_neural_operator")
+
+    # Dataset builder using HyperNOs standard loader
+    def dataset_builder(config):
+        return NO_load_data_model(
+            which_example="darcy",
+            no_architecture={
+                "FourierF": config["FourierF"],
+                "retrain": config["retrain"],
+            },
+            batch_size=config["batch_size"],
+            training_samples=config["training_samples"],
+        )
+
+    # Loss function (relative L2 loss)
+    loss_fn = loss_selector(
+        loss_fn_str="L2",
+        problem_dim=2,
+        beta=1,
+    )
+
+    # Run Ray Tune
+    tune_hyperparameters(
+        config_space=config_space,
+        model_builder=model_builder,
+        dataset_builder=dataset_builder,
+        loss_fn=loss_fn,
+        default_hyper_params=[default_hyper_params],
+        num_samples=10,
+        max_epochs=default_hyper_params["epochs"],
+        checkpoint_freq=default_hyper_params["epochs"],
+        grace_period=10,
+        reduction_factor=2,
+        runs_per_cpu=1.0,
+        runs_per_gpu=1.0 if torch.cuda.is_available() else 0.0,
+    )
+
+if __name__ == "__main__":
+    run_hpo_tfno_darcy()

--- a/scripts/ray_tune_uno_darcy.py
+++ b/scripts/ray_tune_uno_darcy.py
@@ -1,0 +1,89 @@
+"""
+Hyperparameter optimization for UNO on Darcy Flow using HyperNOs (https://github.com/MaxGhi8/HyperNOs) and Ray Tune.
+"""
+
+import torch
+from ray import tune
+from hypernos.datasets import NO_load_data_model
+from hypernos.loss_fun import loss_selector
+from hypernos.tune import tune_hyperparameters
+from hypernos.wrappers import wrap_model_builder
+from neuralop.models import UNO
+
+def run_hpo_uno_darcy():
+    # Base hyperparameters
+    default_hyper_params = {
+        "training_samples": 1024,
+        "learning_rate": 0.001,
+        "epochs": 50,
+        "batch_size": 32,
+        "weight_decay": 1e-5,
+        "scheduler_step": 10,
+        "scheduler_gamma": 0.98,
+        "beta": 1,
+        "hidden_channels": 32,
+        "modes": 16,
+        "input_dim": 1,
+        "out_dim": 1,
+        "problem_dim": 2,
+        "FourierF": 0,
+        "retrain": 4,
+    }
+
+    # Define the search space
+    config_space = {
+        "learning_rate": tune.loguniform(1e-4, 1e-2),
+        "hidden_channels": tune.choice([16, 32, 64]),
+        "uno_out_channels": tune.choice([[32, 64, 64, 32], [16, 32, 32, 16]]),
+        "uno_n_modes": tune.choice([[16, 16], [8, 8]]),
+    }
+
+    # Merge fixed params
+    fixed_params = {**default_hyper_params}
+    for param in config_space.keys():
+        fixed_params.pop(param, None)
+    config_space.update(fixed_params)
+
+    # Model builder for NeuralOperator's UNO
+    def model_builder(config):
+        return UNO(
+            in_channels=config["input_dim"],
+            out_channels=config["out_dim"],
+            hidden_channels=config["hidden_channels"],
+            uno_out_channels=config["uno_out_channels"],
+            uno_n_modes=config["uno_n_modes"],
+            uno_scalings=[[1.0, 1.0], [0.5, 0.5], [1.0, 1.0], [2.0, 2.0]],
+            n_layers=4,
+            horizontal_skips_map={4: 0, 3: 1}
+        )
+    
+    model_builder = wrap_model_builder(model_builder, "darcy_uno_operator")
+
+    def dataset_builder(config):
+        return NO_load_data_model(
+            which_example="darcy",
+            no_architecture={
+                "FourierF": config["FourierF"],
+                "retrain": config["retrain"],
+            },
+            batch_size=config["batch_size"],
+            training_samples=config["training_samples"],
+        )
+
+    loss_fn = loss_selector("L2", problem_dim=2, beta=1)
+
+    tune_hyperparameters(
+        config_space=config_space,
+        model_builder=model_builder,
+        dataset_builder=dataset_builder,
+        loss_fn=loss_fn,
+        default_hyper_params=[default_hyper_params],
+        num_samples=10,
+        max_epochs=default_hyper_params["epochs"],
+        checkpoint_freq=default_hyper_params["epochs"],
+        runs_per_cpu=1.0,
+        runs_per_gpu=1.0 if torch.cuda.is_available() else 0.0,
+    )
+
+if __name__ == "__main__":
+    run_hpo_uno_darcy()


### PR DESCRIPTION
This PR adds three new scripts to the scripts/ directory for performing hyperparameter optimization on SFNO, TFNO, and UNO models using HyperNOs and Ray Tune.

Changes
 - New HPO Scripts:
   - scripts/ray_tune_sfno_swe.py: HPO for SFNO on Spherical Shallow Water Equations.
   - scripts/ray_tune_tfno_darcy.py: HPO for TFNO on Darcy Flow.
   - scripts/ray_tune_uno_darcy.py: HPO for UNO on Darcy Flow.
 - Documentation:
   - Updated README.rst to include a row on HPO and reference the new scripts.

The new scripts provide a standardized framework for optimizing hyperparameters in neural operators. They utilize the HyperNOs library for model and dataset loading, while Ray Tune manages the
search space and execution of trials. This addition facilitates more robust experimentation and model tuning for users of the library.

Users will need to install hypernos and ray[tune] to use these scripts.
                                                                                 