### PR TITLE
Fix shape comparison bug in SpectralConv.transform

### DIFF
--- a/neuralop/layers/spectral_convolution.py
+++ b/neuralop/layers/spectral_convolution.py
@@ -381,7 +381,7 @@ class SpectralConv(BaseSpectralConv):
             self.bias = None
 
     def transform(self, x, output_shape=None):
-        in_shape = list(x.shape[2:])
+        in_shape = tuple(x.shape[2:])
 
         if self.resolution_scaling_factor is not None and output_shape is None:
             out_shape = tuple(


### PR DESCRIPTION
I believe there is a bug in SpectralConv.transform where in_shape is created as a list while out_shape is a tuple, causing the equality check to always fail.