### PR TITLE
Add configurable FNO conv bias kernel

### DIFF
--- a/neuralop/layers/fno_block.py
+++ b/neuralop/layers/fno_block.py
@@ -15,6 +15,34 @@ from ..utils import validate_scaling_factor
 Number = Union[int, float]
 
 
+def _make_conv_bias(in_channels, out_channels, n_dim, kernel_size):
+    """Create the local convolutional bias term used alongside SpectralConv."""
+    if kernel_size < 1:
+        raise ValueError(f"conv_bias_kernel must be >= 1, got {kernel_size}")
+
+    if kernel_size == 1:
+        return skip_connection(
+            in_channels,
+            out_channels,
+            skip_type="linear",
+            n_dim=n_dim,
+        )
+
+    if n_dim > 3:
+        raise NotImplementedError(
+            "conv_bias_kernel > 1 is only implemented for 1D, 2D, and 3D FNO blocks."
+        )
+
+    conv_module = getattr(nn, f"Conv{n_dim}d")
+    return conv_module(
+        in_channels,
+        out_channels,
+        kernel_size=kernel_size,
+        padding="same",
+        bias=False,
+    )
+
+
 class FNOBlocks(nn.Module):
     """FNOBlocks implements a sequence of Fourier layers.
     
@@ -60,6 +88,10 @@ class FNOBlocks(nn.Module):
     fno_skip : str, optional
         Module to use for FNO skip connections. Options: "linear", "soft-gating", "identity", None, by default "linear"
         If None, no skip connection is added. See layers.skip_connections for more details
+    conv_bias_kernel : int, optional
+        Kernel size for the local convolutional bias term used when ``fno_skip="linear"``.
+        ``1`` preserves the default pointwise bias term, while larger kernels add a
+        local convolution alongside the global spectral convolution. Default: 1
     channel_mlp_skip : str, optional
         Module to use for ChannelMLP skip connections. Options: "linear", "soft-gating", "identity", None, by default "soft-gating"
         If None, no skip connection is added. See layers.skip_connections for more details
@@ -119,6 +151,7 @@ class FNOBlocks(nn.Module):
         ada_in_features=None,
         preactivation=False,
         fno_skip="linear",
+        conv_bias_kernel=1,
         channel_mlp_skip="soft-gating",
         complex_data=False,
         separable=False,
@@ -151,6 +184,7 @@ class FNOBlocks(nn.Module):
         self.fixed_rank_modes = fixed_rank_modes
         self.decomposition_kwargs = decomposition_kwargs
         self.fno_skip = fno_skip
+        self.conv_bias_kernel = conv_bias_kernel
         self.channel_mlp_skip = channel_mlp_skip
         self.complex_data = complex_data
 
@@ -203,8 +237,24 @@ class FNOBlocks(nn.Module):
         )
 
         if fno_skip is not None:
-            self.fno_skips = nn.ModuleList(
-                [
+            if fno_skip.lower() == "linear":
+                # FourCastNet v3-like local + global convolutions: the spectral
+                # path is global, while larger kernels give this bias term locality.
+                fno_skip_modules = [
+                    _make_conv_bias(
+                        self.in_channels,
+                        self.out_channels,
+                        self.n_dim,
+                        conv_bias_kernel,
+                    )
+                    for _ in range(n_layers)
+                ]
+            else:
+                if conv_bias_kernel != 1:
+                    raise ValueError(
+                        "conv_bias_kernel can only differ from 1 when fno_skip='linear'."
+                    )
+                fno_skip_modules = [
                     skip_connection(
                         self.in_channels,
                         self.out_channels,
@@ -213,8 +263,12 @@ class FNOBlocks(nn.Module):
                     )
                     for _ in range(n_layers)
                 ]
-            )
+            self.fno_skips = nn.ModuleList(fno_skip_modules)
         else:
+            if conv_bias_kernel != 1:
+                raise ValueError(
+                    "conv_bias_kernel can only differ from 1 when fno_skip='linear'."
+                )
             self.fno_skips = None
         if self.complex_data and self.fno_skips is not None:
             self.fno_skips = nn.ModuleList([ComplexValued(x) for x in self.fno_skips])

--- a/neuralop/layers/tests/test_fno_block.py
+++ b/neuralop/layers/tests/test_fno_block.py
@@ -199,3 +199,28 @@ def test_FNOBlock_skip_connections_preactivation(fno_skip, channel_mlp_skip):
 
     # Check output shape
     assert res.shape == (2, 4, *size)
+
+
+@pytest.mark.parametrize("n_dim", [1, 2, 3])
+def test_FNOBlock_conv_bias_kernel(n_dim):
+    """Test local convolutional bias kernels beside spectral convolution."""
+    modes = (8, 8, 8)
+    size = [10, 10, 10]
+    conv_bias_kernel = 3
+
+    block = FNOBlocks(
+        3,
+        4,
+        modes[:n_dim],
+        n_layers=2,
+        conv_bias_kernel=conv_bias_kernel,
+        fno_skip="linear",
+        use_channel_mlp=False,
+    )
+
+    x = torch.randn(2, 3, *size[:n_dim])
+    res = block(x)
+
+    assert res.shape == (2, 4, *size[:n_dim])
+    assert block.conv_bias_kernel == conv_bias_kernel
+    assert block.fno_skips[0].kernel_size == (conv_bias_kernel,) * n_dim

--- a/neuralop/models/fno.py
+++ b/neuralop/models/fno.py
@@ -89,6 +89,10 @@ class FNO(BaseModel, name="FNO"):
     fno_skip : Literal["linear", "identity", "soft-gating", None], optional
         Type of skip connection to use in FNO layers. Options: "linear", "identity", "soft-gating", None.
         Default: "linear"
+    conv_bias_kernel : int, optional
+        Kernel size for the local convolutional bias term used when ``fno_skip="linear"``.
+        ``1`` preserves the default pointwise bias term, while larger kernels add a
+        local convolution alongside the global spectral convolution. Default: 1
     resolution_scaling_factor : Union[Number, List[Number]], optional
         Layer-wise factor by which to scale the domain resolution of function.
         Options:
@@ -185,6 +189,7 @@ class FNO(BaseModel, name="FNO"):
         channel_mlp_expansion: float = 0.5,
         channel_mlp_skip: Literal["linear", "identity", "soft-gating", None] = "soft-gating",
         fno_skip: Literal["linear", "identity", "soft-gating", None] = "linear",
+        conv_bias_kernel: int = 1,
         resolution_scaling_factor: Union[Number, List[Number]] = None,
         domain_padding: Union[Number, List[Number]] = None,
         fno_block_precision: str = "full",
@@ -227,6 +232,7 @@ class FNO(BaseModel, name="FNO"):
         self.fixed_rank_modes = fixed_rank_modes
         self.decomposition_kwargs = decomposition_kwargs
         self.fno_skip = (fno_skip,)
+        self.conv_bias_kernel = conv_bias_kernel
         self.channel_mlp_skip = (channel_mlp_skip,)
         self.implementation = implementation
         self.separable = separable
@@ -291,6 +297,7 @@ class FNO(BaseModel, name="FNO"):
             norm=norm,
             preactivation=preactivation,
             fno_skip=fno_skip,
+            conv_bias_kernel=conv_bias_kernel,
             channel_mlp_skip=channel_mlp_skip,
             complex_data=complex_data,
             max_n_modes=max_n_modes,

--- a/neuralop/models/tests/test_fno.py
+++ b/neuralop/models/tests/test_fno.py
@@ -248,3 +248,35 @@ def test_fno_channel_mlp_params(channel_mlp_dropout, channel_mlp_expansion, non_
 
     # Check output size
     assert list(out.shape) == [batch_size, 1, *size]
+
+
+def test_fno_conv_bias_kernel():
+    """Test FNO with a local convolutional bias kernel."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    s = 12
+    modes = 5
+    hidden_channels = 9
+    batch_size = 3
+    n_layers = 2
+    n_dim = 2
+    size = (s,) * n_dim
+    n_modes = (modes,) * n_dim
+    conv_bias_kernel = 3
+
+    model = FNO(
+        in_channels=3,
+        out_channels=1,
+        n_modes=n_modes,
+        hidden_channels=hidden_channels,
+        n_layers=n_layers,
+        conv_bias_kernel=conv_bias_kernel,
+    ).to(device)
+
+    in_data = torch.randn(batch_size, 3, *size).to(device)
+    out = model(in_data)
+
+    assert list(out.shape) == [batch_size, 1, *size]
+    assert model.conv_bias_kernel == conv_bias_kernel
+    assert model.fno_blocks.conv_bias_kernel == conv_bias_kernel
+
+    out.sum().backward()


### PR DESCRIPTION
## Summary

Adds `conv_bias_kernel: int = 1` to `FNO` and threads it through to `FNOBlocks`.

This enables an FCN3-like local convolutional bias alongside the global spectral convolution, giving FNO blocks a configurable local + global convolution path. This can help for non-smooth problems where purely global spectral layers may struggle to represent localised features.

By default, `conv_bias_kernel=1` preserves the existing pointwise channel-mixing behaviour. Larger values configure the bias path to use a local convolution kernel.

## Tests

- `python -m compileall neuralop/layers/fno_block.py neuralop/models/fno.py neuralop/layers/tests/test_fno_block.py neuralop/models/tests/test_fno.py`
- `/private/tmp/neuralop-test-venv/bin/python -m pytest neuralop/layers/tests/test_fno_block.py neuralop/models/tests/test_fno.py`

Result: `390 passed`