### PR TITLE
fix: align GINOConfig parameter names with GINO.__init__ signature

### DIFF
--- a/config/models.py
+++ b/config/models.py
@@ -149,11 +149,13 @@ class GINOConfig(ModelConfig):
     out_channels: int
     latent_feature_channels: Optional[int] = None
     gno_coord_dim: int = 3
-    gno_coord_embed_dim: int = 16
-    gno_radius: float = 0.033
+    gno_embed_channels: int = 16
+    in_gno_radius: float = 0.033
+    out_gno_radius: float = 0.033
     in_gno_transform_type: str = "linear"
     out_gno_transform_type: str = "linear"
-    gno_pos_embed_type: str = "nerf"
+    in_gno_pos_embed_type: str = "nerf"
+    out_gno_pos_embed_type: str = "nerf"
     gno_weighting_function: Optional[str] = None
     gno_weight_function_scale: Optional[float] = None
     fno_n_modes: List[int] = [16, 16, 16]
@@ -163,7 +165,6 @@ class GINOConfig(ModelConfig):
     fno_ada_in_features: int = 32
     fno_factorization: str = "tucker"
     fno_rank: float = 0.4
-    fno_domain_padding: float = 0.125
     fno_channel_mlp_expansion: float = 1.0
     fno_resolution_scaling_factor: int = 1
 
@@ -173,8 +174,9 @@ class GINO_Small3d(GINOConfig):
     out_channels: int = 1
     latent_feature_channels: Optional[int] = 1
     gno_coord_dim: int = 3
-    gno_coord_embed_dim: int = 16
-    gno_radius: float = 0.033
+    gno_embed_channels: int = 16
+    in_gno_radius: float = 0.033
+    out_gno_radius: float = 0.033
 
 
 class GINO_Poisson2d(GINOConfig):
@@ -209,7 +211,6 @@ class GINO_Poisson2d(GINOConfig):
     fno_ada_in_features: int = 8
     fno_factorization: Optional[Any] = None
     fno_rank: float = 0.8
-    fno_domain_padding: float = 0.0
 
 
 class OTNOConfig(ModelConfig):


### PR DESCRIPTION
## Summary

`GINOConfig` (and its subclass `GINO_Small3d`) defined four config fields whose names do not match any parameter in `GINO.__init__`. This caused an immediate `TypeError` when running `scripts/train_gino_carcfd.py`, because `get_model` passes all config fields as `**kwargs` directly to the model constructor.

**Changes in `config/models.py`:**

| Old field (config) | Correct field (GINO `__init__`) |
|---|---|
| `gno_coord_embed_dim` | `gno_embed_channels` |
| `gno_radius` | `in_gno_radius` + `out_gno_radius` (split) |
| `gno_pos_embed_type` | `in_gno_pos_embed_type` + `out_gno_pos_embed_type` (split) |
| `fno_domain_padding` | *(removed — not a GINO parameter)* |

The same stale `fno_domain_padding` field is also removed from `GINO_Poisson2d`, which inherits from `GINOConfig`.

Note: `GINO_Poisson2d` already used the correct split names (`in_gno_radius`, `out_gno_radius`, `in_gno_pos_embed_type`, `out_gno_pos_embed_type`, `gno_embed_channels`) as its own overrides — those are preserved unchanged.

## Test plan

- [x] Ran `scripts/train_gino_carcfd.py` — model now instantiates and trains without error (verified epoch 0 and epoch 1 with decreasing loss)
- [x] `black config/models.py` — no formatting changes needed