### PR TITLE
Fix double non-linearity application in `FNOBlocks` when `use_channel_mlp=False`

### DIFF
--- a/neuralop/layers/fno_block.py
+++ b/neuralop/layers/fno_block.py
@@ -311,8 +311,9 @@ class FNOBlocks(nn.Module):
                     [ComplexValued(x) for x in self.channel_mlp_skips]
                 )
 
-        # Each block will have 2 norms if we also use a ChannelMLP
-        self.n_norms = 2
+        # Each block has 2 norms when using ChannelMLP (one after FNO conv, one after MLP),
+        # but only 1 when channel MLP is disabled.
+        self.n_norms = 2 if self.use_channel_mlp else 1
         if norm is None:
             self.norm = None
         elif norm == "instance_norm":
@@ -405,11 +406,11 @@ class FNOBlocks(nn.Module):
             else:
                 x = self.channel_mlp[index](x)
 
-        if self.norm is not None:
-            x = self.norm[self.n_norms * index + 1](x)
+            if self.norm is not None:
+                x = self.norm[self.n_norms * index + 1](x)
 
-        if index < (self.n_layers - 1):
-            x = self.non_linearity(x)
+            if index < (self.n_layers - 1):
+                x = self.non_linearity(x)
 
         return x
 
@@ -442,10 +443,10 @@ class FNOBlocks(nn.Module):
         if index < (self.n_layers - 1):
             x = self.non_linearity(x)
 
-        if self.norm is not None:
-            x = self.norm[self.n_norms * index + 1](x)
-
         if self.use_channel_mlp:
+            if self.norm is not None:
+                x = self.norm[self.n_norms * index + 1](x)
+
             if self.channel_mlp_skips is not None:
                 x = self.channel_mlp[index](x) + x_skip_channel_mlp
             else:

--- a/neuralop/layers/tests/test_fno_block.py
+++ b/neuralop/layers/tests/test_fno_block.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+import torch.nn.functional as F
 from ..fno_block import FNOBlocks
 
 
@@ -248,3 +249,31 @@ def test_FNOBlock_conv_bias_kernel(n_dim):
     assert res.shape == (2, 4, *size[:n_dim])
     assert block.conv_bias_kernel == conv_bias_kernel
     assert block.fno_skips[0].kernel_size == (conv_bias_kernel,) * n_dim
+
+
+def test_FNOBlock_no_double_nonlinearity():
+    """Regression test for issue #728: non-linearity must not be applied twice when use_channel_mlp=False."""
+    call_count = 0
+
+    def counting_nonlin(x):
+        nonlocal call_count
+        call_count += 1
+        return F.gelu(x)
+
+    n_layers = 3
+    block = FNOBlocks(
+        3,
+        3,
+        (8, 8),
+        n_layers=n_layers,
+        use_channel_mlp=False,
+        non_linearity=counting_nonlin,
+    )
+    x = torch.randn(2, 3, 16, 16)
+    for i in range(n_layers):
+        call_count = 0
+        x = block(x, index=i)
+        expected = 1 if i < n_layers - 1 else 0
+        assert call_count == expected, (
+            f"Layer {i}: expected {expected} non-linearity call(s), got {call_count}"
+        )


### PR DESCRIPTION
Fixes #728

### Problem

When `use_channel_mlp=False`, `FNOBlocks.forward_with_postactivation` applied
the non-linearity **twice** per non-final block:

```
gelu(gelu(conv(x) + skip(x)))  # actual (broken)
gelu(conv(x) + skip(x))        # expected
```

The same indexing bug existed in `forward_with_preactivation`. This was
introduced in v2.0.0 when the `use_channel_mlp` flag was reintroduced without
restoring the guards that existed in v0.3.0. The result was silent prediction
differences despite parameter counts and state dicts matching exactly between
versions. The bug affects all non-final `FNOBlocks` and flows through to
`FNOGNO` and `GINO` via their `fno_use_channel_mlp` parameter.

### Changes

**`neuralop/layers/fno_block.py`**
- `__init__`: Set `self.n_norms = 1` when `use_channel_mlp=False` (was always
  `2`) so the norm `ModuleList` is sized correctly and norm indexing is safe.
- `forward_with_postactivation`: Guard the trailing norm and trailing
  non-linearity inside `if self.use_channel_mlp` so they only fire when the
  channel MLP is active.
- `forward_with_preactivation`: Same guard — move the second norm index inside
  `if self.use_channel_mlp`.

**`neuralop/layers/tests/test_fno_block.py`**
- Add `test_FNOBlock_no_double_nonlinearity`: regression test that wraps the
  non-linearity in a call counter and asserts it fires exactly once per
  non-final block (zero times on the final block) when `use_channel_mlp=False`.
