### PR TITLE
Fixed character overlay when printing progress for dataset download

### DIFF
--- a/neuralop/data/datasets/web_utils.py
+++ b/neuralop/data/datasets/web_utils.py
@@ -108,7 +108,7 @@ def download_from_url(
                     # print progress dynamically
                     curr_size += chunk_size
                     prog = curr_size / size
-                    print(f"Download in progress: {prog:.2%}", end="\r")
+                    print(f"Download in progress: {prog:.2%}".ljust(40), end="\r")
 
             assert (
                 fpath.stat().st_size == size


### PR DESCRIPTION
When downloading multiple datasets (i.e DarcyFlow for gridsize 16 and 32), the first set completes download printing

**Download in progress: 100.01%**

Leaving a '%' character at the end. The new dataset download progress prints as:

**Download in progress: 62.81%%**

This happens because the carriage return ('/r') moves the cursor back to the start of the line, it does not erase anything there.

Adding **.ljust(40)** to add a fixed width string, so the entire output is fully overwritten. 