### PR TITLE
Fix TF32 settings for reproducible PINO training

### DIFF
--- a/config/burgers_config.py
+++ b/config/burgers_config.py
@@ -30,6 +30,7 @@ class BurgersOptConfig(ConfigBase):
     weight_decay: float = 1e-4
     eval_interval: int = 1
     mixed_precision: bool = False
+    allow_tf32: bool = True
     scheduler: str = "ReduceLROnPlateau"  # Or 'CosineAnnealingLR' OR 'ReduceLROnPlateau'
     scheduler_patience: int = 100  # For ReduceLROnPlateau only
     step_size: int = 60

--- a/config/burgers_pino_config.py
+++ b/config/burgers_pino_config.py
@@ -30,6 +30,8 @@ class BurgersOptConfig(OptimizationConfig):
     weight_decay: float = 1e-4
     eval_interval: int = 1
     mixed_precision: bool = False
+    # Full IEEE float32 avoids architecture-dependent TF32 rounding in PINO.
+    allow_tf32: bool = False
     scheduler: str = "ReduceLROnPlateau"  # Or 'CosineAnnealingLR' OR 'ReduceLROnPlateau'
     scheduler_patience: int = 100  # For ReduceLROnPlateau only
     step_size: int = 60

--- a/config/burgers_rno_config.py
+++ b/config/burgers_rno_config.py
@@ -29,6 +29,7 @@ class BurgersOptConfig(ConfigBase):
     weight_decay: float = 0.0
     eval_interval: int = 1
     mixed_precision: bool = False
+    allow_tf32: bool = True
     scheduler: str = "StepLR"
     scheduler_patience: int = 100
     step_size: int = 60

--- a/config/default_config.py
+++ b/config/default_config.py
@@ -58,6 +58,7 @@ class Opt(ConfigBase):
     scheduler: str = "StepLR"
     step_size: int = 100
     gamma: float = 0.5
+    allow_tf32: bool = True
 
 
 class Data(ConfigBase):

--- a/config/gino_carcfd_config.py
+++ b/config/gino_carcfd_config.py
@@ -21,6 +21,7 @@ class CarCFDOptConfig(ConfigBase):
     training_loss: str = "l2"
     testing_loss: str = "l2"
     weight_decay: float = 1e-4
+    allow_tf32: bool = True
     scheduler: str = "StepLR"
     step_size: int = 50
     gamma: float = 0.5

--- a/config/opt.py
+++ b/config/opt.py
@@ -10,6 +10,10 @@ class OptimizationConfig(ConfigBase):
     weight_decay: float = 1e-4
     eval_interval: int = 1
     mixed_precision: bool = False
+    # Keep the historical fast default for general training. PINO overrides
+    # this to False because TF32 can change the numerical trajectory across
+    # GPU architectures.
+    allow_tf32: bool = True
     scheduler: Literal["StepLR", "ReduceLROnPlateau", "CosineAnnealingLR"] = "StepLR"
     scheduler_T_max: int = 500
     scheduler_patience: int = 50

--- a/config/uqno_config.py
+++ b/config/uqno_config.py
@@ -54,6 +54,7 @@ class UQNODarcyDatasetConfig(ConfigBase):
 class UQNO_OptConfig(ConfigBase):
     alpha: float = 0.9
     delta: float = 0.95
+    allow_tf32: bool = True
     solution: SolutionModelOptConfig = SolutionModelOptConfig()
     residual: ResidualModelOptConfig = ResidualModelOptConfig()
 

--- a/neuralop/training/__init__.py
+++ b/neuralop/training/__init__.py
@@ -1,5 +1,5 @@
 from .trainer import Trainer
-from .torch_setup import setup
+from .torch_setup import set_tf32, setup
 from .training_state import load_training_state, save_training_state
 from .incremental import IncrementalFNOTrainer
 from .adamw import AdamW

--- a/neuralop/training/tests/test_torch_setup.py
+++ b/neuralop/training/tests/test_torch_setup.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+import pytest
+
+from neuralop.training import torch_setup
+
+
+class LegacyTorch:
+    def __init__(self):
+        self.precision = None
+        self.backends = SimpleNamespace(
+            cuda=SimpleNamespace(matmul=SimpleNamespace(allow_tf32=None)),
+            cudnn=SimpleNamespace(allow_tf32=None),
+        )
+
+    def set_float32_matmul_precision(self, precision):
+        self.precision = precision
+
+
+class NewTorch:
+    def __init__(self):
+        self.backends = SimpleNamespace(fp32_precision="none")
+
+
+@pytest.mark.parametrize(
+    ("allow_tf32", "expected_precision"),
+    [(False, "highest"), (True, "high")],
+)
+def test_set_tf32_legacy_api(monkeypatch, allow_tf32, expected_precision):
+    fake_torch = LegacyTorch()
+    monkeypatch.setattr(torch_setup, "torch", fake_torch)
+
+    torch_setup.set_tf32(allow_tf32)
+
+    assert fake_torch.precision == expected_precision
+    assert fake_torch.backends.cuda.matmul.allow_tf32 is allow_tf32
+    assert fake_torch.backends.cudnn.allow_tf32 is allow_tf32
+
+
+@pytest.mark.parametrize(
+    ("allow_tf32", "expected_precision"), [(False, "ieee"), (True, "tf32")]
+)
+def test_set_tf32_new_api(monkeypatch, allow_tf32, expected_precision):
+    fake_torch = NewTorch()
+    monkeypatch.setattr(torch_setup, "torch", fake_torch)
+
+    torch_setup.set_tf32(allow_tf32)
+
+    assert fake_torch.backends.fp32_precision == expected_precision
+
+
+def test_set_tf32_rejects_non_boolean_values():
+    with pytest.raises(TypeError, match="allow_tf32 must be a bool"):
+        torch_setup.set_tf32("false")

--- a/neuralop/training/tests/test_torch_setup.py
+++ b/neuralop/training/tests/test_torch_setup.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -19,7 +21,15 @@ class LegacyTorch:
 
 class NewTorch:
     def __init__(self):
-        self.backends = SimpleNamespace(fp32_precision="none")
+        self.backends = SimpleNamespace(
+            fp32_precision="none",
+            cuda=SimpleNamespace(matmul=SimpleNamespace(fp32_precision="tf32")),
+            cudnn=SimpleNamespace(
+                fp32_precision="none",
+                conv=SimpleNamespace(fp32_precision="tf32"),
+                rnn=SimpleNamespace(fp32_precision="tf32"),
+            ),
+        )
 
 
 @pytest.mark.parametrize(
@@ -47,8 +57,46 @@ def test_set_tf32_new_api(monkeypatch, allow_tf32, expected_precision):
     torch_setup.set_tf32(allow_tf32)
 
     assert fake_torch.backends.fp32_precision == expected_precision
+    assert fake_torch.backends.cuda.matmul.fp32_precision == expected_precision
+    assert fake_torch.backends.cudnn.fp32_precision == expected_precision
+    assert fake_torch.backends.cudnn.conv.fp32_precision == expected_precision
+    assert fake_torch.backends.cudnn.rnn.fp32_precision == expected_precision
 
 
 def test_set_tf32_rejects_non_boolean_values():
     with pytest.raises(TypeError, match="allow_tf32 must be a bool"):
         torch_setup.set_tf32("false")
+
+
+def test_set_tf32_overrides_existing_backend_settings():
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import torch
+from neuralop.training.torch_setup import set_tf32
+
+if hasattr(torch.backends, "fp32_precision"):
+    backends = [
+        torch.backends,
+        torch.backends.cuda.matmul,
+        torch.backends.cudnn,
+        torch.backends.cudnn.conv,
+        torch.backends.cudnn.rnn,
+    ]
+    for enabled in (False, True):
+        for backend in backends:
+            backend.fp32_precision = "ieee" if enabled else "tf32"
+        set_tf32(enabled)
+        expected = "tf32" if enabled else "ieee"
+        assert all(backend.fp32_precision == expected for backend in backends)
+else:
+    for enabled in (False, True):
+        set_tf32(enabled)
+        assert torch.backends.cuda.matmul.allow_tf32 is enabled
+        assert torch.backends.cudnn.allow_tf32 is enabled
+""",
+        ],
+        check=True,
+    )

--- a/neuralop/training/torch_setup.py
+++ b/neuralop/training/torch_setup.py
@@ -24,20 +24,14 @@ def set_tf32(allow_tf32: bool):
 
     precision = "tf32" if allow_tf32 else "ieee"
 
-    # PyTorch >= 2.9: use the new global precision policy. Setting the global
-    # policy also covers CUDA matmuls and cuDNN operators without combining
-    # the new API with the deprecated per-backend flags.
     if hasattr(torch.backends, "fp32_precision"):
-        try:
-            torch.backends.fp32_precision = precision
-        except (AttributeError, RuntimeError):
-            # A partially backported build may expose the attribute without
-            # supporting assignment. Fall through to the legacy API.
-            pass
-        else:
-            return
+        torch.backends.fp32_precision = precision
+        torch.backends.cuda.matmul.fp32_precision = precision
+        torch.backends.cudnn.fp32_precision = precision
+        torch.backends.cudnn.conv.fp32_precision = precision
+        torch.backends.cudnn.rnn.fp32_precision = precision
+        return
 
-    # PyTorch < 2.9: set the matmul policy and the separate cuDNN flag.
     try:
         torch.set_float32_matmul_precision("high" if allow_tf32 else "highest")
     except AttributeError:

--- a/neuralop/training/torch_setup.py
+++ b/neuralop/training/torch_setup.py
@@ -2,6 +2,57 @@ import torch
 import neuralop.mpu.comm as comm
 
 
+def set_tf32(allow_tf32: bool):
+    """Configure float32 math precision consistently across PyTorch versions.
+
+    Parameters
+    ----------
+    allow_tf32 : bool
+        Whether float32 matrix multiplications and cuDNN convolutions may use
+        TensorFloat-32. ``False`` selects IEEE float32 math and is the safer
+        choice for reproducible physics-informed training.
+
+    Notes
+    -----
+    PyTorch 2.9 introduced the ``torch.backends.fp32_precision`` API and is
+    deprecating the older ``allow_tf32`` flags. Older PyTorch releases use
+    the legacy flags, so this helper keeps the training scripts compatible
+    with both APIs without mixing them on newer releases.
+    """
+    if not isinstance(allow_tf32, bool):
+        raise TypeError(f"allow_tf32 must be a bool, got {type(allow_tf32).__name__}")
+
+    precision = "tf32" if allow_tf32 else "ieee"
+
+    # PyTorch >= 2.9: use the new global precision policy. Setting the global
+    # policy also covers CUDA matmuls and cuDNN operators without combining
+    # the new API with the deprecated per-backend flags.
+    if hasattr(torch.backends, "fp32_precision"):
+        try:
+            torch.backends.fp32_precision = precision
+        except (AttributeError, RuntimeError):
+            # A partially backported build may expose the attribute without
+            # supporting assignment. Fall through to the legacy API.
+            pass
+        else:
+            return
+
+    # PyTorch < 2.9: set the matmul policy and the separate cuDNN flag.
+    try:
+        torch.set_float32_matmul_precision("high" if allow_tf32 else "highest")
+    except AttributeError:
+        pass
+
+    cuda_backends = getattr(torch.backends, "cuda", None)
+    cuda_matmul = getattr(cuda_backends, "matmul", None)
+    if cuda_matmul is not None:
+        cuda_matmul.allow_tf32 = allow_tf32
+
+    cudnn = getattr(torch.backends, "cudnn", None)
+    if cudnn is not None:
+        cudnn.allow_tf32 = allow_tf32
+
+
 def setup(config):
     """A convenience function to intialize the device, setup torch settings and
     check multi-grid and other values. It sets up distributed communitation, if used.
@@ -12,6 +63,7 @@ def setup(config):
         this function checks:
         * config.distributed (use_distributed, seed)
         * config.data (n_train, batch_size, test_batch_sizes, n_tests, test_resolutions)
+        * config.opt (allow_tf32)
 
     Returns
     -------
@@ -65,10 +117,7 @@ def setup(config):
         if seed is not None:
             torch.cuda.manual_seed(seed)
         increase_l2_fetch_granularity()
-        try:
-            torch.set_float32_matmul_precision("high")
-        except AttributeError:
-            pass
+        set_tf32(config.opt.get("allow_tf32", True))
 
         torch.backends.cudnn.benchmark = True
 

--- a/scripts/train_burgers_pino.py
+++ b/scripts/train_burgers_pino.py
@@ -13,7 +13,7 @@ import torch.nn.functional as F
 
 from neuralop import H1Loss, LpLoss, BurgersEqnLoss, ICLoss, get_model
 from neuralop.data.datasets import load_mini_burgers_1dtime
-from neuralop.training import AdamW
+from neuralop.training import AdamW, setup
 from neuralop.utils import get_wandb_api_key, count_model_params, get_project_root
 from neuralop.losses.meta_losses import Relobralo, SoftAdapt
 
@@ -29,7 +29,9 @@ config = make_config_from_cli(Default)
 config = config.to_dict()
 
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+# Apply the same device and precision setup used by the other training entry
+# points. The PINO config opts into IEEE float32 by default for reproducibility.
+device, is_logger = setup(config)
 
 
 # Set up WandB logging


### PR DESCRIPTION
This adds an explicit `allow_tf32` option to the shared training setup and routes the Burgers PINO script through it. General training permits TF32 by default; the Burgers PINO configuration selects IEEE float32.

On newer PyTorch versions, changing only the global precision setting does not override an existing backend setting. The helper now sets the global, CUDA matmul, and cuDNN precision controls explicitly. Older versions use the legacy flags, without mixing the two APIs.

Validation on Python 3.12.13 and PyTorch 2.14.0+cpu:
- 6 focused tests passed, including a separate-process test of the real PyTorch controls with conflicting backend settings.
- 76 training/config tests passed with zencfg 0.3.0; the dataset-dependent `test_incremental` was excluded after its download stalled.
- The Burgers PINO configuration loads and shared setup runs on CPU.
- `git diff --check` passed.

Full-suite collection is currently blocked by the `make_config` import in `test_model_from_config.py`. CUDA execution and a matched PINO training comparison across GPUs remain unverified; these CPU tests validate precision configuration, not cross-GPU training reproducibility.

Related to #720.