### PR TITLE
Use native segment reduction during compilation

### DIFF
--- a/neuralop/layers/gno_block.py
+++ b/neuralop/layers/gno_block.py
@@ -80,7 +80,9 @@ class GNOBlock(nn.Module):
         Default None, by default None
     use_torch_scatter_reduce : bool, optional
         Whether to use torch-scatter to perform grouped reductions in the IntegralTransform.
-        If False, uses native Python reduction in neuralop.layers.segment_csr, by default True
+        If False, uses native PyTorch segment reduction when available, by default True.
+        Native reduction is also selected automatically while tracing with
+        ``torch.compile``.
 
         .. warning::
 

--- a/neuralop/layers/integral_transform.py
+++ b/neuralop/layers/integral_transform.py
@@ -58,7 +58,9 @@ class IntegralTransform(nn.Module):
         by default independently of this parameter, by default 'linear'
     use_torch_scatter : bool, optional
         Whether to use torch-scatter to perform grouped reductions in the IntegralTransform. 
-        If False, uses native Python reduction in neuralop.layers.segment_csr, by default True
+        If False, uses native PyTorch segment reduction when available, by default True.
+        Native reduction is also selected automatically while tracing with
+        ``torch.compile``.
 
         .. warning:: 
 

--- a/neuralop/layers/segment_csr.py
+++ b/neuralop/layers/segment_csr.py
@@ -5,6 +5,36 @@ import torch
 from torch import einsum
 
 
+def _is_compiling():
+    """Return whether this function is being traced by ``torch.compile``."""
+    compiler = getattr(torch, "compiler", None)
+    is_compiling = getattr(compiler, "is_compiling", None)
+    if is_compiling is not None:
+        return is_compiling()
+
+    # ``torch.compiler.is_compiling`` is not available on older supported
+    # PyTorch versions. Keep the fallback private so importing this module does
+    # not require a particular PyTorch release.
+    dynamo = getattr(torch, "_dynamo", None)
+    is_compiling = getattr(dynamo, "is_compiling", None)
+    return is_compiling is not None and is_compiling()
+
+
+def _native_segment_reduce(src, indptr, reduction):
+    """Reduce CSR segments with the native PyTorch implementation."""
+    batched = src.ndim == 3
+    axis = 1 if batched else 0
+
+    # ``segment_reduce`` returns NaN for empty mean segments. Dividing the sum
+    # by clamped lengths preserves the historical zero output for empty
+    # neighborhoods while retaining a single compiled native operation.
+    out = torch.segment_reduce(src, "sum", offsets=indptr, axis=axis)
+    if reduction == "mean":
+        lengths = indptr.diff(dim=-1).to(dtype=out.dtype).clamp_min(1)
+        out = out / lengths.unsqueeze(-1)
+    return out
+
+
 def segment_csr(
     src: torch.Tensor,
     indptr: torch.Tensor,
@@ -18,11 +48,15 @@ def segment_csr(
     in neuralop.layers.IntegralTransform
 
     If use_scatter is set to False or torch_scatter is not
-    properly built, segment_csr falls back to a naive PyTorch implementation
+    properly built, segment_csr uses native PyTorch reduction when available,
+    otherwise falling back to the legacy PyTorch implementation.
 
-    Note: the native version is mainly intended for running tests on
-    CPU-only GitHub CI runners to get around a versioning issue.
-    torch_scatter should be installed and built if possible.
+    When available, native ``torch.segment_reduce`` is used whenever
+    ``torch.compile`` is tracing this function or ``use_scatter`` is False.
+    This keeps compiled GINO models free of an opaque ``torch_scatter`` call,
+    while preserving the faster ``torch_scatter`` path for eager execution.
+    Older PyTorch versions without ``torch.segment_reduce`` retain the
+    existing PyTorch fallback.
 
     Parameters
     ----------
@@ -35,7 +69,8 @@ def segment_csr(
         How to reduce a neighborhood. Options: 'mean', 'sum'. If mean,
         reduce by taking the average of all neighbors. Otherwise take the sum.
     use_scatter : bool, optional
-        Whether to use torch-scatter.segment_csr. If False, uses native Python reduction, by default True
+        Whether to use torch-scatter.segment_csr for eager execution. If False,
+        use native PyTorch reduction when available, by default True
 
         .. warning::
 
@@ -45,6 +80,10 @@ def segment_csr(
     """
     if reduction not in ["mean", "sum"]:
         raise ValueError("reduce must be one of 'mean', 'sum'")
+
+    use_native = not use_scatter or _is_compiling()
+    if use_native and hasattr(torch, "segment_reduce"):
+        return _native_segment_reduce(src, indptr, reduction)
 
     if importlib.util.find_spec("torch_scatter") is not None and use_scatter:
         """only import torch_scatter when cuda is available"""

--- a/neuralop/layers/tests/test_segment_csr.py
+++ b/neuralop/layers/tests/test_segment_csr.py
@@ -1,4 +1,5 @@
 import torch
+from .. import segment_csr as segment_csr_module
 from ..segment_csr import segment_csr
 
 import pytest
@@ -44,3 +45,68 @@ def test_native_segcsr_reductions():
     assert out_mean.shape == (3, 3)
     diff = out_mean - torch.ones([3, 3])
     assert not diff.nonzero().any()
+
+
+@pytest.mark.skipif(
+    not hasattr(torch, "segment_reduce"),
+    reason="torch.segment_reduce requires a newer PyTorch version",
+)
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("reduction", ["sum", "mean"])
+def test_native_segment_reduce_matches_csr_fallback(batch_size, reduction):
+    src = torch.arange(batch_size * 4 * 2, dtype=torch.float32).reshape(
+        batch_size, 4, 2
+    )
+    indptr = torch.tensor([0, 2, 2, 4], dtype=torch.long)
+    if batch_size > 1:
+        batched_indptr = indptr.repeat(batch_size, 1)
+        native_src = src
+        native_indptr = batched_indptr
+    else:
+        native_src = src.squeeze(0)
+        native_indptr = indptr
+
+    native = segment_csr(
+        native_src, native_indptr, reduction=reduction, use_scatter=False
+    )
+    expected = []
+    for start, end in zip(indptr[:-1], indptr[1:]):
+        values = (
+            native_src[..., start:end, :]
+            if batch_size > 1
+            else native_src[start:end]
+        )
+        if end == start:
+            values = torch.zeros_like(native_src[..., :1, :]).sum(dim=-2)
+        elif reduction == "mean":
+            values = values.mean(dim=-2)
+        else:
+            values = values.sum(dim=-2)
+        expected.append(values)
+    expected = torch.stack(expected, dim=-2)
+
+    torch.testing.assert_close(native, expected)
+
+
+@pytest.mark.skipif(
+    not hasattr(torch, "segment_reduce"),
+    reason="torch.segment_reduce requires a newer PyTorch version",
+)
+def test_compiling_prefers_native_segment_reduce(monkeypatch):
+    monkeypatch.setattr(segment_csr_module, "_is_compiling", lambda: True)
+    native_called = False
+    torch_segment_reduce = torch.segment_reduce
+
+    def recording_segment_reduce(*args, **kwargs):
+        nonlocal native_called
+        native_called = True
+        return torch_segment_reduce(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "segment_reduce", recording_segment_reduce)
+
+    src = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    indptr = torch.tensor([0, 2, 2, 4], dtype=torch.long)
+    result = segment_csr(src, indptr, reduction="mean", use_scatter=True)
+    expected = torch.tensor([[1.0, 2.0], [0.0, 0.0], [5.0, 6.0]])
+    assert native_called
+    torch.testing.assert_close(result, expected)


### PR DESCRIPTION
Fixes #733

## Summary
- use native `torch.segment_reduce` when compiling or when scatter-free execution is requested
- preserve the eager `torch_scatter` path
- preserve zero output for empty mean neighborhoods
- document the backend selection behavior

## Validation
- 93 targeted tests passed locally