### PR TITLE
Keep native neighbor CSR counts exact

### DIFF
--- a/neuralop/layers/neighbor_search.py
+++ b/neuralop/layers/neighbor_search.py
@@ -109,9 +109,18 @@ def native_neighbor_search(
     if return_norm:
         weights = dists[dists.nonzero(as_tuple=True)]
         nbr_dict["weights"] = weights **2 # weighting function computed on squared norms
-    in_nbr = torch.where(dists > 0, 1., 0.,)
-    nbrhd_sizes = torch.cumsum(torch.sum(in_nbr, dim=1), dim=0) # num points in each neighborhood, summed cumulatively
-    splits = torch.cat((torch.tensor([0.]).to(queries.device), nbrhd_sizes))
+    # Keep neighborhood counts in an integer dtype. Accumulating them in
+    # float32 loses exactness once the total exceeds 2**24, which can make
+    # neighbors_row_splits disagree with neighbors_index.
+    nbrhd_sizes = torch.cumsum(
+        torch.sum(dists > 0, dim=1, dtype=torch.long), dim=0
+    )
+    splits = torch.cat(
+        (
+            torch.zeros(1, dtype=torch.long, device=queries.device),
+            nbrhd_sizes,
+        )
+    )
     
     nbr_dict["neighbors_index"] = nbr_indices.long().to(queries.device)
     nbr_dict["neighbors_row_splits"] = splits.long()

--- a/neuralop/layers/tests/test_neighbor_search.py
+++ b/neuralop/layers/tests/test_neighbor_search.py
@@ -53,3 +53,21 @@ def test_fallback_nb_search():
 
     return_dict = compute_norm_separate(return_dict, coords, coords)
     print(return_dict["squared_norm"])
+
+
+def test_large_neighbor_counts_keep_csr_consistent():
+    # This creates just over 2**24 coincident pairs, the point where float32
+    # cumulative counts can no longer represent every integer exactly.
+    n_points = 4097
+    data = torch.zeros(n_points, 1)
+    queries = torch.zeros(n_points, 1)
+
+    result = native_neighbor_search(data, queries, radius=1.0)
+    expected_pairs = n_points * n_points
+    expected_splits = torch.arange(
+        0, expected_pairs + 1, n_points, dtype=torch.long
+    )
+
+    assert result["neighbors_index"].numel() == expected_pairs
+    assert result["neighbors_row_splits"].dtype == torch.long
+    torch.testing.assert_close(result["neighbors_row_splits"], expected_splits)


### PR DESCRIPTION
Fixes #740

## Summary
- accumulate native neighbor counts in int64 instead of float32
- keep `neighbors_index` and `neighbors_row_splits` consistent above 2**24 pairs
- add a regression with 4,097 × 4,097 coincident points

## Validation
- 2 neighbor-search tests passed
- 85 GNO/GINO downstream tests passed