### PR TITLE
Allow explicit PT dataset file paths

### DIFF
--- a/neuralop/data/datasets/navier_stokes.py
+++ b/neuralop/data/datasets/navier_stokes.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Union, List
+from typing import Union, List, Optional
 
 from torch.utils.data import DataLoader
 
@@ -52,6 +52,12 @@ class NavierStokesDataset(PTDataset):
         rate at which to subsample each input dimension, by default None
     download : bool, optional
         whether to download data if not present, by default True
+    train_path : Union[Path, str], optional
+        Path to the training data file. If provided, this path is used instead of the
+        default filename constructed from ``root_dir`` and ``train_resolution``.
+    test_paths : List[Union[Path, str]], optional
+        Paths to the test data files, in the same order as ``test_resolutions``. If
+        provided, these paths are used instead of the default filenames.
 
     Attributes
     ----------
@@ -76,6 +82,8 @@ class NavierStokesDataset(PTDataset):
         channel_dim=1,
         subsampling_rate=None,
         download: bool = True,
+        train_path: Optional[Union[Path, str]] = None,
+        test_paths: Optional[List[Union[Path, str]]] = None,
     ):
         """Initialize the NavierStokesDataset.
 
@@ -101,7 +109,9 @@ class NavierStokesDataset(PTDataset):
             ), f"Error: resolution {res} not available"
 
         # download darcy data from zenodo archive if passed
-        if download:
+        # Explicit paths refer to files supplied by the caller and should not trigger
+        # a download of the conventionally named archive files.
+        if download and train_path is None and test_paths is None:
             files_to_download = []
             already_downloaded_files = [x.name for x in root_dir.iterdir()]
             for res in resolutions:
@@ -132,6 +142,8 @@ class NavierStokesDataset(PTDataset):
             channel_dim=channel_dim,
             input_subsampling_rate=subsampling_rate,
             output_subsampling_rate=subsampling_rate,
+            train_path=train_path,
+            test_paths=test_paths,
         )
 
 

--- a/neuralop/data/datasets/navier_stokes.py
+++ b/neuralop/data/datasets/navier_stokes.py
@@ -108,23 +108,28 @@ class NavierStokesDataset(PTDataset):
                 res in available_resolutions
             ), f"Error: resolution {res} not available"
 
-        # download darcy data from zenodo archive if passed
-        # Explicit paths refer to files supplied by the caller and should not trigger
-        # a download of the conventionally named archive files.
-        if download and train_path is None and test_paths is None:
+        if download:
             files_to_download = []
             already_downloaded_files = [x.name for x in root_dir.iterdir()]
             for res in resolutions:
-                if (
-                    f"nsforcing_train_{res}.pt" not in already_downloaded_files
-                    or f"nsforcing_test_{res}.pt" not in already_downloaded_files
-                ):
+                needs_train = (
+                    train_path is None
+                    and res == train_resolution
+                    and f"nsforcing_train_{res}.pt" not in already_downloaded_files
+                )
+                needs_test = (
+                    test_paths is None
+                    and res in test_resolutions
+                    and f"nsforcing_test_{res}.pt" not in already_downloaded_files
+                )
+                if needs_train or needs_test:
                     files_to_download.append(f"nsforcing_{res}.tgz")
-            download_from_zenodo_record(
-                record_id=zenodo_record_id,
-                root=root_dir,
-                files_to_download=files_to_download,
-            )
+            if files_to_download:
+                download_from_zenodo_record(
+                    record_id=zenodo_record_id,
+                    root=root_dir,
+                    files_to_download=files_to_download,
+                )
 
         # once downloaded/if files already exist, init PTDataset
         super().__init__(

--- a/neuralop/data/datasets/pt_dataset.py
+++ b/neuralop/data/datasets/pt_dataset.py
@@ -63,6 +63,13 @@ class PTDataset:
         If not, we need to unsqueeze it to explicitly have a channel dim.
         Only applies when there is only one data channel, as in our example problems
         Defaults to True
+    train_path : Union[Path, str], optional
+        Path to the training data file. If not provided, the path is constructed from
+        ``root_dir``, ``dataset_name``, and ``train_resolution``.
+    test_paths : List[Union[Path, str]], optional
+        Paths to the test data files, in the same order as ``test_resolutions``. If not
+        provided, the paths are constructed from ``root_dir``, ``dataset_name``, and
+        each test resolution.
 
     All datasets are required to expose the following attributes after init:
 
@@ -90,6 +97,8 @@ class PTDataset:
         channel_dim=1,
         dtype=None,
         channels_squeezed=True,
+        train_path: Optional[Union[Path, str]] = None,
+        test_paths: Optional[List[Union[Path, str]]] = None,
     ):
         """Initialize the PTDataset.
 
@@ -106,11 +115,18 @@ class PTDataset:
         self.test_resolutions = test_resolutions
         self.test_batch_sizes = test_batch_sizes
 
+        if test_paths is not None and len(test_paths) != len(test_resolutions):
+            raise ValueError(
+                "test_paths must contain one path for each test resolution"
+            )
+
         # Load train data
 
-        data = torch.load(
-        Path(root_dir).joinpath(f"{dataset_name}_train_{train_resolution}.pt").as_posix()
-        )
+        if train_path is None:
+            train_path = Path(root_dir).joinpath(
+                f"{dataset_name}_train_{train_resolution}.pt"
+            )
+        data = torch.load(Path(train_path).as_posix())
 
         x_train = data["x"].to(dtype).clone()
         if channels_squeezed:
@@ -205,9 +221,15 @@ class PTDataset:
 
         # load test data
         self._test_dbs = {}
-        for res, n_test in zip(test_resolutions, n_tests):
+        if test_paths is None:
+            test_paths = [
+                Path(root_dir).joinpath(f"{dataset_name}_test_{res}.pt")
+                for res in test_resolutions
+            ]
+
+        for res, n_test, test_path in zip(test_resolutions, n_tests, test_paths):
             print(f"Loading test db for resolution {res} with {n_test} samples ")
-            data = torch.load(Path(root_dir).joinpath(f"{dataset_name}_test_{res}.pt").as_posix())
+            data = torch.load(Path(test_path).as_posix())
 
             x_test = data["x"].to(dtype).clone()
             if channels_squeezed:

--- a/neuralop/data/datasets/tests/test_ptdatasets.py
+++ b/neuralop/data/datasets/tests/test_ptdatasets.py
@@ -1,6 +1,7 @@
 from ..burgers import Burgers1dTimeDataset
 from ..darcy import DarcyDataset
 from ..navier_stokes import NavierStokesDataset
+from .. import navier_stokes
 from pathlib import Path
 
 import os
@@ -100,5 +101,36 @@ def test_NSExplicitPaths(tmp_path):
         test_paths=[test_path],
     )
 
+    assert len(dataset.train_db) == 2
+    assert len(dataset.test_dbs[128]) == 1
+
+
+@pytest.mark.parametrize("explicit_split", ["train", "test"])
+def test_NSPartialExplicitPaths(tmp_path, monkeypatch, explicit_split):
+    data = {"x": torch.randn(2, 128, 128), "y": torch.randn(2, 128, 128)}
+    explicit_path = tmp_path / "custom.pt"
+    torch.save(data, explicit_path)
+    missing_split = "test" if explicit_split == "train" else "train"
+    downloads = []
+
+    def download(record_id, root, files_to_download):
+        downloads.extend(files_to_download)
+        torch.save(data, root / f"nsforcing_{missing_split}_128.pt")
+
+    monkeypatch.setattr(navier_stokes, "download_from_zenodo_record", download)
+    dataset = NavierStokesDataset(
+        root_dir=tmp_path,
+        n_train=2,
+        n_tests=[1],
+        batch_size=1,
+        test_batch_sizes=[1],
+        train_resolution=128,
+        test_resolutions=[128],
+        encode_output=False,
+        train_path=explicit_path if explicit_split == "train" else None,
+        test_paths=[explicit_path] if explicit_split == "test" else None,
+    )
+
+    assert downloads == ["nsforcing_128.tgz"]
     assert len(dataset.train_db) == 2
     assert len(dataset.test_dbs[128]) == 1

--- a/neuralop/data/datasets/tests/test_ptdatasets.py
+++ b/neuralop/data/datasets/tests/test_ptdatasets.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import os
 import shutil
 
+import torch
 import pytest
 
 test_data_dir = Path("./dataset_test")
@@ -75,3 +76,29 @@ def test_NSDownload():
     assert dataset.test_dbs
     assert dataset.data_processor
     shutil.rmtree(test_data_dir)
+
+
+def test_NSExplicitPaths(tmp_path):
+    train_path = tmp_path / "nsforcing_128_train.pt"
+    test_path = tmp_path / "nsforcing_128_test.pt"
+    train_data = {"x": torch.randn(2, 128, 128), "y": torch.randn(2, 128, 128)}
+    test_data = {"x": torch.randn(1, 128, 128), "y": torch.randn(1, 128, 128)}
+    torch.save(train_data, train_path)
+    torch.save(test_data, test_path)
+
+    dataset = NavierStokesDataset(
+        root_dir=tmp_path,
+        n_train=2,
+        n_tests=[1],
+        batch_size=1,
+        test_batch_sizes=[1],
+        train_resolution=128,
+        test_resolutions=[128],
+        encode_output=False,
+        download=True,
+        train_path=train_path,
+        test_paths=[test_path],
+    )
+
+    assert len(dataset.train_db) == 2
+    assert len(dataset.test_dbs[128]) == 1


### PR DESCRIPTION
Adds optional `train_path` and `test_paths` arguments to PT datasets and exposes them through `NavierStokesDataset`. Callers can load files with names such as `nsforcing_128_train.pt` while retaining the existing automatic filename lookup.

Each split is handled independently: supplying a custom training file still allows missing test data to download, and supplying custom test files still allows missing training data to download. Supplying both avoids the automatic download.

Validation on Python 3.12.13 and PyTorch 2.14.0+cpu:
- 4 focused tests passed: explicit train/test paths, custom train-only paths, custom test-only paths, and the existing Burgers dataset test.
- The partial-path regression failed on the earlier version with a missing-file error.
- The download-selection tests use temporary tensor files and a replacement downloader; live Zenodo archive downloads were not retested.
- Compilation and `git diff --check` passed.

Related to #708.