### PR TITLE
Add chunked GNO forward pass

### DIFF
--- a/neuralop/layers/gno_block.py
+++ b/neuralop/layers/gno_block.py
@@ -248,3 +248,26 @@ class GNOBlock(nn.Module):
         )
 
         return out_features
+
+    def chunked_forward(self, y, x, f_y=None, chunk_size=1024):
+        """Compute the GNO output while limiting materialized neighbor messages.
+
+        Parameters are the same as for :meth:`forward`, with ``chunk_size`` specifying
+        the maximum number of neighbor messages processed at once.
+        """
+        neighbors_dict = self.neighbor_search(data=y, queries=x, radius=self.radius)
+
+        if self.pos_embedding is not None:
+            y_embed = self.pos_embedding(y)
+            x_embed = self.pos_embedding(x)
+        else:
+            y_embed = y
+            x_embed = x
+
+        return self.integral_transform.chunked_forward(
+            y=y_embed,
+            x=x_embed,
+            neighbors=neighbors_dict,
+            f_y=f_y,
+            chunk_size=chunk_size,
+        )

--- a/neuralop/layers/integral_transform.py
+++ b/neuralop/layers/integral_transform.py
@@ -225,3 +225,115 @@ class IntegralTransform(nn.Module):
             use_scatter=self.use_torch_scatter,
         )
         return out_features
+
+    def chunked_forward(self, y, neighbors, x=None, f_y=None, weights=None, chunk_size=1024):
+        """Compute the kernel integral transform in chunks of neighbor messages.
+
+        This method is mathematically equivalent to :meth:`forward` for sum and mean
+        reductions, but limits the number of edge messages materialized at once. It is
+        useful when a dense neighborhood graph does not fit comfortably in memory.
+
+        Parameters
+        ----------
+        chunk_size : int, optional
+            Maximum number of neighbor messages to compute at once, by default 1024
+
+        Other parameters are the same as for :meth:`forward`.
+        """
+        if not isinstance(chunk_size, int) or chunk_size <= 0:
+            raise ValueError("chunk_size must be a positive integer")
+
+        if x is None:
+            x = y
+
+        neighbor_indices = neighbors["neighbors_index"]
+        splits = neighbors["neighbors_row_splits"]
+
+        # Let the regular implementation handle empty neighborhoods so that custom
+        # channel MLPs retain their normal empty-input behavior.
+        if neighbor_indices.numel() == 0:
+            return self.forward(y, neighbors, x=x, f_y=f_y, weights=weights)
+
+        num_reps = splits[1:] - splits[:-1]
+        destination = torch.repeat_interleave(
+            torch.arange(num_reps.numel(), device=splits.device), num_reps
+        )
+
+        batched = False
+        if f_y is not None:
+            if f_y.ndim == 3:
+                batched = True
+                batch_size = f_y.shape[0]
+            elif f_y.ndim == 2:
+                in_features = f_y[neighbor_indices]
+
+        nbr_weights = neighbors.get("weights")
+        if nbr_weights is None:
+            nbr_weights = weights
+        if nbr_weights is None and self.weighting_fn is not None:
+            raise KeyError("if a weighting function is provided, your neighborhoods must contain weights.")
+        if nbr_weights is not None:
+            reduction = "sum"
+        else:
+            reduction = self.reduction
+
+        out_features = None
+        for start in range(0, neighbor_indices.numel(), chunk_size):
+            end = min(start + chunk_size, neighbor_indices.numel())
+            edge_slice = slice(start, end)
+            edge_indices = neighbor_indices[edge_slice]
+            edge_destination = destination[edge_slice]
+
+            rep_features = y[edge_indices]
+            self_features = x[edge_destination]
+            agg_features = torch.cat([rep_features, self_features], dim=-1)
+            if f_y is not None and self.transform_type in (
+                "nonlinear_kernelonly",
+                "nonlinear",
+            ):
+                if batched:
+                    in_features = f_y[:, edge_indices, :]
+                    agg_features = agg_features.repeat(
+                        [batch_size] + [1] * agg_features.ndim
+                    )
+                agg_features = torch.cat([agg_features, in_features], dim=-1)
+
+            rep_features = self.channel_mlp(agg_features)
+
+            if f_y is not None and self.transform_type != "nonlinear_kernelonly":
+                if f_y.ndim == 3:
+                    in_features = f_y[:, edge_indices, :]
+                if rep_features.ndim == 2 and batched:
+                    rep_features = rep_features.unsqueeze(0).repeat(
+                        [batch_size] + [1] * rep_features.ndim
+                    )
+                rep_features.mul_(in_features)
+
+            if nbr_weights is not None:
+                edge_weights = nbr_weights[edge_slice].unsqueeze(-1).unsqueeze(0)
+                if self.weighting_fn is not None:
+                    edge_weights = self.weighting_fn(edge_weights)
+                if not batched:
+                    edge_weights = edge_weights.squeeze(0)
+                rep_features.mul_(edge_weights)
+
+            if out_features is None:
+                if batched:
+                    output_shape = [batch_size, num_reps.numel(), rep_features.shape[-1]]
+                else:
+                    output_shape = [num_reps.numel(), rep_features.shape[-1]]
+                out_features = rep_features.new_zeros(output_shape)
+
+            if batched:
+                out_features.index_add_(1, edge_destination, rep_features)
+            else:
+                out_features.index_add_(0, edge_destination, rep_features)
+
+        if reduction == "mean":
+            divisor = num_reps.to(dtype=out_features.dtype).clamp_min(1)
+            if batched:
+                out_features = out_features / divisor.view(1, -1, 1)
+            else:
+                out_features = out_features / divisor.view(-1, 1)
+
+        return out_features

--- a/neuralop/layers/integral_transform.py
+++ b/neuralop/layers/integral_transform.py
@@ -230,8 +230,9 @@ class IntegralTransform(nn.Module):
         """Compute the kernel integral transform in chunks of neighbor messages.
 
         This method is mathematically equivalent to :meth:`forward` for sum and mean
-        reductions, but limits the number of edge messages materialized at once. It is
-        useful when a dense neighborhood graph does not fit comfortably in memory.
+        reductions, but limits the number of edge messages computed per chunk.
+        The neighborhood graph is still constructed in full, and autograd can
+        retain activations from every chunk during training.
 
         Parameters
         ----------
@@ -264,8 +265,6 @@ class IntegralTransform(nn.Module):
             if f_y.ndim == 3:
                 batched = True
                 batch_size = f_y.shape[0]
-            elif f_y.ndim == 2:
-                in_features = f_y[neighbor_indices]
 
         nbr_weights = neighbors.get("weights")
         if nbr_weights is None:
@@ -284,6 +283,9 @@ class IntegralTransform(nn.Module):
             edge_indices = neighbor_indices[edge_slice]
             edge_destination = destination[edge_slice]
 
+            if f_y is not None:
+                in_features = f_y[:, edge_indices, :] if batched else f_y[edge_indices]
+
             rep_features = y[edge_indices]
             self_features = x[edge_destination]
             agg_features = torch.cat([rep_features, self_features], dim=-1)
@@ -292,7 +294,6 @@ class IntegralTransform(nn.Module):
                 "nonlinear",
             ):
                 if batched:
-                    in_features = f_y[:, edge_indices, :]
                     agg_features = agg_features.repeat(
                         [batch_size] + [1] * agg_features.ndim
                     )
@@ -301,8 +302,6 @@ class IntegralTransform(nn.Module):
             rep_features = self.channel_mlp(agg_features)
 
             if f_y is not None and self.transform_type != "nonlinear_kernelonly":
-                if f_y.ndim == 3:
-                    in_features = f_y[:, edge_indices, :]
                 if rep_features.ndim == 2 and batched:
                     rep_features = rep_features.unsqueeze(0).repeat(
                         [batch_size] + [1] * rep_features.ndim

--- a/neuralop/layers/tests/test_gno_block.py
+++ b/neuralop/layers/tests/test_gno_block.py
@@ -113,7 +113,8 @@ def test_gno_block(
 @pytest.mark.parametrize("reduction", ["sum", "mean"])
 @pytest.mark.parametrize("transform_type", ["linear", "nonlinear", "nonlinear_kernelonly"])
 @pytest.mark.parametrize("batch_size", [None, 1, 2])
-def test_gno_block_chunked_forward(reduction, transform_type, batch_size):
+@pytest.mark.parametrize("device", ["cpu"] + (["cuda"] if torch.cuda.is_available() else []))
+def test_gno_block_chunked_forward(reduction, transform_type, batch_size, device):
     torch.manual_seed(0)
     gno_block = GNOBlock(
         in_channels=in_channels,
@@ -126,11 +127,11 @@ def test_gno_block_chunked_forward(reduction, transform_type, batch_size):
         channel_mlp_layers=[16, 16],
         use_torch_scatter_reduce=False,
         use_open3d_neighbor_search=False,
-    )
-    input_geom = torch.rand(12, 2, requires_grad=True)
-    output_queries = torch.rand(9, 2, requires_grad=True)
+    ).to(device)
+    input_geom = torch.rand(12, 2, device=device, requires_grad=True)
+    output_queries = torch.rand(9, 2, device=device, requires_grad=True)
     shape = (12, in_channels) if batch_size is None else (batch_size, 12, in_channels)
-    f_y = torch.rand(shape, requires_grad=True)
+    f_y = torch.rand(shape, device=device, requires_grad=True)
 
     expected = gno_block(input_geom, output_queries, f_y=f_y)
     actual = gno_block.chunked_forward(

--- a/neuralop/layers/tests/test_gno_block.py
+++ b/neuralop/layers/tests/test_gno_block.py
@@ -108,3 +108,37 @@ def test_gno_block(
     if batch_size > 1 and gno_transform_type != "linear":
         # assert f_y[1:] accumulates no grad if it's used
         assert not f_y.grad[1:].nonzero().any()
+
+
+@pytest.mark.parametrize("reduction", ["sum", "mean"])
+@pytest.mark.parametrize("transform_type", ["linear", "nonlinear"])
+def test_gno_block_chunked_forward(reduction, transform_type):
+    torch.manual_seed(0)
+    gno_block = GNOBlock(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        coord_dim=2,
+        pos_embedding_type=None,
+        radius=10.0,
+        reduction=reduction,
+        transform_type=transform_type,
+        channel_mlp_layers=[16, 16],
+        use_torch_scatter_reduce=False,
+        use_open3d_neighbor_search=False,
+    )
+    input_geom = torch.rand(12, 2)
+    output_queries = torch.rand(9, 2)
+    f_y = None
+    if transform_type == "nonlinear":
+        f_y = torch.rand(2, 12, in_channels, requires_grad=True)
+
+    expected = gno_block(input_geom, output_queries, f_y=f_y)
+    actual = gno_block.chunked_forward(
+        input_geom, output_queries, f_y=f_y, chunk_size=7
+    )
+
+    assert torch.allclose(actual, expected)
+    actual.sum().backward()
+    if f_y is not None:
+        assert f_y.grad is not None
+        assert f_y.grad.isfinite().all()

--- a/neuralop/layers/tests/test_gno_block.py
+++ b/neuralop/layers/tests/test_gno_block.py
@@ -111,8 +111,9 @@ def test_gno_block(
 
 
 @pytest.mark.parametrize("reduction", ["sum", "mean"])
-@pytest.mark.parametrize("transform_type", ["linear", "nonlinear"])
-def test_gno_block_chunked_forward(reduction, transform_type):
+@pytest.mark.parametrize("transform_type", ["linear", "nonlinear", "nonlinear_kernelonly"])
+@pytest.mark.parametrize("batch_size", [None, 1, 2])
+def test_gno_block_chunked_forward(reduction, transform_type, batch_size):
     torch.manual_seed(0)
     gno_block = GNOBlock(
         in_channels=in_channels,
@@ -126,11 +127,10 @@ def test_gno_block_chunked_forward(reduction, transform_type):
         use_torch_scatter_reduce=False,
         use_open3d_neighbor_search=False,
     )
-    input_geom = torch.rand(12, 2)
-    output_queries = torch.rand(9, 2)
-    f_y = None
-    if transform_type == "nonlinear":
-        f_y = torch.rand(2, 12, in_channels, requires_grad=True)
+    input_geom = torch.rand(12, 2, requires_grad=True)
+    output_queries = torch.rand(9, 2, requires_grad=True)
+    shape = (12, in_channels) if batch_size is None else (batch_size, 12, in_channels)
+    f_y = torch.rand(shape, requires_grad=True)
 
     expected = gno_block(input_geom, output_queries, f_y=f_y)
     actual = gno_block.chunked_forward(
@@ -138,7 +138,8 @@ def test_gno_block_chunked_forward(reduction, transform_type):
     )
 
     assert torch.allclose(actual, expected)
-    actual.sum().backward()
-    if f_y is not None:
-        assert f_y.grad is not None
-        assert f_y.grad.isfinite().all()
+    inputs = (input_geom, output_queries, f_y, *gno_block.parameters())
+    expected_grads = torch.autograd.grad(expected.sum(), inputs)
+    actual_grads = torch.autograd.grad(actual.sum(), inputs)
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+        torch.testing.assert_close(actual_grad, expected_grad)


### PR DESCRIPTION
Adds `chunked_forward` to `GNOBlock` and `IntegralTransform` for incremental sum and mean aggregation.

Feature gathering happens inside each chunk for both unbatched and batched inputs. The earlier implementation gathered the entire unbatched feature array before the loop, which failed when the edge count exceeded `chunk_size`.

Validation:
- Google Colab, Tesla T4 (compute capability 7.5), PyTorch 2.11.0+cu128, CUDA 12.8, zencfg 0.3.0.
- **72 GNO tests passed: 54 CUDA cases and 18 CPU cases.** The chunked comparisons now run on CPU and, when available, CUDA. They compare outputs and gradients for unbatched, single-batch, and multi-batch inputs across three transforms and both reductions.
- The unbatched regression fails on the earlier implementation.
- Previous CPU-only validation: 54 GNO tests passed with PyTorch 2.14.0+cpu.
- Optional Open3D and torch-scatter paths were not exercised.

A synthetic dense-graph benchmark on the T4 measured:

| Mode | Peak additional allocated memory (MiB) | Median elapsed time (ms) |
| --- | ---: | ---: |
| Full inference | 172.008 | 88.528 |
| Chunked inference (4,096 edges/chunk) | 8.665 | 17.246 |
| Full forward + backward | 356.350 | 266.424 |
| Chunked forward + backward | 314.104 | 69.172 |

The workload has 512 input points, 512 queries, 262,144 edges, 16 feature channels, hidden widths [64, 64], nonlinear transform, mean reduction, and no positional embedding. One warmup precedes three measured repeats. Memory is peak `torch.cuda.memory_allocated` above the pre-call baseline; timing synchronizes CUDA. Backward measures parameter gradients, not coordinate/input gradients.

These are measurements for one workload, not general memory or throughput guarantees. Neighbor search still constructs the full graph, and autograd retains activations across chunks during training. Measurements used implementation commit `d9c5060`; commit `3f7516c` adds only CUDA test coverage.

<details>
<summary>Benchmark reproducer</summary>

Run in the PR checkout with CUDA PyTorch and the project dependencies installed (`zencfg==0.3.0` for this environment).

```python
import gc, json, statistics, time, sys, subprocess
from pathlib import Path
ROOT = Path.cwd()
HEAD = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=ROOT, text=True).strip()
import torch
sys.path.insert(0, str(ROOT))
from neuralop.layers.gno_block import GNOBlock
torch.manual_seed(726)
block = GNOBlock(in_channels=16, out_channels=16, coord_dim=2,
                 pos_embedding_type=None, radius=10.0, reduction="mean",
                 transform_type="nonlinear", channel_mlp_layers=[64, 64],
                 use_torch_scatter_reduce=False,
                 use_open3d_neighbor_search=False).cuda()
y = torch.rand(512, 2, device="cuda")
x = torch.rand(512, 2, device="cuda")
f = torch.rand(512, 16, device="cuda")
def measure(chunk_size, training):
    times, peaks = [], []
    for repeat in range(4):
        block.zero_grad(set_to_none=True)
        gc.collect()
        torch.cuda.empty_cache()
        torch.cuda.synchronize()
        baseline = torch.cuda.memory_allocated()
        torch.cuda.reset_peak_memory_stats()
        start = time.perf_counter()
        with torch.set_grad_enabled(training):
            output = block(y, x, f_y=f) if chunk_size is None else block.chunked_forward(y, x, f_y=f, chunk_size=chunk_size)
            if training:
                output.square().mean().backward()
        torch.cuda.synchronize()
        if repeat > 0:
            times.append((time.perf_counter() - start)*1000)
            peaks.append((torch.cuda.max_memory_allocated() - baseline)/2**20)
        del output
    return {"median_ms": statistics.median(times), "peak_extra_allocated_mib": max(peaks)}
memory_report = {
    "source_commit": HEAD,
    "torch": torch.__version__, "cuda": torch.version.cuda,
    "gpu": torch.cuda.get_device_name(0),
    "shape": {"input_points":512, "query_points":512, "edges":512*512, "features":16, "hidden":[64,64]},
    "repeats":3, "warmup":1,
    "note":"Synthetic dense graph; incremental torch-allocated memory includes graph construction. Training includes parameter gradients, not input gradients. Optional Open3D/torch-scatter disabled.",
    "results": {}
}
for training in (False, True):
    for chunk_size in (None, 4096):
        key = ("training" if training else "inference") + ("_full" if chunk_size is None else "_chunk4096")
        memory_report["results"][key] = measure(chunk_size, training)
print(json.dumps(memory_report, indent=2))
Path("gno_memory_benchmark.json").write_text(json.dumps(memory_report, indent=2))
```

</details>

Related to #726.