### PR TITLE
Validate spherical SWE dataset indices

### DIFF
--- a/neuralop/data/datasets/spherical_swe.py
+++ b/neuralop/data/datasets/spherical_swe.py
@@ -1,4 +1,5 @@
 from math import ceil, floor
+from operator import index as operator_index
 
 import torch
 from torch.utils.data import DataLoader
@@ -119,6 +120,19 @@ class SphericalSWEDataset(torch.utils.data.Dataset):
         return inp, tar
 
     def __getitem__(self, index):
+        try:
+            index = operator_index(index)
+        except TypeError as exc:
+            raise TypeError(
+                f"{type(self).__name__} indices must be integers, "
+                f"not {type(index).__name__}"
+            ) from exc
+
+        if index < 0 or index >= len(self):
+            raise IndexError(
+                f"index {index} is out of range for dataset of length {len(self)}"
+            )
+
         with torch.inference_mode():
             with torch.no_grad():
                 inp, tar = self._get_sample()

--- a/neuralop/data/datasets/tests/test_spherical_swe.py
+++ b/neuralop/data/datasets/tests/test_spherical_swe.py
@@ -1,0 +1,36 @@
+import pytest
+import torch
+
+
+pytest.importorskip("torch_harmonics")
+
+from ..spherical_swe import SphericalSWEDataset
+
+
+@pytest.fixture
+def dataset():
+    dataset = SphericalSWEDataset.__new__(SphericalSWEDataset)
+    dataset.num_examples = 3
+    dataset.ictype = "random"
+    dataset.normalize = False
+    dataset._get_sample = lambda: (torch.ones(1), torch.zeros(1))
+    return dataset
+
+
+def test_getitem_accepts_valid_integer(dataset):
+    sample = dataset[0]
+
+    assert sample["x"].equal(torch.ones(1))
+    assert sample["y"].equal(torch.zeros(1))
+
+
+@pytest.mark.parametrize("index", ["foo", 1.5, slice(None)])
+def test_getitem_rejects_non_integer_indices(dataset, index):
+    with pytest.raises(TypeError, match="indices must be integers"):
+        dataset[index]
+
+
+@pytest.mark.parametrize("index", [-1, 3])
+def test_getitem_rejects_out_of_range_indices(dataset, index):
+    with pytest.raises(IndexError, match="out of range"):
+        dataset[index]


### PR DESCRIPTION
Fixes #328

Validates that `SphericalSWEDataset` receives integer indices and raises `IndexError` outside `range(len(dataset))`.

Validation on Python 3.12.13 and PyTorch 2.14.0+cpu:
- All 6 index-validation tests passed with the real `torch_harmonics` 0.7.4 package installed; its solver import was not stubbed.
- The tests cover valid integer access, invalid index types, and out-of-range indices. They replace sample generation with small tensors to isolate indexing behavior.
- Compilation and diff checks passed.

The newer torch_harmonics 0.9.2 wheel failed to import with this PyTorch build because of an undefined binary symbol, so this result is specific to the working 0.7.4 environment.